### PR TITLE
Dashboard for Garden pre-release

### DIFF
--- a/terminal-dashboard/_dashboard_lib.sh
+++ b/terminal-dashboard/_dashboard_lib.sh
@@ -45,23 +45,23 @@ get_libraries_by_collection()
 	ignition-fortress"
     elif [ "$COLLECTION" = "garden" ]; then
       LIBS="
-	ignition-cmake2
-	ignition-math7
-	ignition-utils1
-	ignition-tools
-	ignition-common5
-	ignition-msgs9
-	ignition-transport12
-	ignition-fuel-tools8
-	ignition-plugin
-	ignition-rendering7
+	gz-cmake3
+	gz-math7
+	gz-utils2
+	gz-tools2
+	gz-common5
+	gz-msgs9
+	gz-transport12
+	gz-fuel-tools8
+	gz-plugin2
+	gz-rendering7
 	sdformat13
-	ignition-physics6
-	ignition-sensors7
-	ignition-gui7
-	ignition-gazebo7
-	ignition-launch6
-	ignition-garden"
+	gz-physics6
+	gz-sensors7
+	gz-gui7
+	gz-gazebo7
+	gz-launch6
+	gz-garden"
     else
       return 1
     fi

--- a/terminal-dashboard/table.bash
+++ b/terminal-dashboard/table.bash
@@ -30,7 +30,8 @@ RED="\e[101m"
 
 ARCHS=( "amd64")
 DISTROS=( "ubuntu" )
-if [[ $PACKAGE_REPO != "nightly" ]]; then
+# No nightlies or pre-releases for arm
+if [[ $PACKAGE_REPO == "stable" ]]; then
   ARCHS+=( "i386" "arm64" "armhf")
   # No debian version supported across the stack right now
   # DISTROS+=( "debian" )


### PR DESCRIPTION
* Use `gz` names
* Leave only AMD

Current status:

![image](https://user-images.githubusercontent.com/5751272/187519577-08e7a22d-5d64-4edf-a49e-6008578b5381.png)
