### PR TITLE
Add GZDEV_PROJECT_NAME to gz-tools

### DIFF
--- a/jenkins-scripts/docker/ign_tools-compilation.bash
+++ b/jenkins-scripts/docker/ign_tools-compilation.bash
@@ -18,4 +18,16 @@ export BUILDING_SOFTWARE_DIRECTORY="ign-tools"
 export BUILDING_JOB_REPOSITORIES="stable"
 export BUILDING_DEPENDENCIES="ruby"
 
+GZ_TOOLS_MAJOR_VERSION=$(\
+  python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
+  ${WORKSPACE}/ign-plugin/CMakeLists.txt)
+
+# Check GZ_TOOLS version is integer
+if ! [[ ${GZ_TOOLS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
+  echo "Error! GZ_TOOLS_MAJOR_VERSION is not an integer, check the detection"
+  exit -1
+fi
+
+export GZDEV_PROJECT_NAME="gz-tools${GZ_TOOLS_MAJOR_VERSION}"
+
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_tools-compilation.bash
+++ b/jenkins-scripts/docker/ign_tools-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_DEPENDENCIES="ruby"
 
 GZ_TOOLS_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-plugin/CMakeLists.txt)
+  ${WORKSPACE}/ign-tools/CMakeLists.txt)
 
 # Check GZ_TOOLS version is integer
 if ! [[ ${GZ_TOOLS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then


### PR DESCRIPTION
Similar to

* https://github.com/gazebo-tooling/release-tools/pull/688
* https://github.com/gazebo-tooling/release-tools/pull/692

Needed by the following, so nightlies are enabled

* https://github.com/gazebosim/gz-tools/pull/96

Test builds

* Using https://github.com/gazebosim/gz-tools/pull/96 (gz-tools2 requiring nightlies): [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_tools-ci-pr_any-ubuntu_auto-amd64&build=284)](https://build.osrfoundation.org/job/ignition_tools-ci-pr_any-ubuntu_auto-amd64/284/)
* Using `ign-tools1` (make sure that the logic doesn't break it): [![Build Status](http://build.osrfoundation.org/job/ignition_tools-ci-pr_any-ubuntu_auto-amd64/285/badge/icon)](http://build.osrfoundation.org/job/ignition_tools-ci-pr_any-ubuntu_auto-amd64/285/)