### PR TITLE
Add script to convert a gazebodistro file to vcs file with -release repos

### DIFF
--- a/release-repo-scripts/README.md
+++ b/release-repo-scripts/README.md
@@ -72,6 +72,28 @@ git clone https://github.com/gz-release/gz-rendering7-release
 cd gz-rendering7-release
 ./path/to/release-tools/release-repo-scripts/changelog_spawn.sh 7.1.0-1
 ```
+
+### convert_gazebodistro_to_release.py
+
+Convert a gazebodistro file into a vcs compatible file with the -release repositories
+associated to the repositories in the input file.
+
+### Usage
+
+Output will printed to stdout:
+
+```bash
+./path/to/release-tools/release-repo-scripts/convert_gazebodistro_to_release.py <gazbodistro_file>
+```
+
+### Example
+
+To import all release repositories related to gz Garden collection:
+
+```bash
+./path/to/release-tools/release-repo-scripts/convert_gazebodistro_to_release.py ~/code/gazebodistro/collection-garden.yaml  > collection-garden-release.yaml
+vcs import < collection-garden-release.yaml
+```
 ### new_ignition_release_repos.bash
 
 The script will create new -release repositories as forks from the previous version

--- a/release-repo-scripts/convert_gazebodistro_to_release.py
+++ b/release-repo-scripts/convert_gazebodistro_to_release.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+import argparse
+import sys
+
+import yaml
+
+
+def _load_gazebodistro_file(filepath) -> dict:
+    with open(filepath, 'r') as file:
+        gazebodistro = yaml.load(file, Loader=yaml.FullLoader)
+
+    return gazebodistro
+
+
+def _convert_to_release(input_yaml) -> None:
+    repos = {}
+    for repo, repo_info in input_yaml['repositories'].items():
+        branch = repo_info['version'].replace('sdf', 'sdformat')
+        repo_name = f'{branch}-release'
+        repos[repo_name] = {'type': repo_info['type'],
+                            'url': f'https://github.com/gazebo-release/{repo_name}',
+                            'version': 'main'}
+    repos = {'repositories': repos}
+    yaml.dump(repos, sys.stdout)
+
+
+def _init_argparse() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        usage='%(prog)s GAZEBODISTRO_FILE',
+        description='Transform gazebodistro files into vcs files for release repos'
+    )
+    parser.add_argument('input_file', nargs=1, type=str)
+    return parser
+
+
+def main() -> None:
+    """Convert gazebodistro files into vcs files for release repositories in the input file."""
+    parser = _init_argparse()
+    args = parser.parse_args()
+    input_yaml = _load_gazebodistro_file(args.input_file[0])
+    _convert_to_release(input_yaml)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The PR adds a little script that generates vcs compatible files using a gazebodistro file as input and all the -release repositories associated with the input file. More info in the content added to the README. 