### PR TITLE
Homebrew: more gz-sim band-aids 🩹 

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -22,7 +22,7 @@ fi
 
 # Temporary fix for gz-sim
 PROJECT=${PROJECT/gz-gazebo/gz-sim}
-PROJECT_PATH=${PROJECT_PATH/ign-sim/gz-sim}
+PROJECT_PATH=${PROJECT_PATH/ign-sim/ign-gazebo}
 
 # Check for major version number
 # the PROJECT_FORMULA variable is only used for dependency resolution

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -20,8 +20,9 @@ if [[ ${PROJECT/gz} != ${PROJECT} ]]; then
     PROJECT_PATH="${PROJECT_PATH/[0-9]*}"
 fi
 
-# Temporary fix for gz-sim PROJECT_PATH is ign-gazebo, PROJECT is gz-sim
+# Temporary fix for gz-sim
 PROJECT=${PROJECT/gz-gazebo/gz-sim}
+PROJECT_PATH=${PROJECT_PATH/ign-sim/gz-sim}
 
 # Check for major version number
 # the PROJECT_FORMULA variable is only used for dependency resolution


### PR DESCRIPTION
Follow up to:

* #778 
* https://github.com/gazebo-tooling/release-tools/pull/780
* #779 

The `detect_cmake_major_version` script is failing: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-pr_any-homebrew-amd64&build=8992)](https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-homebrew-amd64/8992/)

```
+ PROJECT=gz-sim
+ PROJECT_ARGS=
+ PROJECT_PATH=gz-sim
+ [[ -sim != gz-sim ]]
+ PROJECT_PATH=ign-sim
+ PROJECT_PATH=ign-sim
+ PROJECT=gz-sim
++ python ./scripts/jenkins-scripts/tools/detect_cmake_major_version.py /Users/jenkins/workspace/ignition_gazebo-ci-pr_any-homebrew-amd64/ign-sim/CMakeLists.txt
Traceback (most recent call last):
  File "./scripts/jenkins-scripts/tools/detect_cmake_major_version.py", line 11, in <module>
    f = open(fileName, 'r')
IOError: [Errno 2] No such file or directory: '/Users/jenkins/workspace/ignition_gazebo-ci-pr_any-homebrew-amd64/ign-sim/CMakeLists.txt'
```

This PR fixes it: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-pr_any-homebrew-amd64&build=8995)](https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-homebrew-amd64/8995/)

```
+ PROJECT=gz-sim
+ PROJECT_ARGS=
+ PROJECT_PATH=gz-sim
+ [[ -sim != gz-sim ]]
+ PROJECT_PATH=ign-sim
+ PROJECT_PATH=ign-sim
+ PROJECT=gz-sim
+ PROJECT_PATH=ign-gazebo
++ python ./scripts/jenkins-scripts/tools/detect_cmake_major_version.py /Users/jenkins/workspace/ignition_gazebo-ci-pr_any-homebrew-amd64/ign-gazebo/CMakeLists.txt
+ PROJECT_FORMULA=gz-sim7
```