### PR TITLE
Disable zstd compression for now

### DIFF
--- a/jenkins-scripts/docker/lib/debian-git-repo-base.bash
+++ b/jenkins-scripts/docker/lib/debian-git-repo-base.bash
@@ -64,7 +64,6 @@ if [[ ${DISTRO} == 'jammy' ]]; then
   sudo cat /usr/local/bin/dpkg-deb
   sudo chmod +x /usr/local/bin/dpkg-deb
   export PATH=/usr/local/bin:\$PATH
-  preserve_path='--preserve-envvar PATH'
 fi
 
 echo '# BEGIN SECTION: install build dependencies'

--- a/jenkins-scripts/docker/lib/debian-git-repo-base.bash
+++ b/jenkins-scripts/docker/lib/debian-git-repo-base.bash
@@ -56,6 +56,17 @@ if [[ ${DISTRO} == 'focal' && ${ARCH} == 'arm64' ]]; then
     sudo ln -sf /bin/true /usr/bin/lintian
 fi
 
+# our packages.o.o running xenial does not support default zstd compression of
+# .deb files in jammy. Keep using xz. Not a trivial change, requires wrapper over dpkg-deb
+if [[ ${DISTRO} == 'jammy' ]]; then
+  sudo bash -c 'echo \#\!/bin/bash > /usr/local/bin/dpkg-deb'
+  sudo bash -c 'echo "/usr/bin/dpkg-deb -Zxz \\\$@" >> /usr/local/bin/dpkg-deb'
+  sudo cat /usr/local/bin/dpkg-deb
+  sudo chmod +x /usr/local/bin/dpkg-deb
+  export PATH=/usr/local/bin:\$PATH
+  preserve_path='--preserve-envvar PATH'
+fi
+
 echo '# BEGIN SECTION: install build dependencies'
 cat debian/changelog
 mkdir build-deps


### PR DESCRIPTION
This mirrors what we do in our nightly debbuilder (https://github.com/gazebo-tooling/release-tools/blob/master/jenkins-scripts/docker/lib/debbuild-base.bash#L236-L245) but for other packages such as ogre-2.3 debs.

This should make the ogre-2.3 packages built be able to be successfully uploaded to the package servers.

Once this job passes, it should trigger the copy to the prerelease repo:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ogre-2.3-debbuilder&build=28)](https://build.osrfoundation.org/job/ogre-2.3-debbuilder/28/)

Signed-off-by: Michael Carroll <michael@openrobotics.org>