### PR TITLE
Add CI jobs for garden branches

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -80,22 +80,7 @@ ignition_prerelease_branches = []
 // DESC: versioned names to generate debbuild jobs for special cases that
 // don't appear in ignition_branches (like nightly builders or 0-debbuild
 // jobs for the special cases of foo0 packages)
-ignition_extra_debbuild = [ 'cmake3',
-                            'common5',
-                            'fuel-tools8',
-                            'gazebo7',
-                            'gui7',
-                            'launch6',
-                            'math7',
-                            'msgs9',
-                            'physics6',
-                            'plugin2',
-                            'rendering7',
-                            'sensors7',
-                            'tools2',
-                            'transport12',
-                            'utils1', // see comment https://github.com/gazebo-tooling/release-tools/pull/431#issuecomment-815099918
-                            'utils2']
+ignition_extra_debbuild = [ 'utils1'] // see comment https://github.com/gazebo-tooling/release-tools/pull/431#issuecomment-815099918
 // DESC: exclude ignition from generate any install testing job
 ignition_no_pkg_yet         = [  ]
 // DESC: major versions that has a package in the prerelease repo. Should
@@ -245,7 +230,7 @@ ArrayList all_debbuilders()
         if ("${major_version}" == "0"  || "${major_version}" == "1" )
           major_version = ""
 
-        branches.add("gz-${ign_software}${major_version}")
+        branches.add("ign-${ign_software}${major_version}")
       }
     }
   }

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -14,7 +14,6 @@ ignition_software = [ 'cmake',
                       'plugin',
                       'rendering',
                       'sensors',
-                      'sim',
                       'tools',
                       'transport',
                       'utils' ]
@@ -22,8 +21,7 @@ ignition_software = [ 'cmake',
 ignition_gpu                = [ 'gazebo',
                                 'gui',
                                 'rendering',
-                                'sensors',
-                                'sim' ]
+                                'sensors' ]
 // DESC: software does not support cmake warnings enabled
 ignition_no_cmake_warnings = [ 'cmake',
                       'common',
@@ -103,7 +101,6 @@ ignition_colcon_win         = [ 'common',
                                 'plugin',
                                 'rendering',
                                 'sensors',
-                                'sim',
                                 'tools',
                                 'transport',
                                 'utils' ]

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -58,6 +58,21 @@ ignition_branches           = [ 'cmake'      : [ '2' ],
                                 'tools'      : [ '1' ],
                                 'transport'  : [ '4', '8', '11' ],
                                 'utils'      : [ '1' ]]
+gz_branches                 = [ 'cmake'      : [ '3' ],
+                                'common'     : [ '5' ],
+                                'fuel-tools' : [ '8' ],
+                                'gui'        : [ '7' ],
+                                'launch'     : [ '6' ],
+                                'math'       : [ '7' ],
+                                'msgs'       : [ '9' ],
+                                'physics'    : [ '6' ],
+                                'plugin'     : [ '2' ],
+                                'rendering'  : [ '7' ],
+                                'sensors'    : [ '7' ],
+                                'sim'        : [ '7' ],
+                                'tools'      : [ '2' ],
+                                'transport'  : [ '12' ],
+                                'utils'      : [ '2' ]]
 // DESC: prerelease branches are managed as any other supported branches for
 // special cases different to major branches: get compilation CI on the branch
 // physics/sensors don't need to be included since they use main for gz11
@@ -165,6 +180,15 @@ ArrayList supported_ign_branches(String ign_software)
 
   return major_versions_registered
 }
+ArrayList supported_gz_branches(String gz_software)
+{
+  major_versions_registered = gzition_branches["${gz_software}"]
+
+  if (major_versions_registered == null)
+    return [ '' ]
+
+  return major_versions_registered
+}
 
 // return prerelease branch names
 ArrayList prerelease_branches(String ign_software)
@@ -184,6 +208,11 @@ ArrayList all_branches(String ign_software)
   supported_ign_branches("${ign_software}").each { major_version ->
     if ("${major_version}") {
       branches.add("ign-${ign_software}${major_version}")
+    }
+  }
+  supported_gz_branches("${gz_software}").each { major_version ->
+    if ("${major_version}") {
+      branches.add("gz-${gz_software}${major_version}")
     }
   }
   branches.add('main')
@@ -207,6 +236,14 @@ ArrayList all_debbuilders()
         if ("${major_version}" == "0"  || "${major_version}" == "1" )
           major_version = ""
           branches.add("ign-${ign_software}${major_version}")
+      }
+    }
+    supported_gz_branches("${gz_software}").each { major_version ->
+      if (major_version) {
+        // No 1-debbuild versions, they use the unversioned job
+        if ("${major_version}" == "0"  || "${major_version}" == "1" )
+          major_version = ""
+          branches.add("gz-${gz_software}${major_version}")
       }
     }
   }

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -80,7 +80,8 @@ ignition_prerelease_branches = []
 // DESC: versioned names to generate debbuild jobs for special cases that
 // don't appear in ignition_branches (like nightly builders or 0-debbuild
 // jobs for the special cases of foo0 packages)
-ignition_extra_debbuild = [ 'utils1'] // see comment https://github.com/gazebo-tooling/release-tools/pull/431#issuecomment-815099918
+ignition_extra_debbuild = [ 'gazebo7',
+                            'utils1'] // see comment https://github.com/gazebo-tooling/release-tools/pull/431#issuecomment-815099918
 // DESC: exclude ignition from generate any install testing job
 ignition_no_pkg_yet         = [  ]
 // DESC: major versions that has a package in the prerelease repo. Should

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -258,6 +258,7 @@ ArrayList all_debbuilders()
 // return all ci branch names
 // Map with the form of: major versions as keys.
 // Lists of distros supported as values
+// @TODO[scpeters] update this to support gz_branches after garden release
 Map supported_install_pkg_branches(String ign_software)
 {
   major_versions_prerelease = ignition_prerelease_pkgs["${ign_software}"]

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -14,6 +14,7 @@ ignition_software = [ 'cmake',
                       'plugin',
                       'rendering',
                       'sensors',
+                      'sim',
                       'tools',
                       'transport',
                       'utils' ]
@@ -21,7 +22,8 @@ ignition_software = [ 'cmake',
 ignition_gpu                = [ 'gazebo',
                                 'gui',
                                 'rendering',
-                                'sensors' ]
+                                'sensors',
+                                'sim' ]
 // DESC: software does not support cmake warnings enabled
 ignition_no_cmake_warnings = [ 'cmake',
                       'common',
@@ -101,6 +103,7 @@ ignition_colcon_win         = [ 'common',
                                 'plugin',
                                 'rendering',
                                 'sensors',
+                                'sim',
                                 'tools',
                                 'transport',
                                 'utils' ]

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -686,11 +686,11 @@ ignition_software.each { ign_sw ->
 
   // ign-gazebo only support Windows from ign-gazebo5
   if (ign_sw == 'gazebo')
-    supported_branches = [ 'ign-gazebo6', 'main' ]
+    supported_branches = [ 'ign-gazebo6', 'gz-sim7', 'main' ]
 
   // ign-launch only support Windows from ign-launch5
   if (ign_sw == 'launch')
-    supported_branches = [ 'ign-launch5', 'main' ]
+    supported_branches = [ 'ign-launch5', 'gz-launch6', 'main' ]
 
   def ignition_win_ci_any_job = job(ignition_win_ci_any_job_name)
   OSRFWinCompilationAnyGitHub.create(ignition_win_ci_any_job,
@@ -736,11 +736,11 @@ ignition_software.each { ign_sw ->
     ignition_win_ci_job.with
     {
         // ign-gazebo only works on Windows from ign-gazebo5
-        if (branch == 'ign-gazebo3' || branch == 'ign-gazebo4')
+        if (branch == 'ign-gazebo3')
           disabled()
 
         // ign-launch was not ported to windows until 5
-        if (branch == 'ign-launch2' || branch == 'ign-launch3' || branch == 'ign-launch4')
+        if (branch == 'ign-launch2')
           disabled()
 
         triggers {

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -210,9 +210,9 @@ ArrayList all_branches(String ign_software)
       branches.add("ign-${ign_software}${major_version}")
     }
   }
-  supported_gz_branches("${gz_software}").each { major_version ->
+  supported_gz_branches("${ign_software}").each { major_version ->
     if ("${major_version}") {
-      branches.add("gz-${gz_software}${major_version}")
+      branches.add("gz-${ign_software}${major_version}")
     }
   }
   branches.add('main')
@@ -238,12 +238,12 @@ ArrayList all_debbuilders()
           branches.add("ign-${ign_software}${major_version}")
       }
     }
-    supported_gz_branches("${gz_software}").each { major_version ->
+    supported_gz_branches("${ign_software}").each { major_version ->
       if (major_version) {
         // No 1-debbuild versions, they use the unversioned job
         if ("${major_version}" == "0"  || "${major_version}" == "1" )
           major_version = ""
-          branches.add("gz-${gz_software}${major_version}")
+          branches.add("gz-${ign_software}${major_version}")
       }
     }
   }

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -182,7 +182,7 @@ ArrayList supported_ign_branches(String ign_software)
 }
 ArrayList supported_gz_branches(String gz_software)
 {
-  major_versions_registered = gzition_branches["${gz_software}"]
+  major_versions_registered = gz_branches["${gz_software}"]
 
   if (major_versions_registered == null)
     return [ '' ]

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -235,7 +235,8 @@ ArrayList all_debbuilders()
         // No 1-debbuild versions, they use the unversioned job
         if ("${major_version}" == "0"  || "${major_version}" == "1" )
           major_version = ""
-          branches.add("ign-${ign_software}${major_version}")
+
+        branches.add("ign-${ign_software}${major_version}")
       }
     }
     supported_gz_branches("${ign_software}").each { major_version ->
@@ -243,7 +244,8 @@ ArrayList all_debbuilders()
         // No 1-debbuild versions, they use the unversioned job
         if ("${major_version}" == "0"  || "${major_version}" == "1" )
           major_version = ""
-          branches.add("gz-${ign_software}${major_version}")
+
+        branches.add("gz-${ign_software}${major_version}")
       }
     }
   }

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -156,7 +156,7 @@ Map merge_maps(Map[] sources) {
 
 // return major versions supported or empty if just 0,1 series under
 // -dev package.
-ArrayList supported_branches(String ign_software)
+ArrayList supported_ign_branches(String ign_software)
 {
   major_versions_registered = ignition_branches["${ign_software}"]
 
@@ -181,7 +181,7 @@ ArrayList prerelease_branches(String ign_software)
 ArrayList all_branches(String ign_software)
 {
   List<String> branches = new ArrayList<String>();
-  supported_branches("${ign_software}").each { major_version ->
+  supported_ign_branches("${ign_software}").each { major_version ->
     if ("${major_version}") {
       branches.add("ign-${ign_software}${major_version}")
     }
@@ -201,7 +201,7 @@ ArrayList all_debbuilders()
   List<String> branches = new ArrayList<String>();
   // add all supported branches
   ignition_software.each { ign_software ->
-    supported_branches("${ign_software}").each { major_version ->
+    supported_ign_branches("${ign_software}").each { major_version ->
       if (major_version) {
         // No 1-debbuild versions, they use the unversioned job
         if ("${major_version}" == "0"  || "${major_version}" == "1" )
@@ -225,11 +225,11 @@ Map supported_install_pkg_branches(String ign_software)
 {
   major_versions_prerelease = ignition_prerelease_pkgs["${ign_software}"]
 
-  // construct a map of stable packages based on supported_branches and
+  // construct a map of stable packages based on supported_ign_branches and
   // all_supported_distros
   map_of_stable_versions = [:]
   map_of_stable_versions[ign_software] = [:]
-  supported_branches(ign_software).each { major_version ->
+  supported_ign_branches(ign_software).each { major_version ->
     new_relation = [:]
     new_relation[major_version] = all_supported_distros
     map_of_stable_versions[ign_software] << new_relation

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -1,10 +1,10 @@
 import _configs_.*
 import javaposse.jobdsl.dsl.Job
 
-def sdformat_supported_branches = [ 'sdformat6' , 'sdformat9', 'sdformat12' ]
-def sdformat_gz11_branches = [ 'sdformat9', 'sdformat10', 'sdformat12', 'main' ]
+def sdformat_supported_branches = [ 'sdformat6' , 'sdformat9', 'sdformat12', 'sdformat13' ]
+def sdformat_gz11_branches = [ 'sdformat9', 'sdformat12', 'sdformat13', 'main' ]
 // nightly and prereleases
-def extra_sdformat_debbuilder = [ 'sdformat13' ]
+def extra_sdformat_debbuilder = [  ]
 
 // Main platform using for quick CI
 def ci_distro               = Globals.get_ci_distro()


### PR DESCRIPTION
This renames the `supported_branches` method in `ignition.dsl` to `supported_ign_branches` (https://github.com/gazebo-tooling/release-tools/commit/eab7c8eed4e35d49980e0599e728794c296478f8) and adds a parallel `supported_gz_branches` method that draws from a `gz_branches` data structure (https://github.com/gazebo-tooling/release-tools/commit/9ab203a95aa0b29e843393fbadf4acef4a9f3dcf). It also adds the `sdf13` branch in `sdformat.dsl` (https://github.com/gazebo-tooling/release-tools/commit/558d0e69ad9b40e3cf3cb0d5b06bfa81bafe9dc8).

The code duplication could potentially be reduced with some refactoring, but I think this is the easiest way to get CI working for our garden branches.