### PR TITLE
Update GITHUB_ORG for debbuilds

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -83,7 +83,7 @@ fi
 
 # Step 4: add debian/ subdirectory with necessary metadata files to unpacked source tarball
 rm -rf /tmp/$PACKAGE-release
-git clone https://github.com/ignition-release/$PACKAGE-release -b $RELEASE_REPO_BRANCH /tmp/$PACKAGE-release
+git clone https://github.com/gazebo-release/$PACKAGE-release -b $RELEASE_REPO_BRANCH /tmp/$PACKAGE-release
 cd /tmp/$PACKAGE-release
 # In nightly get the default latest version from default changelog
 if $NIGHTLY_MODE; then
@@ -109,7 +109,7 @@ fi
 case \${BUILD_METHOD} in
     "OVERWRITE_BASE")
 	# 1. Clone the base branch
-        git clone https://github.com/ignition-release/\${PACKAGE}-release \\
+        git clone https://github.com/gazebo-release/\${PACKAGE}-release \\
             -b \${RELEASE_BASE_BRANCH} \\
 	    /tmp/base_$PACKAGE-release
 	# 2. Overwrite the information
@@ -190,7 +190,7 @@ fi
 timeout=0
 # Help to debug race conditions in nightly generation or other problems with versions
 if ${NIGHTLY_MODE}; then
-  apt-cache show *ignition* | ( grep 'Package\\|Version' || true)
+  apt-cache show *gz-* | ( grep 'Package\\|Version' || true)
   # 5 minutes to give time to the uploader
   timeout=300
 fi

--- a/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
+++ b/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
@@ -6,6 +6,6 @@ SCRIPT_DIR="${SCRIPT_DIR%/*}"
 
 export RELEASE_REPO_DIRECTORY=${DISTRO}
 export ENABLE_ROS=false
-export GITHUB_ORG=ignitionrobotics
+export GITHUB_ORG=gazebosim
 
 . ${SCRIPT_DIR}/lib/debbuild-base.bash


### PR DESCRIPTION
Alternative to #732 that keeps `osrf` as default.

Tested with

* https://github.com/gazebo-release/gz-tools2-release/pull/3

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-tools2-debbuilder&build=105)](https://build.osrfoundation.org/job/ign-tools2-debbuilder/105/)

* Needed by https://github.com/gazebo-tooling/release-tools/issues/736