### PR TITLE
Use appropriate substitution invocation for COLCON_PACKAGE

### DIFF
--- a/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
@@ -16,6 +16,24 @@ if "!PKG_MAJOR_VERSION!" == "1" (
    set COLCON_PACKAGE=%COLCON_PACKAGE%!PKG_MAJOR_VERSION!
 )
 
+echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from ignition to gz if needed
+echo Packages in workspace:
+colcon list --names-only
+
+colcon list --names-only | find "!COLCON_PACKAGE!"
+if errorlevel 1 (
+  set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
+  set COLCON_PACKAGE=!COLCON_PACKAGE:gazebo=sim!
+)
+colcon list --names-only | find "!COLCON_PACKAGE!"
+if errorlevel 1 (
+  echo Failed to find package !COLCON_PACKAGE! in workspace.
+  goto :error
+)
+echo Using package name !COLCON_PACKAGE!
+echo # END SECTION
+
+
 set COLCON_AUTO_MAJOR_VERSION=false
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -36,24 +36,24 @@ if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
 )
 
 :: Check if package is in colcon workspace
-echo # BEGIN SECTION: Update package %COLCON_PACKAGE% from ignition to gz if needed
+echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from ignition to gz if needed
 echo Packages in workspace:
 colcon list --names-only
 
-colcon list --names-only | find "%COLCON_PACKAGE%"
+colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (
-  set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
-  set COLCON_PACKAGE=%COLCON_PACKAGE:gazebo=sim%
+  set COLCON_PACKAGE=!COLCON_PACKAGE:ignition=gz!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:gazebo=sim!
 )
-colcon list --names-only | find "%COLCON_PACKAGE%"
+colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (
-  echo Failed to find package %COLCON_PACKAGE% in workspace.
+  echo Failed to find package !COLCON_PACKAGE! in workspace.
   goto :error
 )
-echo Using package name %COLCON_PACKAGE%
+echo Using package name !COLCON_PACKAGE!
 echo # END SECTION
 
-set TEST_RESULT_PATH=%WORKSPACE%\ws\build\%COLCON_PACKAGE%\test_results
+set TEST_RESULT_PATH=%WORKSPACE%\ws\build\!COLCON_PACKAGE!\test_results
 
 setlocal ENABLEDELAYEDEXPANSION
 if not defined GAZEBODISTRO_FILE (
@@ -123,12 +123,12 @@ if exist %LOCAL_WS_SOFTWARE_DIR%\configure.bat (
 
 echo # BEGIN SECTION: compiling %VCS_DIRECTORY%
 cd %LOCAL_WS%
-call %win_lib% :build_workspace %COLCON_PACKAGE% || goto :error
+call %win_lib% :build_workspace !COLCON_PACKAGE! || goto :error
 echo # END SECTION
 
 if "%ENABLE_TESTS%" == "TRUE" (
-    echo # BEGIN SECTION: running tests for %COLCON_PACKAGE%
-    call %win_lib% :tests_in_workspace %COLCON_PACKAGE%
+    echo # BEGIN SECTION: running tests for !COLCON_PACKAGE!
+    call %win_lib% :tests_in_workspace !COLCON_PACKAGE!
     echo # END SECTION
 
     echo # BEGIN SECTION: export testing results

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -217,24 +217,24 @@ colcon list --names-only
 
 colcon list --names-only | find "%COLCON_PACKAGE%"
 if errorlevel 1 (
-  set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
-  set COLCON_PACKAGE=%COLCON_PACKAGE:gazebo=sim%
+  set COLCON_PACKAGE=!COLCON_PACKAGE:ignition=gz!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:gazebo=sim!
 )
-colcon list --names-only | find "%COLCON_PACKAGE%"
+colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (
-  echo Failed to find package %COLCON_PACKAGE% in workspace.
+  echo Failed to find package !COLCON_PACKAGE! in workspace.
   goto :error
 )
-echo Using package name %COLCON_PACKAGE%
+echo Using package name !COLCON_PACKAGE!
 echo # END SECTION
 
 :: two runs to get the dependencies built with testing and the package under
 :: test build with tests
-echo # BEGIN SECTION: colcon compilation without test for dependencies of %COLCON_PACKAGE%
-call :_colcon_build_cmd --packages-skip %COLCON_PACKAGE% "-DBUILD_TESTING=0" "-DCMAKE_CXX_FLAGS=-w"
+echo # BEGIN SECTION: colcon compilation without test for dependencies of !COLCON_PACKAGE!
+call :_colcon_build_cmd --packages-skip !COLCON_PACKAGE! "-DBUILD_TESTING=0" "-DCMAKE_CXX_FLAGS=-w"
 echo # END SECTION
-echo # BEGIN SECTION: colcon compilation with tests for %COLCON_PACKAGE%
-call :_colcon_build_cmd --packages-select %COLCON_PACKAGE% " -DBUILD_TESTING=1"
+echo # BEGIN SECTION: colcon compilation with tests for !COLCON_PACKAGE!
+call :_colcon_build_cmd --packages-select !COLCON_PACKAGE! " -DBUILD_TESTING=1"
 echo # END SECTION
 goto :EOF
 
@@ -248,9 +248,9 @@ goto :EOF
 :: arg1: package whitelist to test
 set COLCON_PACKAGE=%1
 
-echo # BEGIN SECTION: colcon test for %COLCON_PACKAGE%
+echo # BEGIN SECTION: colcon test for !COLCON_PACKAGE!
 colcon test --install-base "install"^
-            --packages-select %COLCON_PACKAGE%^
+            --packages-select !COLCON_PACKAGE!^
             --executor sequential^
             --event-handler console_direct+
 echo # END SECTION


### PR DESCRIPTION
The wrong variable substitution directive is used for `COLCON_PACKAGE` for some of the windows jenkins scripts (`% %` does substitution at parse-time, while `! !` does substitution at runtime), causing variables to not get updated and for builds to fail.

This PR fixes that.