### PR TITLE
Test gz-tools subcommands expected when installing gz- metapackages

### DIFF
--- a/jenkins-scripts/docker/ign_launch-install-test-job.bash
+++ b/jenkins-scripts/docker/ign_launch-install-test-job.bash
@@ -10,6 +10,8 @@ export GPU_SUPPORT_NEEDED=true
 . ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 
 INSTALL_JOB_POSTINSTALL_HOOK="""
+GZ_SIM_RUNTIME_TEST_USE_IGN=${GZ_SIM_RUNTIME_TEST_USE_IGN:-false}
+
 ${GZ_SIM_RUNTIME_TEST}
 """
 # Need bc to proper testing and parsing the time

--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -24,9 +24,26 @@ tar -xf /tmp/master.tar.gz -C ~/.gazebo/models --strip 1 >/dev/null 2>&1
 rm /tmp/master.tar.gz"""
 
 GZ_SIM_RUNTIME_TEST="""
+if \${GZ_SIM_RUNTIME_TEST_USE_IGN}; then
+  CMD_TOOLS='ign'
+  CMD_TOOLS_SIMULATOR='ign gazebo -v'
+  CMD_TOOLS_MODULES='gui fuel topic service gazebo sdf model launch plugin msg log'
+else
+  CMD_TOOLS='gz'
+  CMD_TOOLS_SIMULATOR='gz sim --verbose 4'
+  CMD_TOOLS_MODULES='gui fuel topic service sim sdf model launch plugin msg log'
+fi
+
+echo '# BEGIN SECTION: check gz subcommands available'
+  for module in \${CMD_TOOLS_MODULES}; do
+    echo \"Testing \${module}\"
+    \${CMD_TOOLS} \${module} --versions
+  done
+echo '# END SECTION'
+
 echo '# BEGIN SECTION: test the script'
 TEST_START=\`date +%s\`
-timeout --preserve-status 180 ign gazebo -v -r camera_sensor.sdf || true
+timeout --preserve-status 180 \${CMD_TOOLS_SIMULATOR} -r camera_sensor.sdf || true
 TEST_END=\`date +%s\`
 DIFF=\`echo \"\$TEST_END - \$TEST_START\" | bc\`
 
@@ -34,6 +51,7 @@ if [ \$DIFF -lt 180 ]; then
    echo 'The test took less than 180s. Something bad happened'
    exit 1
 fi
+
 echo '# END SECTION'
 """
 

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -332,6 +332,9 @@ void generate_install_job(prefix, gz_collection_name, distro, arch)
            export ARCH=${arch}
            export INSTALL_JOB_PKG=${dev_package}
            export GZDEV_PROJECT_NAME="${dev_package}"
+           if [[ ${gz_collection_name} == 'citadel' || ${gz_collection_name} == 'fortress' ]]; then
+              export GZ_SIM_RUNTIME_TEST_USE_IGN=true
+           fi
            /bin/bash -x ./scripts/jenkins-scripts/docker/${job_name}
            """.stripIndent())
     }


### PR DESCRIPTION
Extend the CI done in `gz-collection` metapackages to check that `gz-tools` submodules are all installed by default.

* Current problems in Garden detected: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_garden-install-pkg-focal-amd64&build=11)](https://build.osrfoundation.org/job/gz_garden-install-pkg-focal-amd64/11/)
* Citadel run: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_citadel-install-pkg-bionic-amd64&build=13)](https://build.osrfoundation.org/job/gz_citadel-install-pkg-bionic-amd64/13/)

This should help to detect problems related to #830 and https://github.com/gazebosim/gz-tools/issues/111