### PR TITLE
Remove obsolete GITHUB_ORG and use new github orgs in debbuild

### DIFF
--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -101,6 +101,11 @@ if [ -z ${ENABLE_REAPER} ]; then
     ENABLE_REAPER=true
 fi
 
+# We use gazebosim or osrf. osrf by default
+if [ -z ${GITHUB_ORG} ]; then
+    GITHUB_ORG="osrf"
+fi
+
 if [ -z "${NEED_C17_COMPILER}" ]; then
   export INSTALL_C17_COMPILER=false
 fi

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -101,11 +101,6 @@ if [ -z ${ENABLE_REAPER} ]; then
     ENABLE_REAPER=true
 fi
 
-# We use ignitionsrobotics or osrf. osrf by default
-if [ -z ${GITHUB_ORG} ]; then
-    GITHUB_ORG="osrf"
-fi
-
 if [ -z "${NEED_C17_COMPILER}" ]; then
   export INSTALL_C17_COMPILER=false
 fi

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -48,7 +48,7 @@ if ${NIGHTLY_MODE}; then
   if ${USE_REPO_DIRECTORY_FOR_NIGHTLY}; then
     mv ${WORKSPACE}/repo \$REAL_PACKAGE_NAME
   else
-    git clone https://github.com/gazebosim/\$REAL_PACKAGE_NAME -b ${NIGHTLY_SRC_BRANCH}
+    git clone https://github.com/${GITHUB_ORG}/\$REAL_PACKAGE_NAME -b ${NIGHTLY_SRC_BRANCH}
   fi
   PACKAGE_SRC_BUILD_DIR=\$REAL_PACKAGE_NAME
   cd \$REAL_PACKAGE_NAME

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -48,7 +48,7 @@ if ${NIGHTLY_MODE}; then
   if ${USE_REPO_DIRECTORY_FOR_NIGHTLY}; then
     mv ${WORKSPACE}/repo \$REAL_PACKAGE_NAME
   else
-    git clone https://github.com/${GITHUB_ORG}/\$REAL_PACKAGE_NAME -b ${NIGHTLY_SRC_BRANCH}
+    git clone https://github.com/gazebosim/\$REAL_PACKAGE_NAME -b ${NIGHTLY_SRC_BRANCH}
   fi
   PACKAGE_SRC_BUILD_DIR=\$REAL_PACKAGE_NAME
   cd \$REAL_PACKAGE_NAME
@@ -83,7 +83,7 @@ fi
 
 # Step 4: add debian/ subdirectory with necessary metadata files to unpacked source tarball
 rm -rf /tmp/$PACKAGE-release
-git clone https://github.com/ignition-release/$PACKAGE-release -b $RELEASE_REPO_BRANCH /tmp/$PACKAGE-release
+git clone https://github.com/gazebo-release/$PACKAGE-release -b $RELEASE_REPO_BRANCH /tmp/$PACKAGE-release
 cd /tmp/$PACKAGE-release
 # In nightly get the default latest version from default changelog
 if $NIGHTLY_MODE; then
@@ -109,7 +109,7 @@ fi
 case \${BUILD_METHOD} in
     "OVERWRITE_BASE")
 	# 1. Clone the base branch
-        git clone https://github.com/ignition-release/\${PACKAGE}-release \\
+        git clone https://github.com/gazebo-release/\${PACKAGE}-release \\
             -b \${RELEASE_BASE_BRANCH} \\
 	    /tmp/base_$PACKAGE-release
 	# 2. Overwrite the information
@@ -190,7 +190,7 @@ fi
 timeout=0
 # Help to debug race conditions in nightly generation or other problems with versions
 if ${NIGHTLY_MODE}; then
-  apt-cache show *ignition* | ( grep 'Package\\|Version' || true)
+  apt-cache show *gz-* | ( grep 'Package\\|Version' || true)
   # 5 minutes to give time to the uploader
   timeout=300
 fi

--- a/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
+++ b/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
@@ -6,5 +6,6 @@ SCRIPT_DIR="${SCRIPT_DIR%/*}"
 
 export RELEASE_REPO_DIRECTORY=${DISTRO}
 export ENABLE_ROS=false
+export GITHUB_ORG=gazebosim
 
 . ${SCRIPT_DIR}/lib/debbuild-base.bash

--- a/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
+++ b/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
@@ -6,6 +6,5 @@ SCRIPT_DIR="${SCRIPT_DIR%/*}"
 
 export RELEASE_REPO_DIRECTORY=${DISTRO}
 export ENABLE_ROS=false
-export GITHUB_ORG=ignitionrobotics
 
 . ${SCRIPT_DIR}/lib/debbuild-base.bash


### PR DESCRIPTION
Tested with new gz- packages [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-tools2-debbuilder&build=92)](https://build.osrfoundation.org/view/all/job/ign-tools2-debbuilder/92/)