### PR TITLE
Fix gz-sim nightly branch, garden view sdf13 jobs

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -282,9 +282,9 @@ gz_collection_jobs =
         'ignition_utils-ci-gz-utils2-homebrew-amd64',
         'ignition_utils-install-pkg-focal-amd64',
         'ignition_utils1-install_bottle-homebrew-amd64',
-        'sdformat-ci-main-focal-amd64',
-        'sdformat-ci-main-homebrew-amd64',
-        'sdformat-ci-main-windows7-amd64',
+        'sdformat-ci-sdformat13-focal-amd64',
+        'sdformat-ci-sdformat13-homebrew-amd64',
+        'sdformat-ci-sdformat13-windows7-amd64',
         'sdformat-install-sdformat12_pkg-focal-amd64'
   ],
 ]

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -558,6 +558,8 @@ nightly_scheduler_job.with
                 src_branch="${sensors_branch}"
               elif [[ "\${n}" != "\${n/sdformat/}" ]]; then
                 src_branch="${sdformat_branch}"
+              elif  [[ "\${n}" != "\${n/sim/}" ]]; then
+                src_branch="${gazebo_branch}"
               elif [[ "\${n}" != "\${n/transport/}" ]]; then
                 src_branch="${transport_branch}"
               elif [[ "\${n}" != "\${n/tools/}" ]]; then


### PR DESCRIPTION
I noticed that the most recently nightly build scheduler is using the `main` branch for the gz-sim7 builds, when it should be using `gz-sim7`:

* https://build.osrfoundation.org/job/ignition-garden-nightly-scheduler/374/

~~~
releasing gz-sim7 (from branch main
 - done
~~~

This should be fixed by https://github.com/gazebo-tooling/release-tools/commit/a64a5a46fba66c406c66eb8f800c9768d92a2556

I also forgot to update the sdformat13 jobs in the garden view in #793, so I've updated that in https://github.com/gazebo-tooling/release-tools/commit/24c9b58a4818c1aee0e3bd4dc9eb3e8d74fd62a0 as well.