### PR TITLE
merge forward script: ensure different args

### DIFF
--- a/source-repo-scripts/merge_forward_pull_request.bash
+++ b/source-repo-scripts/merge_forward_pull_request.bash
@@ -31,6 +31,9 @@ TO_BRANCH=${2}
 if [[ $# -ne 2 ]]; then
   echo "./merge_forward_pull_request.bash <from_branch> <to_branch>"
   exit 1
+elif [[ "$FROM_BRANCH" == "$TO_BRANCH" ]]; then
+  echo "Arguments ${FROM_BRANCH} and ${TO_BRANCH} must not be identical"
+  exit 1
 fi
 
 set -e


### PR DESCRIPTION
I noticed a pull request created with the same branch name used for the source and destination. We can easily check for that case and return an error.