### PR TITLE
Support gz- repos on source_changelog script

### DIFF
--- a/source-repo-scripts/source_changelog.bash
+++ b/source-repo-scripts/source_changelog.bash
@@ -1,15 +1,23 @@
 #!/bin/bash
+# bash source_changelog.bash <PREV_VER>
 
 PREV_TAG=$1
 
 git fetch --tags
 
 REPO=$(basename `git rev-parse --show-toplevel`)
-REPO_FULL="${REPO/ign-/ignition-}"
+REPO="${REPO/ign-/gz-}"
 MAJOR=${PREV_TAG%.*.*}
 BRANCH=${REPO/sdformat/sdf}${MAJOR}
+TAG="${REPO}${MAJOR}"
 
-COMMITS=$(git log ${BRANCH}...${REPO_FULL}${MAJOR}_${PREV_TAG}  --pretty=format:"%h")
+# TODO(chapulina) Support Garden tags and branches, which will start with gz-
+TAG="${TAG/gz-/ignition-}"
+TAG="${TAG/sim/gazebo}"
+BRANCH="${BRANCH/gz-/ign-}"
+BRANCH="${BRANCH/sim/gazebo}"
+
+COMMITS=$(git log ${BRANCH}...${TAG}_${PREV_TAG}  --pretty=format:"%h")
 
 for COMMIT in $COMMITS
 do
@@ -19,6 +27,6 @@ do
   PR=${PR%)}
 
   echo "1. $TITLE"
-  echo "    * [Pull request #$PR](https://github.com/ignitionrobotics/$REPO/pull/$PR)"
+  echo "    * [Pull request #$PR](https://github.com/gazebosim/$REPO/pull/$PR)"
   echo ""
 done


### PR DESCRIPTION
These are needed if you clone from the new `gz` URLs. 

~~I tried to keep compatibility with old `ign` clones, but I haven't fully tested this yet.~~

Works with old `ign-` clones too, used it in

* https://github.com/gazebosim/gz-rendering/pull/651

Also used with

* https://github.com/gazebosim/gz-sensors/pull/238