### PR TITLE
Use short names for Windows sdformat DSL jobs

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -118,6 +118,7 @@ gz_collection_jobs =
         'sdformat-ci-sdformat9-homebrew-amd64',
         'sdformat-ci-sdformat9-windows7-amd64',
         'sdformat-install-sdformat9_pkg-focal-amd64'
+        'sdformat-sdf9-win'
   ],
   'fortress' : [
         'ign_common-ign-4-win',
@@ -200,8 +201,8 @@ gz_collection_jobs =
         'ignition_utils1-install_bottle-homebrew-amd64',
         'sdformat-ci-sdformat12-focal-amd64',
         'sdformat-ci-sdformat12-homebrew-amd64',
-        'sdformat-ci-sdformat12-windows7-amd64',
-        'sdformat-install-sdformat12_pkg-focal-amd64'
+        'sdformat-install-sdformat12_pkg-focal-amd64',
+        'sdformat-sdf12-win.xml'
   ],
   'garden' : [
         'ign_common-gz-5-win',
@@ -284,8 +285,8 @@ gz_collection_jobs =
         'ignition_utils1-install_bottle-homebrew-amd64',
         'sdformat-ci-sdformat13-focal-amd64',
         'sdformat-ci-sdformat13-homebrew-amd64',
-        'sdformat-ci-sdformat13-windows7-amd64',
-        'sdformat-install-sdformat12_pkg-focal-amd64'
+        'sdformat-install-sdformat12_pkg-focal-amd64',
+        'sdformat-sdf13-win'
   ],
 ]
 

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -118,7 +118,7 @@ gz_collection_jobs =
         'sdformat-ci-sdformat9-homebrew-amd64',
         'sdformat-ci-sdformat9-windows7-amd64',
         'sdformat-install-sdformat9_pkg-focal-amd64',
-        'sdformat-sdf9-win'
+        'sdformat-sdf-9-win'
   ],
   'fortress' : [
         'ign_common-ign-4-win',
@@ -202,7 +202,7 @@ gz_collection_jobs =
         'sdformat-ci-sdformat12-focal-amd64',
         'sdformat-ci-sdformat12-homebrew-amd64',
         'sdformat-install-sdformat12_pkg-focal-amd64',
-        'sdformat-sdf12-win.xml'
+        'sdformat-sdf-12-win.xml'
   ],
   'garden' : [
         'ign_common-gz-5-win',
@@ -286,7 +286,7 @@ gz_collection_jobs =
         'sdformat-ci-sdformat13-focal-amd64',
         'sdformat-ci-sdformat13-homebrew-amd64',
         'sdformat-install-sdformat12_pkg-focal-amd64',
-        'sdformat-sdf13-win'
+        'sdformat-sdf-13-win'
   ],
 ]
 

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -117,7 +117,7 @@ gz_collection_jobs =
         'sdformat-ci-sdformat9-focal-amd64',
         'sdformat-ci-sdformat9-homebrew-amd64',
         'sdformat-ci-sdformat9-windows7-amd64',
-        'sdformat-install-sdformat9_pkg-focal-amd64'
+        'sdformat-install-sdformat9_pkg-focal-amd64',
         'sdformat-sdf9-win'
   ],
   'fortress' : [

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -369,8 +369,9 @@ sdformat_supported_versions.each { version ->
 // 2. main / @ SCM/Daily
 all_versions = sdformat_supported_versions + 'main'
 all_versions.each { version ->
-  // Use replace to get branch names to sync with ignition packages
-  def sdformat_win_ci_job = job("sdformat-" + version.replace('sdformat', 'sdf') + "-win")
+  // Use replace to get branch names to sync with ignition packages and the
+  // format of $branch-$version
+  def sdformat_win_ci_job = job("sdformat-" + version.replace('sdformat', 'sdf-') + "-win")
   OSRFWinCompilation.create(sdformat_win_ci_job)
   OSRFGitHub.create(sdformat_win_ci_job, "gazebosim/sdformat",
                     get_sdformat_branch_name(version))

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -371,7 +371,7 @@ all_versions = sdformat_supported_versions + 'main'
 all_versions.each { version ->
   // Use replace to get branch names to sync with ignition packages and the
   // format of $branch-$version
-  def sdformat_win_ci_job = job("sdformat-" + version.replace('sdformat', 'sdf-') + "-win")
+  def sdformat_win_ci_job = job("sdformat-sdf-" + version.replace('sdformat','') + "-win")
   OSRFWinCompilation.create(sdformat_win_ci_job)
   OSRFGitHub.create(sdformat_win_ci_job, "gazebosim/sdformat",
                     get_sdformat_branch_name(version))

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -353,7 +353,7 @@ sdformat_supported_versions.each { version ->
 // WINDOWS: CI job
 
 // 1. any
-  String ci_build_any_job_name_win7 = "sdformat-ci-pr_any-windows7-amd64"
+  String ci_build_any_job_name_win7 = "sdformat-pr-win"
   def sdformat_win_ci_any_job = job(ci_build_any_job_name_win7)
   OSRFWinCompilationAnyGitHub.create(sdformat_win_ci_any_job,
                                 "gazebosim/sdformat")
@@ -369,7 +369,8 @@ sdformat_supported_versions.each { version ->
 // 2. main / @ SCM/Daily
 all_versions = sdformat_supported_versions + 'main'
 all_versions.each { version ->
-  def sdformat_win_ci_job = job("sdformat-ci-${version}-windows7-amd64")
+  // Use replace to get branch names to sync with ignition packages
+  def sdformat_win_ci_job = job("sdformat-" + version.replace('sdformat', 'sdf') + "-win")
   OSRFWinCompilation.create(sdformat_win_ci_job)
   OSRFGitHub.create(sdformat_win_ci_job, "gazebosim/sdformat",
                     get_sdformat_branch_name(version))


### PR DESCRIPTION
To get consistency in the naming scheme I would like to change sdformat Windows names to use the same format the the ones using colcon in ignition.dsl. The format is: 
 * Branch CI: `$software_name-$branch_unversioned-$version-win`
 * Any PR testing: `$software_name-pr-win`
 * Main branch CI: `$software_name-ci-win`

This will follow up #812 to get the whole family of Windows jobs with a consistent name scheme, if I'm not wrong.

This also affects https://github.com/osrf/buildfarmer/pull/338. To keep history, we should rename the jobs before merging //cc @Blast545 