### PR TITLE
Ignore ALSA lib false positive in warnings inside Jenkins

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilation.groovy
@@ -77,7 +77,11 @@ class OSRFLinuxCompilation extends OSRFLinuxBase
               minimumSeverity {
                 name('LOW')
               }
-              filters { }
+              filters {
+                'io.jenkins.plugins.analysis.core.filter.ExcludeFile' {
+                  pattern('.*ALSA lib.*')
+                }
+              }
               isEnabledForFailure(false)
               isAggregatingResults(false)
               isBlameDisabled(false)


### PR DESCRIPTION
Should fix #814 

Tested [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros2_gazebo_pkgs-ci-default_rolling-jammy-amd64&build=22)](https://build.osrfoundation.org/job/ros2_gazebo_pkgs-ci-default_rolling-jammy-amd64/22/)