### PR TITLE
windows: add boost-core vcpkg dep to ign-gazebo, launch

### DIFF
--- a/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-gazebo
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: dlfcn
-set DEPEN_PKGS=dlfcn-win32 cuda cppzmq curl openssl jsoncpp ffmpeg freeimage ogre ogre2 ogre22 qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq
+set DEPEN_PKGS=assimp ccd cppzmq cuda curl dlfcn-win32 eigen3 fcl ffmpeg freeimage gflags glib gts jsoncpp libyaml libzip ogre ogre2 ogre22 openssl protobuf qt5 qwt tinyxml2 zeromq
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set IGN_MAJOR_VERSION=%%i
 if %IGN_MAJOR_VERSION% GEQ 7 (
   set DEPEN_PKGS=%DEPEN_PKGS% gdal

--- a/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-gazebo
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: dlfcn
-set DEPEN_PKGS=assimp ccd cppzmq cuda curl dlfcn-win32 eigen3 fcl ffmpeg freeimage gflags glib gts jsoncpp libyaml libzip ogre ogre2 ogre22 openssl protobuf qt5 qwt tinyxml2 zeromq
+set DEPEN_PKGS=assimp boost-core ccd cppzmq cuda curl dlfcn-win32 eigen3 fcl ffmpeg freeimage gflags glib gts jsoncpp libyaml libzip ogre ogre2 ogre22 openssl protobuf qt5 qwt tinyxml2 zeromq
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set IGN_MAJOR_VERSION=%%i
 if %IGN_MAJOR_VERSION% GEQ 7 (
   set DEPEN_PKGS=%DEPEN_PKGS% gdal

--- a/jenkins-scripts/ign_launch-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_launch-default-devel-windows-amd64.bat
@@ -4,7 +4,7 @@ set VCS_DIRECTORY=ign-launch
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS=assimp ccd cppzmq cuda curl dlfcn-win32 eigen3 fcl ffmpeg freeimage gflags glib gts jsoncpp libyaml libzip ogre ogre2 ogre22 openssl protobuf qt5 qwt tinyxml2 zeromq
+set DEPEN_PKGS=assimp boost-core ccd cppzmq cuda curl dlfcn-win32 eigen3 fcl ffmpeg freeimage gflags glib gts jsoncpp libyaml libzip ogre ogre2 ogre22 openssl protobuf qt5 qwt tinyxml2 zeromq
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set IGN_MAJOR_VERSION=%%i
 if %IGN_MAJOR_VERSION% GEQ 6 (
   set DEPEN_PKGS=%DEPEN_PKGS% gdal

--- a/jenkins-scripts/ign_launch-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_launch-default-devel-windows-amd64.bat
@@ -4,7 +4,7 @@ set VCS_DIRECTORY=ign-launch
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS=dlfcn-win32 cuda cppzmq curl openssl jsoncpp ffmpeg freeimage ogre ogre2 ogre22 qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq
+set DEPEN_PKGS=assimp ccd cppzmq cuda curl dlfcn-win32 eigen3 fcl ffmpeg freeimage gflags glib gts jsoncpp libyaml libzip ogre ogre2 ogre22 openssl protobuf qt5 qwt tinyxml2 zeromq
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set IGN_MAJOR_VERSION=%%i
 if %IGN_MAJOR_VERSION% GEQ 6 (
   set DEPEN_PKGS=%DEPEN_PKGS% gdal


### PR DESCRIPTION
Hoping to fix the Garden CI builds of gz-sim on windows:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gazebo-ci-win&build=209)](https://build.osrfoundation.org/job/ign_gazebo-ci-win/209/) https://build.osrfoundation.org/job/ign_gazebo-ci-win/209/

~~~
CMake Error at C:/Program Files/CMake/share/cmake-3.20/Modules/FindBoost.cmake:1793 (file):
  file STRINGS file
  "C:/vcpkg/installed/x64-windows/include/boost/version.hpp" cannot be read.
Call Stack (most recent call first):
  C:/vcpkg/scripts/buildsystems/vcpkg.cmake:782 (_find_package)
  CMakeLists.txt:98 (find_package)


CMake Warning at C:/Jenkins/workspace/ign_gazebo-ci-win/ws/install/gz-cmake3/share/cmake/gz-cmake3/cmake3/IgnConfigureBuild.cmake:69 (message):
   CONFIGURATION WARNINGS:
   -- Ogre 1.x versions greater than 1.9 are not officially supported.
   -- The software might compile and even work but support from upstream
   -- could be reduced to accepting patches for newer versions
Call Stack (most recent call first):
  CMakeLists.txt:178 (gz_configure_build)


---
Failed   <<< gz-rendering7	[ Exited with code 1 ]
~~~

Noting that the [ign-rendering build script](https://github.com/gazebo-tooling/release-tools/blob/master/jenkins-scripts/ign_rendering-default-devel-windows-amd64.bat#L8) has `boost-core` listed as a vcpkg dependency, add that to the gz-sim and gz-launch scripts. Also, alphabetize the dependency lists. A new build has been queued using this branch for testing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gazebo-ci-win&build=210)](https://build.osrfoundation.org/job/ign_gazebo-ci-win/210/) https://build.osrfoundation.org/job/ign_gazebo-ci-win/210/
