### PR TITLE
Install assimp for gz-common on Windows

### DIFF
--- a/jenkins-scripts/ign_common-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_common-default-devel-windows-amd64.bat
@@ -4,7 +4,7 @@ set VCS_DIRECTORY=ign-common
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS=ffmpeg freeimage gts tinyxml2
+set DEPEN_PKGS=assimp ffmpeg freeimage gts tinyxml2
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set IGN_MAJOR_VERSION=%%i
 if %IGN_MAJOR_VERSION% GEQ 5 (
   set DEPEN_PKGS=%DEPEN_PKGS% gdal


### PR DESCRIPTION
* https://github.com/gazebosim/gz-common/pull/393

We already install it for `gz-sim` and `gz-launch`, i.e.

https://github.com/gazebo-tooling/release-tools/blob/f7959b4fdf58188129112d67e956f57dc52f0ef3/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat#L8