### PR TITLE
Fix release table for transport11

### DIFF
--- a/terminal-dashboard/table.bash
+++ b/terminal-dashboard/table.bash
@@ -73,7 +73,7 @@ for LIB in $(get_libraries_by_collection "${COLLECTION}" ); do
           # The Source field is not mandatory and it is probably not present when
           # the binary package has the same name than the source package
           PKG_VERSION=$(wget -qO- http://packages.osrfoundation.org/gazebo/${DISTRO}-${PACKAGE_REPO}/dists/${VER}/main/binary-${ARCH}/Packages | \
-            grep -1 -m 1 -e "Source: ${LIB}" -e "Package: ${LIB}" | \
+            grep -2 -m 1 -e "Source: ${LIB}" -e "Package: ${LIB}" | \
             sed -n 's/^Version: \(.*\)/\1/p' | uniq)
         fi
 


### PR DESCRIPTION
With the changes in https://github.com/gazebo-release/gz-transport11-release/pull/4, the entry for `transport11` is now

```
Package: ignition-transport11-cli
Source: ignition-transport11
Version: 11.1.0-7~bionic
Architecture: amd64
...
```

And that breaks the table script. Pulling an extra line fixes it. Try with

```bash
bash terminal-dashboard/table.bash
```