### PR TITLE
Windows colcon: handle ignition-gazebo -> gz-sim case

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -43,6 +43,7 @@ colcon list --names-only
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
+  set COLCON_PACKAGE=%COLCON_PACKAGE:gazebo=sim%
 )
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -218,6 +218,7 @@ colcon list --names-only
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
   set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
+  set COLCON_PACKAGE=%COLCON_PACKAGE:gazebo=sim%
 )
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/718

Follow up to

* https://github.com/gazebo-tooling/release-tools/pull/754
* https://github.com/gazebo-tooling/release-tools/pull/755

`gz-sim` has been failing with 

```
# BEGIN SECTION: Update package ignition-gazebo7 from ignition to gz if needed

C:\Jenkins\workspace\ign_gazebo-pr-win>echo Packages in workspace: 
Packages in workspace:

C:\Jenkins\workspace\ign_gazebo-pr-win>colcon list --names-only 
gz-cmake3
gz-common5
gz-fuel_tools8
gz-gui7
gz-math7
gz-msgs9
gz-physics6
gz-plugin2
gz-rendering7
gz-sensors7
gz-sim7
gz-sim7
gz-tools2
gz-transport12
gz-utils2
sdformat13

C:\Jenkins\workspace\ign_gazebo-pr-win>colcon list --names-only   | find "ignition-gazebo7" 

C:\Jenkins\workspace\ign_gazebo-pr-win>if errorlevel 1 (set COLCON_PACKAGE=gz-gazebo7 ) 

C:\Jenkins\workspace\ign_gazebo-pr-win>colcon list --names-only   | find "gz-gazebo7" 

C:\Jenkins\workspace\ign_gazebo-pr-win>if errorlevel 1 (
echo Failed to find package gz-gazebo7 in workspace.  
 goto :error 
) 
Failed to find package gz-gazebo7 in workspace.
```

Test build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gazebo-pr-win&build=4625)](https://build.osrfoundation.org/job/ign_gazebo-pr-win/4625/)