### PR TITLE
Use ign-garden debbuilder name

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -34,7 +34,7 @@ gz_collections = [
           'physics'   : [ debbuild: 'gz-physics6'    , branch: 'gz-physics6' ],
           'gazebo'    : [ debbuild: 'gz-sim7'        , branch: 'gz-sim7' ],
           'launch'    : [ debbuild: 'gz-launch6'     , branch: 'gz-launch6' ],
-          'garden'    : [ debbuild: 'gz-garden'      , branch: 'main' ],
+          'garden'    : [ debbuild: 'ign-garden'     , branch: 'main' ],
     ],
   ],
 ]


### PR DESCRIPTION
Nightly deb builder scheduler is unstable:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-garden-nightly-scheduler&build=377)](https://build.osrfoundation.org/job/ignition-garden-nightly-scheduler/377/) https://build.osrfoundation.org/job/ignition-garden-nightly-scheduler/377/

~~~
releasing gz-garden (from branch main
Traceback (most recent call last):
  File "./scripts/release.py", line 668, in <module>
    go(sys.argv)
  File "./scripts/release.py", line 665, in go
    urllib.request.urlopen(url)
  File "/usr/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/usr/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 409: Conflict
MARK_AS_UNSTABLE
 - done
~~~

From the log in job workspace:

~~~
- Linux: https://build.osrfoundation.org//job/gz-garden-debbuilder/...
~~~

The `gz-garden-debbuilder` is not the active job name, so revert to ign-garden-debbuilder for now:

* https://build.osrfoundation.org//job/gz-garden-debbuilder
* https://build.osrfoundation.org//job/ign-garden-debbuilder