### PR TITLE
brew CI: set PYTHONPATH

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -34,6 +34,8 @@ export HOMEBREW_PREFIX=/usr/local
 export HOMEBREW_CELLAR=${HOMEBREW_PREFIX}/Cellar
 export PATH=${HOMEBREW_PREFIX}/bin:$PATH
 
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python
+
 # make verbose mode?
 MAKE_VERBOSE_STR=""
 if [[ ${MAKE_VERBOSE} ]]; then


### PR DESCRIPTION
Something changed recently in the way python works on homebrew, and some of our tests are currently unable to find our installed python bindings:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat13-homebrew-amd64&build=8)](https://build.osrfoundation.org/job/sdformat-ci-sdformat13-homebrew-amd64/8/) https://build.osrfoundation.org/job/sdformat-ci-sdformat13-homebrew-amd64/8/

~~~
282:     from gz.math import Pose3d, Color
282: E   ModuleNotFoundError: No module named 'gz'
~~~

Setting `PYTHONPATH` to `/usr/local/lib/python` allows finding the `gz` python bindings.

### Test with this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat13-homebrew-amd64&build=9)](https://build.osrfoundation.org/job/sdformat-ci-sdformat13-homebrew-amd64/9/) https://build.osrfoundation.org/job/sdformat-ci-sdformat13-homebrew-amd64/9/
