### PR TITLE
Be sure of update gzdev if docker cache is invalidated

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -278,7 +278,11 @@ cat >> Dockerfile << DELIM_DOCKER3
 # Could not open file *_Packages.diff_Index - open (2: No such file or directory)
 # TODO: remove workaround for 13.56.139.45 server
 RUN echo "${MONTH_YEAR_STR}"
-DELIM_DOCKER3
+# If the previous command invalidated the cache, a new install of gzdev is
+# needed to update to possible recent changes in configuration and/or code and
+# not being used since the docker cache did not get them.
+dockerfile_install_gzdev_repos
+ELIM_DOCKER3
 
 cat >> Dockerfile << DELIM_DOCKER3_2
 RUN sed -i -e 's:13\.56\.139\.45:packages.osrfoundation.org:g' /etc/apt/sources.list.d/* || true \

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -278,11 +278,12 @@ cat >> Dockerfile << DELIM_DOCKER3
 # Could not open file *_Packages.diff_Index - open (2: No such file or directory)
 # TODO: remove workaround for 13.56.139.45 server
 RUN echo "${MONTH_YEAR_STR}"
+DELIM_DOCKER3
+
 # If the previous command invalidated the cache, a new install of gzdev is
 # needed to update to possible recent changes in configuration and/or code and
 # not being used since the docker cache did not get them.
 dockerfile_install_gzdev_repos
-ELIM_DOCKER3
 
 cat >> Dockerfile << DELIM_DOCKER3_2
 RUN sed -i -e 's:13\.56\.139\.45:packages.osrfoundation.org:g' /etc/apt/sources.list.d/* || true \


### PR DESCRIPTION
When generating the `Dockerfile` we inject a command to invalidate the docker cache monthly. If that happens, it is possible that new gzdev configuration is needed to update to possible recent changes in configuration and/or code before we install packages in the next command.

Example of errors: https://build.osrfoundation.org/job/ignition_gui-ci-pr_any-ubuntu_auto-amd64/1729/console

Testing first run with invalidated cache: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-pr_any-ubuntu_auto-amd64&build=1743)](https://build.osrfoundation.org/job/ignition_gui-ci-pr_any-ubuntu_auto-amd64/1743/)