### PR TITLE
Fix gz-sim for Homebrew

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -20,6 +20,9 @@ if [[ ${PROJECT/gz} != ${PROJECT} ]]; then
     PROJECT_PATH="${PROJECT_PATH/[0-9]*}"
 fi
 
+# Temporary fix for gz-sim PROJECT_PATH is ign-gazebo, PROJECT is gz-sim
+PROJECT=${PROJECT/gz-gazebo/gz-sim}
+
 # Check for major version number
 # the PROJECT_FORMULA variable is only used for dependency resolution
 PROJECT_FORMULA=${PROJECT//[0-9]}$(\


### PR DESCRIPTION
* Follow up to https://github.com/gazebo-tooling/release-tools/pull/778/files

`gz-sim` is a special snowflake, we were ending up with `brew install gz-gazebo3 --only-dependencies`

Just fixing it within the bash file for now, ideally we'll pass `sim` as the project name eventually

Merging to fix CI