### PR TITLE
Print vcs export information on Windows

### DIFF
--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -241,6 +241,7 @@ goto :EOF
 :: ##################################
 :list_workspace_pkgs
 colcon list -t || goto :error
+vcs export --exact || goto :error
 goto :EOF
 
 :: ##################################


### PR DESCRIPTION
This simple command will allow us to check differences between the versions of the packages used when building a buildfarm job for Windows. 

Any suggestions to implement something similar for Linux? we've realized the packages are not being imported there via `vcs`.

FYI: @Crola1702

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>