### PR TITLE
Use default for RUN_AUTOPKGTEST in _gazebo_utils.sh

### DIFF
--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -37,6 +37,10 @@ fi
 echo '# END SECTION'
 """
 
+# autopkgtest is a mechanism to test the installation of the generated packages
+# at the end of the package production.
+RUN_AUTOPKGTEST=${RUN_AUTOPKGTEST:-true}
+
 DEBBUILD_AUTOPKGTEST="""
 if \$RUN_AUTOPKGTEST; then
 echo '# BEGIN SECTION: run autopkgtest'

--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -42,7 +42,7 @@ echo '# END SECTION'
 RUN_AUTOPKGTEST=${RUN_AUTOPKGTEST:-true}
 
 DEBBUILD_AUTOPKGTEST="""
-if \$RUN_AUTOPKGTEST; then
+if $RUN_AUTOPKGTEST; then
 echo '# BEGIN SECTION: run autopkgtest'
 cd $WORKSPACE/pkgs
 set +e

--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -38,7 +38,7 @@ echo '# END SECTION'
 """
 
 DEBBUILD_AUTOPKGTEST="""
-if $RUN_AUTOPKGTEST; then
+if \$RUN_AUTOPKGTEST; then
 echo '# BEGIN SECTION: run autopkgtest'
 cd $WORKSPACE/pkgs
 set +e

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -19,10 +19,6 @@ fi
 # testing jobs and seems to be slow at the end of jenkins jobs
 export ENABLE_REAPER=false
 
-# autopkgtest is a mechanism to test the installation of the generated packages
-# at the end of the package production.
-RUN_AUTOPKGTEST=${RUN_AUTOPKGTEST:-true}
-
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
 . ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 

--- a/jenkins-scripts/docker/lib/debian-git-repo-base.bash
+++ b/jenkins-scripts/docker/lib/debian-git-repo-base.bash
@@ -25,8 +25,6 @@ if [[ -z ${BRANCH} ]]; then
   export CLONE_NEEDED=false
 fi
 
-RUN_AUTOPKGTEST=${RUN_AUTOPKGTEST:-true}
-
 cat > build.sh << DELIM
 ###################################################
 # Make project-specific changes here


### PR DESCRIPTION
The debian-git-repo-base.bash script was declaring the default for `RUN_AUTOPKGTEST` variable after the `_gazebo_utils.sh` script was sourced so the default value was not in use and the build was broken https://build.osrfoundation.org/job/ogre-2.3-debbuilder/3/.

Test with this branch: https://build.osrfoundation.org/job/ogre-2.3-debbuilder/5/badge/

