### PR TITLE
Windows fixes for 753 (ign -> gz)

### DIFF
--- a/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
@@ -16,14 +16,14 @@ if "!PKG_MAJOR_VERSION!" == "1" (
    set COLCON_PACKAGE=%COLCON_PACKAGE%!PKG_MAJOR_VERSION!
 )
 
-echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from ignition to gz if needed
+echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
 echo Packages in workspace:
 colcon list --names-only
 
 colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (
-  set COLCON_PACKAGE=%COLCON_PACKAGE:ignition=gz%
-  set COLCON_PACKAGE=!COLCON_PACKAGE:gazebo=sim!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:gz=ignition!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:sim=gazebo!
 )
 colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -36,14 +36,14 @@ if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
 )
 
 :: Check if package is in colcon workspace
-echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from ignition to gz if needed
+echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
 echo Packages in workspace:
 colcon list --names-only
 
 colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (
-  set COLCON_PACKAGE=!COLCON_PACKAGE:ignition=gz!
-  set COLCON_PACKAGE=!COLCON_PACKAGE:gazebo=sim!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:gz=ignition!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:sim=gazebo!
 )
 colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -211,14 +211,14 @@ goto :EOF
 set COLCON_PACKAGE=%1
 
 :: Check if package is in colcon workspace
-echo # BEGIN SECTION: Update package %COLCON_PACKAGE% from ignition to gz if needed
+echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
 echo Packages in workspace:
 colcon list --names-only
 
-colcon list --names-only | find "%COLCON_PACKAGE%"
+colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (
-  set COLCON_PACKAGE=!COLCON_PACKAGE:ignition=gz!
-  set COLCON_PACKAGE=!COLCON_PACKAGE:gazebo=sim!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:gz=ignition!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:sim=gazebo!
 )
 colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -211,21 +211,8 @@ goto :EOF
 set COLCON_PACKAGE=%1
 
 :: Check if package is in colcon workspace
-echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
-echo Packages in workspace:
+echo # BEGIN SECTION Packages in workspace:
 colcon list --names-only
-
-colcon list --names-only | find "!COLCON_PACKAGE!"
-if errorlevel 1 (
-  set COLCON_PACKAGE=!COLCON_PACKAGE:gz=ignition!
-  set COLCON_PACKAGE=!COLCON_PACKAGE:sim=gazebo!
-)
-colcon list --names-only | find "!COLCON_PACKAGE!"
-if errorlevel 1 (
-  echo Failed to find package !COLCON_PACKAGE! in workspace.
-  goto :error
-)
-echo Using package name !COLCON_PACKAGE!
 echo # END SECTION
 
 :: two runs to get the dependencies built with testing and the package under


### PR DESCRIPTION
@methylDragon while working on #753 I found that Windows builds [seems to fail ](https://build.osrfoundation.org/job/_test_ign_physics-ign-2-win/1/console)with problems in COLCON_PACKAGE var. We are chaging in #753 all COLCON_PACKAGE names to `gz-*`, something that is going to break old supported branches that expect `ignition-*`. I made 75877eec8c54725074b4cf996790ed14025477d8 to revert the logic.

The other patch here is removing the code in windows_library since the `build_workspace` is only called from the `jenkins-scripts/lib/colcon-default-devel-windows.bat` that already implements the logic as far as I can tell.

I've tested this branch in: https://build.osrfoundation.org/job/_test_ign_physics-ign-2-win/8/