### PR TITLE
release.py: fix tarball name for fuel_tools

### DIFF
--- a/release.py
+++ b/release.py
@@ -438,6 +438,8 @@ def create_tarball_path(tarball_name, version, builddir, dry_run):
         if (not dry_run):
             if not os.path.isfile(alt_tarball_path):
                 error("Can not find a tarball at: " + tarball_path + " or at " + alt_tarball_path)
+            else:
+                tarball_fname = alt_tarball_fname
         tarball_path = alt_tarball_path
 
     out, err = check_call(['shasum', '--algorithm', '256', tarball_path])


### PR DESCRIPTION
For `gz-fuel-tools8`, the name of the tarball sent to Jenkins is not matching the tarball actual uploaded to s3. For example, the tarball URI in https://github.com/osrf/homebrew-simulation/pull/2027 is:

* https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel-tools-8.0.0~pre1.tar.bz2

but that file does not exist. The actual uploaded tarball has `fuel_tools` instead of `fuel-tools`:

* https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-8.0.0~pre1.tar.bz2

I believe the issue is that the `tarball_fname` variable returned from `create_tarball_path` was not updated when trying a new tarball file name. I think this fixes it.