### PR TITLE
Install ffmpeg from vcpkg in gazebo builds.

### DIFF
--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -22,6 +22,10 @@ call %win_lib% :remove_vcpkg_package qwt
 :: from vcpkg.
 call %win_lib% :install_vcpkg_package tinyxml2
 
+:: gazebo-sim needs libavutil (part of ffmpeg) which is not the win32 deps but
+:: it can be used from vcpkg.
+call %win_lib% :install_vcpkg_package ffmpeg
+
 :: IF exist %LOCAL_WS% ( rmdir /s /q %LOCAL_WS% ) || goto %win_lib% :error
 :: reusing the workspace
 


### PR DESCRIPTION
This dependency was previously optional and seemingly omitted from Windows build farm builds. However it is now required based empirically on recently failing jobs.

Since ffmpeg is not a dependency that we've built and distributed via s3 we can try to install the version from vcpkg for now.