### PR TITLE
Port gz-cmake to use colcon on Windows

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -92,7 +92,8 @@ gz_prerelease_pkgs    = [ 'placeholder' : [
                         ]
 // packages using colcon for windows compilation while migrating all them to
 // this solution
-gz_colcon_win         = [ 'common',
+gz_colcon_win         = [ 'cmake',
+                          'common',
                           'fuel-tools',
                           'gazebo',
                           'gui',

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -42,6 +42,7 @@ gz_collections = [
 gz_collection_jobs =
 [
   'citadel' : [
+        'ign_cmake-ign-2-win',
         'ign_common-ign-3-win',
         'ign_fuel-tools-ign-4-win',
         'ign_gazebo-ign-3-win',
@@ -59,7 +60,6 @@ gz_collection_jobs =
         'ignition_citadel-install_bottle-homebrew-amd64',
         'ignition_cmake-ci-ign-cmake2-focal-amd64',
         'ignition_cmake-ci-ign-cmake2-homebrew-amd64',
-        'ignition_cmake-ci-ign-cmake2-windows7-amd64',
         'ignition_cmake2-install-pkg-focal-amd64',
         'ignition_cmake2-install_bottle-homebrew-amd64',
         'ignition_common-ci-ign-common3-focal-amd64',
@@ -120,6 +120,7 @@ gz_collection_jobs =
         'sdformat-install-sdformat9_pkg-focal-amd64'
   ],
   'fortress' : [
+        'ign_cmake-ign-2-win',
         'ign_common-ign-4-win',
         'ign_fuel-tools-ign-7-win',
         'ign_gazebo-ign-6-win',
@@ -136,7 +137,6 @@ gz_collection_jobs =
         'ign_utils-ign-1-win',
         'ignition_cmake-ci-ign-cmake2-focal-amd64',
         'ignition_cmake-ci-ign-cmake2-homebrew-amd64',
-        'ignition_cmake-ci-ign-cmake2-windows7-amd64',
         'ignition_cmake2-install-pkg-focal-amd64',
         'ignition_cmake2-install_bottle-homebrew-amd64',
         'ignition_common-ci-ign-common4-focal-amd64',
@@ -204,6 +204,7 @@ gz_collection_jobs =
         'sdformat-install-sdformat12_pkg-focal-amd64'
   ],
   'garden' : [
+        'ign_cmake-gz-3-win',
         'ign_common-gz-5-win',
         'ign_fuel-tools-gz-8-win',
         'ign_gazebo-ci-win',
@@ -220,7 +221,6 @@ gz_collection_jobs =
         'ign_utils-gz-2-win',
         'ignition_cmake-ci-gz-cmake3-focal-amd64',
         'ignition_cmake-ci-gz-cmake3-homebrew-amd64',
-        'ignition_cmake-ci-gz-cmake3-windows7-amd64',
         'ignition_cmake2-install-pkg-focal-amd64',
         'ignition_cmake2-install_bottle-homebrew-amd64',
         'ignition_common-ci-gz-common5-focal-amd64',

--- a/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
@@ -7,6 +7,6 @@ set IGN_CLEAN_WORKSPACE=true
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=gz-cmake
 set COLCON_AUTO_MAJOR_VERSION=true
-set COLCON_PACKAGE_EXTRA_CMAKE_ARGS=-DBUILDSYSTEM_TESTING:BOOL=True
+set COLCON_PACKAGE_EXTRA_CMAKE_ARGS="-DBUILDSYSTEM_TESTING:BOOL=True"
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
@@ -7,6 +7,6 @@ set IGN_CLEAN_WORKSPACE=true
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=gz-cmake
 set COLCON_AUTO_MAJOR_VERSION=true
-set COLCON_EXTRA_CMAKE_ARGS=-DBUILDSYSTEM_TESTING:BOOL=True
+set COLCON_PACKAGE_EXTRA_CMAKE_ARGS=-DBUILDSYSTEM_TESTING:BOOL=True
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
@@ -4,6 +4,6 @@ set VCS_DIRECTORY=gz-cmake
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set EXTRA_CMAKE_TEST_ARGS=-DBUILDSYSTEM_TESTING:BOOL=True
+set COLCON_EXTRA_CMAKE_ARGS=-DBUILDSYSTEM_TESTING:BOOL=True
 
-call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"
+call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
@@ -4,6 +4,9 @@ set VCS_DIRECTORY=gz-cmake
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
+:: This needs to be migrated to DSL to get multi-major versions correctly
+set COLCON_PACKAGE=gz-cmake
+set COLCON_AUTO_MAJOR_VERSION=true
 set COLCON_EXTRA_CMAKE_ARGS=-DBUILDSYSTEM_TESTING:BOOL=True
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -5,6 +5,7 @@
 ::   - GAZEBODISTRO_FILE : (optional) vcs yaml file in the gazebodistro repository
 ::   - COLCON_PACKAGE : package name to test in colcon ws
 ::   - COLCON_AUTO_MAJOR_VERSION (default false): auto detect major version from CMakeLists
+::   - COLCON_PACKAGE_EXTRA_CMAKE_ARGS : (optional) CMake arg to inject into colcon
 ::   - BUILD_TYPE     : (default Release) [ Release | Debug ] Build type to use
 ::   - DEPEN_PKGS     : (optional) list of dependencies (separted by spaces)
 ::   - KEEP_WORKSPACE : (optional) true | false. Clean workspace at the end
@@ -123,7 +124,7 @@ if exist %LOCAL_WS_SOFTWARE_DIR%\configure.bat (
 
 echo # BEGIN SECTION: compiling %VCS_DIRECTORY%
 cd %LOCAL_WS%
-call %win_lib% :build_workspace !COLCON_PACKAGE! || goto :error
+call %win_lib% :build_workspace !COLCON_PACKAGE! !COLCON_PACKAGE_EXTRA_CMAKE_ARGS! || goto :error
 echo # END SECTION
 
 if "%ENABLE_TESTS%" == "TRUE" (

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -221,7 +221,7 @@ echo # BEGIN SECTION: colcon compilation without test for dependencies of !COLCO
 call :_colcon_build_cmd --packages-skip !COLCON_PACKAGE! "-DBUILD_TESTING=0" "-DCMAKE_CXX_FLAGS=-w"
 echo # END SECTION
 echo # BEGIN SECTION: colcon compilation with tests for !COLCON_PACKAGE!
-call :_colcon_build_cmd --packages-select !COLCON_PACKAGE! " %COLCON_EXTRA_CMAKE_ARGS%" " -DBUILD_TESTING=1"
+call :_colcon_build_cmd --packages-select !COLCON_PACKAGE! !COLCON_EXTRA_CMAKE_ARGS! " -DBUILD_TESTING=1"
 echo # END SECTION
 goto :EOF
 

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -206,9 +206,11 @@ goto :EOF
 :: Build all the workspaces packages except the package provided in arg1
 ::
 :: arg1: name of the colcon package excluded from building
+:: arg2: extra cmake parameter to pass to the target package COLCON_PACKAGE
 :build_workspace
 
 set COLCON_PACKAGE=%1
+set _COLCON_EXTRA_CMAKE_ARGS=%2
 
 :: Check if package is in colcon workspace
 echo # BEGIN SECTION Packages in workspace:
@@ -221,7 +223,7 @@ echo # BEGIN SECTION: colcon compilation without test for dependencies of !COLCO
 call :_colcon_build_cmd --packages-skip !COLCON_PACKAGE! "-DBUILD_TESTING=0" "-DCMAKE_CXX_FLAGS=-w"
 echo # END SECTION
 echo # BEGIN SECTION: colcon compilation with tests for !COLCON_PACKAGE!
-call :_colcon_build_cmd --packages-select !COLCON_PACKAGE! !COLCON_EXTRA_CMAKE_ARGS! " -DBUILD_TESTING=1"
+call :_colcon_build_cmd --packages-select !COLCON_PACKAGE! %_COLCON_EXTRA_CMAKE_ARGS% " -DBUILD_TESTING=1"
 echo # END SECTION
 goto :EOF
 

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -221,7 +221,7 @@ echo # BEGIN SECTION: colcon compilation without test for dependencies of !COLCO
 call :_colcon_build_cmd --packages-skip !COLCON_PACKAGE! "-DBUILD_TESTING=0" "-DCMAKE_CXX_FLAGS=-w"
 echo # END SECTION
 echo # BEGIN SECTION: colcon compilation with tests for !COLCON_PACKAGE!
-call :_colcon_build_cmd --packages-select !COLCON_PACKAGE! " -DBUILD_TESTING=1"
+call :_colcon_build_cmd --packages-select !COLCON_PACKAGE! " %COLCON_EXTRA_CMAKE_ARGS%" " -DBUILD_TESTING=1"
 echo # END SECTION
 goto :EOF
 


### PR DESCRIPTION
This is the last gz- of #412. ign-cmake was a bit special since it adds a CMake parameters to the compilation thus I needed to implement that parameter passing in the form of `_COLCON_EXTRA_CMAKE_ARGS`.

If we want to keep the history of the CI jobs, we can rename them before we merge this PR. //cc @Blast545. This also affects t https://github.com/osrf/buildfarmer/pull/338.

Test:

 * New ign_cmake-ci-win [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_cmake-ci-win&build=9)](https://build.osrfoundation.org/job/ign_cmake-ci-win/9/)
 * No use of cmake argument ign-plugin [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_plugin-ci-win&build=31)](https://build.osrfoundation.org/job/ign_plugin-ci-win/31/)