### PR TITLE
extra.dsl: debbuild priority 100

### DIFF
--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -59,6 +59,10 @@ gbp_repo_debbuilds.each { software ->
                    'OSRF repo name to upload the package to')
     }
 
+    properties {
+      priority 100
+    }
+
     scm {
       git {
         remote {


### PR DESCRIPTION
Match the priority used in OSRFLinuxBuildPkg for the ogre debbuild jobs

* https://build.osrfoundation.org/job/ogre-2.3-debbuilder
* https://github.com/gazebo-tooling/release-tools/blob/master/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy#L35