### PR TITLE
Fixes for DSL related to gz transition: sim7 support, gpu for sim jobs

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -21,6 +21,7 @@ gz_software = [ 'cmake',
 gz_gpu                = [ 'gazebo',
                           'gui',
                           'rendering',
+                          'sim',
                           'sensors' ]
 // DESC: software does not support cmake warnings enabled
 gz_no_cmake_warnings = [ 'cmake',
@@ -81,8 +82,7 @@ gz_prerelease_branches = []
 // DESC: versioned names to generate debbuild jobs for special cases that
 // don't appear in gz_branches (like nightly builders or 0-debbuild
 // jobs for the special cases of foo0 packages)
-gz_extra_debbuild = [ 'gazebo7',
-                      'utils1' ] // see comment https://github.com/gazebo-tooling/release-tools/pull/431#issuecomment-815099918
+gz_extra_debbuild = [ 'utils1' ] // see comment https://github.com/gazebo-tooling/release-tools/pull/431#issuecomment-815099918
 // DESC: exclude ignition from generate any install testing job
 gz_no_pkg_yet         = [  ]
 // DESC: major versions that has a package in the prerelease repo. Should
@@ -201,17 +201,19 @@ ArrayList all_branches(String software_name)
       branches.add("ign-${software_name}${major_version}")
     }
   }
+  prerelease_branches("${software_name}").each { branch ->
+    if ("${branch}") {
+      branches.add(branch)
+    }
+  }
+  if (software_name == 'gazebo')
+    software_name = 'sim'
   supported_gz_branches("${software_name}").each { major_version ->
     if ("${major_version}") {
       branches.add("gz-${software_name}${major_version}")
     }
   }
   branches.add('main')
-  prerelease_branches("${software_name}").each { branch ->
-    if ("${branch}") {
-      branches.add(branch)
-    }
-  }
   return branches
 }
 


### PR DESCRIPTION
- Stop using gazebo7 extra builder. 
- Add 'sim' to the support list of packages for GPU
- Fix all_branches to take into account 'sim' and not 'gazebo'