### PR TITLE
Forward-port PR: handle .git URLs

### DIFF
--- a/source-repo-scripts/merge_forward_pull_request.bash
+++ b/source-repo-scripts/merge_forward_pull_request.bash
@@ -38,7 +38,7 @@ set -e
 CURRENT_BRANCH=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 
 ORIGIN_URL=$(git remote get-url origin)
-ORIGIN_ORG_REPO=$(echo ${ORIGIN_URL} | sed -e 's@.*github\.com.@@')
+ORIGIN_ORG_REPO=$(echo ${ORIGIN_URL} | sed -e 's@.*github\.com.@@' | sed -e 's/\.git//g')
 
 TITLE="Merge ${FROM_BRANCH} ➡️  ${TO_BRANCH}"
 


### PR DESCRIPTION
Support URLs like

`git@github.com:ignitionrobotics/ign-utils.git`

Used this to open

* https://github.com/gazebosim/gz-utils/pull/71