### PR TITLE
sdformat windows script: depend on eigen3

### DIFF
--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set VCS_DIRECTORY=sdformat
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="libxml2 tinyxml2"
+set DEPEN_PKGS="eigen3 libxml2 tinyxml2"
 
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set SDFORMAT_MAJOR_VERSION=%%i
 


### PR DESCRIPTION
Add eigen3 to the vcpkg DEPEN_PKGS variable.

Supports windows CI for https://github.com/gazebosim/sdformat/pull/1054.