### PR TITLE
changelog script: improve tag/branch detection

### DIFF
--- a/source-repo-scripts/source_changelog.bash
+++ b/source-repo-scripts/source_changelog.bash
@@ -1,23 +1,17 @@
 #!/bin/bash
 # bash source_changelog.bash <PREV_VER>
 
-PREV_TAG=$1
+PREV_VER=$1
 
 git fetch --tags
 
-REPO=$(basename `git rev-parse --show-toplevel`)
-REPO="${REPO/ign-/gz-}"
-MAJOR=${PREV_TAG%.*.*}
-BRANCH=${REPO/sdformat/sdf}${MAJOR}
-TAG="${REPO}${MAJOR}"
+# Find tag that ends with _$PREV_VER
+PREV_TAG=$(git tag | grep "_${PREV_VER}$")
 
-# TODO(chapulina) Support Garden tags and branches, which will start with gz-
-TAG="${TAG/gz-/ignition-}"
-TAG="${TAG/sim/gazebo}"
-BRANCH="${BRANCH/gz-/ign-}"
-BRANCH="${BRANCH/sim/gazebo}"
+# Compare current branch to PREV_TAG
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-COMMITS=$(git log ${BRANCH}...${TAG}_${PREV_TAG}  --pretty=format:"%h")
+COMMITS=$(git log ${BRANCH}...${PREV_TAG}  --pretty=format:"%h")
 
 for COMMIT in $COMMITS
 do

--- a/source-repo-scripts/source_changelog.bash
+++ b/source-repo-scripts/source_changelog.bash
@@ -5,6 +5,8 @@ PREV_VER=$1
 
 git fetch --tags
 
+REPO=$(basename $(git remote get-url origin))
+
 # Find tag that ends with _$PREV_VER
 PREV_TAG=$(git tag | grep "_${PREV_VER}$")
 

--- a/source-repo-scripts/source_changelog.bash
+++ b/source-repo-scripts/source_changelog.bash
@@ -5,7 +5,8 @@ PREV_VER=$1
 
 git fetch --tags
 
-REPO=$(basename $(git remote get-url origin))
+ORIGIN_URL=$(git remote get-url origin)
+REPO=$(basename ${ORIGIN_URL%.git})
 
 # Find tag that ends with _$PREV_VER
 PREV_TAG=$(git tag | grep "_${PREV_VER}$")


### PR DESCRIPTION
Currently the source_changelog.bash script only works for ignition-* tags, while garden will use gz-* tags. This updates the script to grep for a tag that ends with the specified version number. It also uses the current branch for the comparison to avoid assumptions about ign-* or gz-* branch names.

I needed to make these changes in order to generate gz-garden changelogs:

~~~
cd gz-cmake
git checkout gz-cmake3
../release-tools/source-repo-scripts/source_changelog.bash 2.15.0
~~~