### PR TITLE
Add pytest to list of pip installed dependencies for sdformat

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -78,6 +78,9 @@ brew install ${PROJECT_FORMULA} ${PROJECT_ARGS} --only-dependencies
 # the following is needed to install :build dependencies of a formula
 brew install $(brew deps --1 --include-build ${PROJECT_FORMULA})
 
+# pytest is needed to run python tests with junit xml output
+PIP_PACKAGES_NEEDED="${PIP_PACKAGES_NEEDED} pytest"
+
 if [[ "${RERUN_FAILED_TESTS}" -gt 0 ]]; then
   # Install lxml for flaky_junit_merge.py
   PIP_PACKAGES_NEEDED="${PIP_PACKAGES_NEEDED} lxml"

--- a/jenkins-scripts/sdformat-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/sdformat-default-devel-homebrew-amd64.bash
@@ -4,7 +4,7 @@
 [[ -L ${0} ]] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
 SCRIPT_DIR="${SCRIPT_DIR%/*}"
 
-PIP_PACKAGES_NEEDED="psutil"
+PIP_PACKAGES_NEEDED="psutil pytest"
 
 . ${SCRIPT_DIR}/lib/project-default-devel-homebrew-amd64.bash sdformat
 

--- a/jenkins-scripts/sdformat-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/sdformat-default-devel-homebrew-amd64.bash
@@ -4,7 +4,7 @@
 [[ -L ${0} ]] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
 SCRIPT_DIR="${SCRIPT_DIR%/*}"
 
-PIP_PACKAGES_NEEDED="psutil pytest"
+PIP_PACKAGES_NEEDED="psutil"
 
 . ${SCRIPT_DIR}/lib/project-default-devel-homebrew-amd64.bash sdformat
 


### PR DESCRIPTION
As mentioned in https://github.com/gazebosim/sdformat/pull/1063, `pytest` is needed to generate junit xml files for python tests.