### PR TITLE
ign2gz: fixes for checkout directory names in Win/Brew

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -23,10 +23,13 @@ class GenericAnyJobGitHub
      GenericMail.update_field(job, 'defaultContent',
                     '$JOB_DESCRIPTION \n' + GenericCompilation.get_compilation_mail_content())
 
-    // Use new gz- repositories
-    github_repo = Globals.ign2gz(github_repo)
     // Get repo name for relativeTargetDirectory
     String github_repo_name = github_repo.substring(github_repo.lastIndexOf("/") + 1)
+
+    // Use new gz- repositories
+    // TODO(jrivero): move this before github_repo_name once -compilation
+    // scripts are prepared to work with gz- prefix
+    github_repo = Globals.ign2gz(github_repo)
 
     job.with
     {

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -23,10 +23,10 @@ class GenericAnyJobGitHub
      GenericMail.update_field(job, 'defaultContent',
                     '$JOB_DESCRIPTION \n' + GenericCompilation.get_compilation_mail_content())
 
-    // Get repo name for relativeTargetDirectory
-    String github_repo_name = github_repo.substring(github_repo.lastIndexOf("/") + 1)
     // Use new gz- repositories
     github_repo = Globals.ign2gz(github_repo)
+    // Get repo name for relativeTargetDirectory
+    String github_repo_name = github_repo.substring(github_repo.lastIndexOf("/") + 1)
 
     job.with
     {

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -33,6 +33,9 @@ class Globals
    static String ign2gz(String str) {
      str = str.replaceAll("ignitionrobotics","gazebosim")
      str = str.replaceAll("ign-gazebo","gz-sim")
+     // This one is to workaround failures in main DSL files generating
+     // gz-gazebo instead of gz-sim
+     str = str.replaceAll("gz-gazebo","gz-sim")
      return str.replaceAll("ign-","gz-")
    }
 

--- a/jenkins-scripts/dsl/_configs_/OSRFGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFGitHub.groovy
@@ -8,12 +8,12 @@ class OSRFGitHub
                               String rev    = 'master',
                               String subdir = 'NOT-DEFINED-USE-DEFAULT')
   {
+    repo = Globals.ign2gz(repo)
+
     String software_name = repo.tokenize('/').last()
 
     if (subdir == 'NOT-DEFINED-USE-DEFAULT')
       subdir = software_name
-
-    repo = Globals.ign2gz(repo)
 
     job.with
     {

--- a/jenkins-scripts/dsl/_configs_/OSRFWinCompilationAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFWinCompilationAnyGitHub.groovy
@@ -21,8 +21,10 @@ class OSRFWinCompilationAnyGitHub
     OSRFWinCompilation.create(job, enable_testing, enable_cmake_warnings)
 
     /* Properties from generic any */
+    // TODO(jrivero): remove replace once the rest of the migraton code is
+    // deployed in the ignition.dsl file
     GenericAnyJobGitHub.create(job,
-                               github_repo,
+                               github_repo.replace('gz-gazebo','gz-sim'),
                                supported_branches,
                                enable_github_pr_integration)
   }

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -558,7 +558,10 @@ ignition_software.each { ign_sw ->
               then
                 /bin/bash -xe "\$HOMEBREW_SCRIPT"
               else
-                /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "gz-${ign_sw}"
+                software_name = "gz-${ign_sw}"
+                [[ ${ign_sw} == 'gazebo' ]] && software_name="gz-sim"
+                /bin/bash -xe
+                "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
               fi
               """.stripIndent())
       }
@@ -591,7 +594,9 @@ ignition_software.each { ign_sw ->
                 then
                   /bin/bash -xe "\$HOMEBREW_SCRIPT"
                 else
-                  /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "gz-${ign_sw}"
+                  software_name="gz-${ign_sw}"
+                  [[ ${ign_sw} == 'gazebo' ]] && software_name="gz-sim"
+                  "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
                 fi
                 """.stripIndent())
         }

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -665,7 +665,7 @@ ignition_software.each { ign_sw ->
 
   def ignition_win_ci_any_job = job(ignition_win_ci_any_job_name)
   OSRFWinCompilationAnyGitHub.create(ignition_win_ci_any_job,
-                                    "gazebosim/ign-${ign_sw}",
+                                    "gazebosim/gz-${ign_sw}",
                                     enable_testing(ign_sw),
                                     supported_branches,
                                     ENABLE_GITHUB_PR_INTEGRATION,
@@ -701,8 +701,8 @@ ignition_software.each { ign_sw ->
                               enable_testing(ign_sw),
                               enable_cmake_warnings(ign_sw))
     OSRFGitHub.create(ignition_win_ci_job,
-                              "gazebosim/ign-${ign_sw}",
-                              "${branch}", "ign-${ign_sw}")
+                              "gazebosim/gz-${ign_sw}",
+                              "${branch}")
 
     ignition_win_ci_job.with
     {

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -558,7 +558,7 @@ ignition_software.each { ign_sw ->
               then
                 /bin/bash -xe "\$HOMEBREW_SCRIPT"
               else
-                software_name = "gz-${ign_sw}"
+                software_name="gz-${ign_sw}"
                 [[ ${ign_sw} == 'gazebo' ]] && software_name="gz-sim"
                 /bin/bash -xe
                 "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -560,8 +560,7 @@ ignition_software.each { ign_sw ->
               else
                 software_name="gz-${ign_sw}"
                 [[ ${ign_sw} == 'gazebo' ]] && software_name="gz-sim"
-                /bin/bash -xe
-                "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
+                /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
               fi
               """.stripIndent())
       }
@@ -596,7 +595,7 @@ ignition_software.each { ign_sw ->
                 else
                   software_name="gz-${ign_sw}"
                   [[ ${ign_sw} == 'gazebo' ]] && software_name="gz-sim"
-                  "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
+                  /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
                 fi
                 """.stripIndent())
         }


### PR DESCRIPTION
Different fixes to deal with right naming for directory Git checkouts on Windows and Brew:
  * Relocate `Globals.ign2gz` method at the beginning to deal with problems coming ign-gazebo -> gz-sim
  * Add an extra replace to deal with errors in gn-gazebo -> gz-sim transformation in other DSL files
  * For Windows: remove the optional argument in `OSRFGitHub.create` to leave the default which is just correct. Use new repository name in `OSRFWinCompilationAnyGitHub.create` to make the directory checkout to be correct.
  * For Brew: deal with ign-gazebo -> gz-sim conversion when invoking scripts

Should fix: https://github.com/gazebo-tooling/gazebodistro/pull/117#issuecomment-1204425171
Retry test run: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gazebo-pr-win&build=4855)](https://build.osrfoundation.org/job/ign_gazebo-pr-win/4855/)