### PR TITLE
Add support to Jammy for one-liner installation of Gazebo Classic

### DIFF
--- a/one-line-installations/gazebo.sh
+++ b/one-line-installations/gazebo.sh
@@ -153,6 +153,11 @@ do_install() {
 				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
 			fi
 			case "$dist_version" in
+				jammy)
+					# Packages for Jammy come directly from Ubuntu repositories, unversioned
+					# No released packages in packages.o.o
+					GZ_VER=
+				;;
 				xenial)
 					GZ_VER=10
 				;;


### PR DESCRIPTION
Unversioned packages for Ubuntu Jammy in the one-liner installation