### PR TITLE
Added MFC compiler tools on Windows

### DIFF
--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: ogre2 from vcpkg-ports
-set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 mesa[gles2] mesa[egl]
+set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 mesa[gles2]
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: ogre2 from vcpkg-ports
-set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22
+set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 mesa[gles2] mesa[egl]
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: ogre2 from vcpkg-ports
-set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 mesa mesa[egl]
+set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 mesa[gles2] mesa[egl]
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: ogre2 from vcpkg-ports
-set DEPEN_PKGS=qt5 qt5-winextras qt5-translations qwt protobuf tinyxml2 freeimage ogre ogre22 angle
+set DEPEN_PKGS=qt5 qt5-winextras qt5-quickcontrols qt5-translations qwt protobuf tinyxml2 freeimage ogre ogre22 angle
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: ogre2 from vcpkg-ports
-set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 angle
+set DEPEN_PKGS=qt5 qt5-winextras qt5-translations qwt protobuf tinyxml2 freeimage ogre ogre22 angle
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: ogre2 from vcpkg-ports
-set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 mesa[gles2] mesa[egl]
+set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 mesa mesa[egl]
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: ogre2 from vcpkg-ports
-set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 mesa[gles2]
+set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22 angle
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -15,6 +15,6 @@ set VCPKG_CMD=%VCPKG_DIR%\vcpkg.exe
 set VCPKG_CMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%/scripts/buildsystems/vcpkg.cmake
 if NOT DEFINED VCPKG_SNAPSHOT (
   :: see https://github.com/microsoft/vcpkg/releases
-  set VCPKG_SNAPSHOT=2021.05.12
+  set VCPKG_SNAPSHOT=2020.11
 )
 goto :EOF

--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -15,6 +15,6 @@ set VCPKG_CMD=%VCPKG_DIR%\vcpkg.exe
 set VCPKG_CMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%/scripts/buildsystems/vcpkg.cmake
 if NOT DEFINED VCPKG_SNAPSHOT (
   :: see https://github.com/microsoft/vcpkg/releases
-  set VCPKG_SNAPSHOT=2020.11
+  set VCPKG_SNAPSHOT=2021.05.12
 )
 goto :EOF

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -63,7 +63,7 @@ FOR /F "tokens=2 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Stud
 FOR /F "tokens=2 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -prerelease ^| findstr "channelId:"') DO set "CHANNEL=%%i"
 FOR /F "tokens=3 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -prerelease ^| findstr "installationPath:"') DO set "INSTALLPATH=C:%%i"
 
-C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
+"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe" modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
 
 goto :EOF
 

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -65,8 +65,6 @@ FOR /F "tokens=3 delims=:" %%i IN ('call "C:\Program Files (x86)\Microsoft Visua
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe" modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
 
-mklink C:\vcpkg\installed\x64-windows\bin\libGLESv2.dll C:\vcpkg\installed\x64-windows\bin\libGLESv2_mesa.dll || VER>NUL
-
 goto :EOF
 
 :: ##################################

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -59,10 +59,10 @@ IF exist "%MSVC_ON_WIN64_E%" (
    exit -1
 )
 
+:: This is required by qt5-winextras
 FOR /F "tokens=2 delims=:" %%i IN ('call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "productId:"') DO set "PRODUCT=%%i"
 FOR /F "tokens=2 delims=:" %%i IN ('call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "channelId:"') DO set "CHANNEL=%%i"
 FOR /F "tokens=3 delims=:" %%i IN ('call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "installationPath:"') DO set "INSTALLPATH=C:%%i"
-
 call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe" modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
 
 goto :EOF

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -65,6 +65,8 @@ FOR /F "tokens=3 delims=:" %%i IN ('call "C:\Program Files (x86)\Microsoft Visua
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe" modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
 
+mklink C:\vcpkg\installed\x64-windows\bin\libGLESv2.dll C:\vcpkg\installed\x64-windows\bin\libGLESv2_mesa.dll || VER>NUL
+
 goto :EOF
 
 :: ##################################

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -59,11 +59,11 @@ IF exist "%MSVC_ON_WIN64_E%" (
    exit -1
 )
 
-FOR /F "tokens=2 delims=:" %%i IN ('"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "productId:"') DO set "PRODUCT=%%i"
-FOR /F "tokens=2 delims=:" %%i IN ('"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "channelId:"') DO set "CHANNEL=%%i"
-FOR /F "tokens=3 delims=:" %%i IN ('"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "installationPath:"') DO set "INSTALLPATH=C:%%i"
+FOR /F "tokens=2 delims=:" %%i IN ('call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "productId:"') DO set "PRODUCT=%%i"
+FOR /F "tokens=2 delims=:" %%i IN ('call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "channelId:"') DO set "CHANNEL=%%i"
+FOR /F "tokens=3 delims=:" %%i IN ('call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "installationPath:"') DO set "INSTALLPATH=C:%%i"
 
-"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe" modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
+call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe" modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
 
 goto :EOF
 

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -59,9 +59,9 @@ IF exist "%MSVC_ON_WIN64_E%" (
    exit -1
 )
 
-FOR /F "tokens=2 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -prerelease ^| findstr "productId:"') DO set "PRODUCT=%%i"
-FOR /F "tokens=2 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -prerelease ^| findstr "channelId:"') DO set "CHANNEL=%%i"
-FOR /F "tokens=3 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -prerelease ^| findstr "installationPath:"') DO set "INSTALLPATH=C:%%i"
+FOR /F "tokens=2 delims=:" %%i IN ('"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "productId:"') DO set "PRODUCT=%%i"
+FOR /F "tokens=2 delims=:" %%i IN ('"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "channelId:"') DO set "CHANNEL=%%i"
+FOR /F "tokens=3 delims=:" %%i IN ('"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease ^| findstr "installationPath:"') DO set "INSTALLPATH=C:%%i"
 
 "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe" modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
 

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -59,6 +59,12 @@ IF exist "%MSVC_ON_WIN64_E%" (
    exit -1
 )
 
+FOR /F "tokens=2 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -prerelease ^| findstr "productId:"') DO set "PRODUCT=%%i"
+FOR /F "tokens=2 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -prerelease ^| findstr "channelId:"') DO set "CHANNEL=%%i"
+FOR /F "tokens=3 delims=:" %%i IN ('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -prerelease ^| findstr "installationPath:"') DO set "INSTALLPATH=C:%%i"
+
+C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installershell.exe modify --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.ATL --productId %PRODUCT% --channelId %CHANNEL% -q --installPath "%INSTALLPATH%"
+
 goto :EOF
 
 :: ##################################


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

I added `qt5-winextras` in  `ign-gui` CI, but this requires `MFC compiler tools`. This PR install this dependency using the MSVC installer shell.

You can see the error in the CI [here](https://build.osrfoundation.org/job/ign_gui-pr-win/885/consoleFull#591808568aa60f765-a60a-427d-900c-dc128ab22287)