### PR TITLE
Windows colcon: Rename ignition package to gz if not in ws

### DIFF
--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -183,18 +183,6 @@ set COLCON_PACKAGE=%2
 set COLCON_EXTRA_CMAKE_ARGS=%3
 set COLCON_EXTRA_CMAKE_ARGS2=%4
 
-:: Check if package is in colcon workspace
-echo HERE1! %COLCON_PACKAGE%
-colcon list --names-only | find /i "%COLCON_PACKAGE"
-if errorlevel 1 (
-  set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
-)
-colcon list --names-only | find /i "%COLCON_PACKAGE"
-if errorlevel 1 (
-  echo Failed to find package %COLCON_PACKAGE% in workspace.
-  goto :error
-)
-
 :: TODO: be sure that this way of defining MAKEFLAGS is working
 set MAKEFLAGS=-j%MAKE_JOBS%
 
@@ -222,8 +210,9 @@ goto :EOF
 
 set COLCON_PACKAGE=%1
 
-echo HERE2! %COLCON_PACKAGE%
+echo HERE! %COLCON_PACKAGE%
 :: Check if package is in colcon workspace
+colcon list --names-only
 colcon list --names-only | find /i "%COLCON_PACKAGE"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -213,11 +213,11 @@ set COLCON_PACKAGE=%1
 echo HERE! %COLCON_PACKAGE%
 :: Check if package is in colcon workspace
 colcon list --names-only
-colcon list --names-only | findstr /I "%COLCON_PACKAGE"
+colcon list --names-only | findstr /i /b /C:"%COLCON_PACKAGE"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
 )
-colcon list --names-only | findstr /I "%COLCON_PACKAGE"
+colcon list --names-only | findstr /i /b /C:"%COLCON_PACKAGE"
 if errorlevel 1 (
   echo Failed to find package %COLCON_PACKAGE% in workspace.
   goto :error

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -213,11 +213,11 @@ set COLCON_PACKAGE=%1
 echo HERE! %COLCON_PACKAGE%
 :: Check if package is in colcon workspace
 colcon list --names-only
-colcon list --names-only | findstr /i /b /C:"%COLCON_PACKAGE"
+colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
 )
-colcon list --names-only | findstr /i /b /C:"%COLCON_PACKAGE"
+colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
   echo Failed to find package %COLCON_PACKAGE% in workspace.
   goto :error

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -218,13 +218,13 @@ colcon list --names-only
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
-  echo Using package name %COLCON_PACKAGE%
 )
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
   echo Failed to find package %COLCON_PACKAGE% in workspace.
   goto :error
 )
+echo Using package name %COLCON_PACKAGE%
 echo # END SECTION
 
 :: two runs to get the dependencies built with testing and the package under

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -246,7 +246,6 @@ goto :EOF
 :tests_in_workspace
 :: arg1: package whitelist to test
 set COLCON_PACKAGE=%1
-set COLCON_PACKAGE_GZ=%1
 
 echo # BEGIN SECTION: colcon test for %COLCON_PACKAGE%
 colcon test --install-base "install"^

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -213,11 +213,11 @@ set COLCON_PACKAGE=%1
 echo HERE! %COLCON_PACKAGE%
 :: Check if package is in colcon workspace
 colcon list --names-only
-colcon list --names-only | find /i "%COLCON_PACKAGE"
+colcon list --names-only | findstr /I "%COLCON_PACKAGE"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
 )
-colcon list --names-only | find /i "%COLCON_PACKAGE"
+colcon list --names-only | findstr /I "%COLCON_PACKAGE"
 if errorlevel 1 (
   echo Failed to find package %COLCON_PACKAGE% in workspace.
   goto :error

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -183,6 +183,17 @@ set COLCON_PACKAGE=%2
 set COLCON_EXTRA_CMAKE_ARGS=%3
 set COLCON_EXTRA_CMAKE_ARGS2=%4
 
+:: Check if package is in colcon workspace
+colcon list --names-only | find /i "%COLCON_PACKAGE"
+if errorlevel 1 (
+  set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
+)
+colcon list --names-only | find /i "%COLCON_PACKAGE"
+if errorlevel 1 (
+  echo Failed to find package %COLCON_PACKAGE% in workspace.
+  goto :error
+)
+
 :: TODO: be sure that this way of defining MAKEFLAGS is working
 set MAKEFLAGS=-j%MAKE_JOBS%
 
@@ -229,6 +240,7 @@ goto :EOF
 :tests_in_workspace
 :: arg1: package whitelist to test
 set COLCON_PACKAGE=%1
+set COLCON_PACKAGE_GZ=%1
 
 echo # BEGIN SECTION: colcon test for %COLCON_PACKAGE%
 colcon test --install-base "install"^

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -184,6 +184,7 @@ set COLCON_EXTRA_CMAKE_ARGS=%3
 set COLCON_EXTRA_CMAKE_ARGS2=%4
 
 :: Check if package is in colcon workspace
+echo HERE1! %COLCON_PACKAGE%
 colcon list --names-only | find /i "%COLCON_PACKAGE"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
@@ -220,6 +221,18 @@ goto :EOF
 :build_workspace
 
 set COLCON_PACKAGE=%1
+
+echo HERE2! %COLCON_PACKAGE%
+:: Check if package is in colcon workspace
+colcon list --names-only | find /i "%COLCON_PACKAGE"
+if errorlevel 1 (
+  set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
+)
+colcon list --names-only | find /i "%COLCON_PACKAGE"
+if errorlevel 1 (
+  echo Failed to find package %COLCON_PACKAGE% in workspace.
+  goto :error
+)
 
 :: two runs to get the dependencies built with testing and the package under
 :: test build with tests

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -210,18 +210,22 @@ goto :EOF
 
 set COLCON_PACKAGE=%1
 
-echo HERE! %COLCON_PACKAGE%
 :: Check if package is in colcon workspace
+echo # BEGIN SECTION: Update package %COLCON_PACKAGE% from ignition to gz if needed
+echo Packages in workspace:
 colcon list --names-only
+
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
+  echo Using package name %COLCON_PACKAGE%
 )
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
   echo Failed to find package %COLCON_PACKAGE% in workspace.
   goto :error
 )
+echo # END SECTION
 
 :: two runs to get the dependencies built with testing and the package under
 :: test build with tests


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/718

We need to support Citadel and Fortress `ignition-` packages, as well as Garden `gz-` packages.

The logic here checks if colcon can detect the `ignition-` package in the workspace, and if it can't, it renames the package to `gz-` and tries that.

Test runs:

* With `gz-`, using https://github.com/gazebosim/gz-utils/pull/57: https://build.osrfoundation.org/job/ign_utils-pr-win/225/console#console-section-6

```
# BEGIN SECTION: Update package ignition-utils2 from ignition to gz if needed
Packages in workspace:
gz-cmake3
gz-utils2

gz-utils2
Using package name gz-utils2
# END SECTION
```

* With `ignition-`, using `ign-utils1` branch: https://build.osrfoundation.org/job/ign_utils-pr-win/227/console

```
# BEGIN SECTION: Update package ignition-utils1 from ignition to gz if needed
Packages in workspace:

ignition-cmake2
ignition-utils1
ignition-utils1
ignition-utils1
Using package name ignition-utils1
# END SECTION
```