### PR TITLE
Add a github action CI to check correctness of DSL files 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,52 @@
+name: CI
+
+# base_ref / head_reaf are only available in PRs
+on: [pull_request]
+
+jobs:
+  dsl_ci:
+    runs-on: ubuntu-latest
+    name: Diff for DSL code
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Idenfify files changed in this PR
+        id: files
+        run: |
+            git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}
+            echo "::set-output name=changed-files::$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}| tr '\n' ' ')"
+      - name: Run testing on changed config files
+        id: dsl_check
+        run: |
+          for changed_file in ${{ steps.files.outputs.changed-files }}; do
+            if [[ ${changed_file} != ${changed_file/dsl\/*} ]]; then
+              echo "+ Detected at leat one config file: ${changed_file}."
+              echo "::set-output name=run_job::true"
+              break
+            else
+              echo "::set-output name=run_job::false"
+            fi
+          done
+      - name: Checkout
+        if: steps.dsl_check.outputs.run_job == 'true'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v3
+        if: steps.dsl_check.outputs.run_job == 'true'
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Download job dsl jar
+        if: steps.dsl_check.outputs.run_job == 'true'
+        run: curl https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/job-dsl-core/1.77/job-dsl-core-1.77-standalone.jar -o jobdsl.jar
+      - name: Generate all DSL files
+        if: steps.dsl_check.outputs.run_job == 'true'
+        run: |
+          # simulate token for brew_release
+          sudo mkdir -p /var/lib/jenkins/ && sudo touch /var/lib/jenkins/remote_token
+          sudo chown -R ${USER} /var/lib/jenkins
+          cd jenkins-scripts/dsl
+          java -jar ../../jobdsl.jar *.dsl

--- a/jenkins-scripts/dsl/_configs_/GenericRemoteToken.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericRemoteToken.groovy
@@ -15,7 +15,12 @@ class GenericRemoteToken
       println("check your filesystem in the jenkins node for: ")
       println(token_file)
       // We can not use exit here, DSL job hangs
-      buildUnstable()
+      job.with
+      {
+        steps {
+          setBuildResult('UNSTABLE')
+        }
+      }
     }
 
     job.with


### PR DESCRIPTION
The PR adds a short CI for checking that PR changes are not breaking DSL files. This is a simple action that opens the door to do something more useful like showing the real diffs in Jenkins configurations when a PR is being created and DSL files are touched.

Nothing very special in the Github action a part of checking in DSL files are being modified and only run the action in that case. The CI discovered an error in one of the DSL files, fixed in 5421b2eda145719de92ec28aa0876dae2197978e.

Next steps could be:
 * Run the generation only in modified files or in all files if the file is a shared code (inside _configs_).
 * Run the generation in master and compare the XML files being generated exporting a file with real diffs on changes to land in Jenkins.