### PR TITLE
Fix bug for node labels in gz-physics when using release.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -641,7 +641,8 @@ def go(argv):
                     # Need to use JENKINS_NODE_TAG parameter for large memory nodes
                     # since it runs qemu emulation
                     linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a
-                elif ('ignition-physics' in args.package_alias):
+                elif ('ignition-physics' in args.package_alias) or \
+                     ('gz-physics' in args.package_alias):
                     linux_platform_params['JENKINS_NODE_TAG'] = 'large-memory'
 
                 if (NIGHTLY and a == 'i386'):


### PR DESCRIPTION
Completing #799.

release.py should handle the gz-physics in the same way it did with ignition-physics to setup the right label for powerful nodes in the buildfarm.