### PR TITLE
Explicit head branch when opening forward-port PR

### DIFF
--- a/source-repo-scripts/merge_forward_pull_request.bash
+++ b/source-repo-scripts/merge_forward_pull_request.bash
@@ -35,6 +35,8 @@ fi
 
 set -e
 
+CURRENT_BRANCH=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+
 ORIGIN_URL=$(git remote get-url origin)
 ORIGIN_ORG_REPO=$(echo ${ORIGIN_URL} | sed -e 's@.*github\.com.@@')
 
@@ -52,4 +54,5 @@ gh pr create \
     --title "$TITLE" \
     --repo "$ORIGIN_ORG_REPO" \
     --base "$TO_BRANCH" \
-    --body "$BODY"
+    --body "$BODY" \
+    --head "$CURRENT_BRANCH"


### PR DESCRIPTION
I don't know exactly what conditions make this necessary, but I often run into a situation where the `gh` CLI complains like this:

`pull request create failed: GraphQL error: Head sha can't be blank...`

I noticed that passing an explicit head fixes the issue