### PR TITLE
Fix terminal-dashboard to avoid confusions with arch=all packages

### DIFF
--- a/terminal-dashboard/table.bash
+++ b/terminal-dashboard/table.bash
@@ -32,12 +32,24 @@ ARCHS=( "amd64")
 DISTROS=( "ubuntu" )
 # No nightlies or pre-releases for arm
 if [[ $PACKAGE_REPO == "stable" ]]; then
-  ARCHS+=( "i386" "arm64" "armhf")
+  if [[ $COLLECTION == "citadel" || $COLLECTION == "fortress" ]]; then
+    ARCHS+=( "i386" )
+  fi
+
+  ARCHS+=( "arm64" "armhf")
   # No debian version supported across the stack right now
   # DISTROS+=( "debian" )
 fi
 
 for LIB in $(get_libraries_by_collection "${COLLECTION}" ); do
+  # We are assuming that all the gz- libraries have a package named libgz-${LIB}
+  # except for the collection packages starting with Garden. Note that relying
+  # on the fact of having a packages available in a given arch does not imply
+  # that build is successful since arch=all debs are built once for amd64 and
+  # appear in all the arches.
+  if [[ "${LIB}" != "gz-${COLLECTION}" && "${LIB}" != "ignition-${COLLECTION}" ]]; then
+    LIB=lib${LIB}
+  fi
   echo -e "\e[107m\e[90m${LIB}\e[49m\e[39m"
 
   LIB_VER=""

--- a/terminal-dashboard/table.bash
+++ b/terminal-dashboard/table.bash
@@ -49,7 +49,7 @@ fi
 # once for amd64 and appear in all the arches.
 # The Source field (for source packages) is not mandatory and it is probably
 # not present when the binary package has the same name than the source
-# package so here we are assuming.
+# package.
 for LIB in $(get_libraries_by_collection "${COLLECTION}" ); do
   if [[ "${LIB}" != "gz-${COLLECTION}" && "${LIB}" != "ignition-${COLLECTION}" ]]; then
     LIB=lib${LIB}

--- a/terminal-dashboard/table.bash
+++ b/terminal-dashboard/table.bash
@@ -41,12 +41,16 @@ if [[ $PACKAGE_REPO == "stable" ]]; then
   # DISTROS+=( "debian" )
 fi
 
+# Search heuristics used and context:
+# We are assuming that all the gz- libraries have a package named libgz${LIB} or
+# libgz${LIB}-dev except for the collection packages starting with Garden.
+# Note that relying on the fact of having a packages available in a given
+# arch does not imply that build is successful since arch=all debs are built
+# once for amd64 and appear in all the arches.
+# The Source field (for source packages) is not mandatory and it is probably
+# not present when the binary package has the same name than the source
+# package so here we are assuming.
 for LIB in $(get_libraries_by_collection "${COLLECTION}" ); do
-  # We are assuming that all the gz- libraries have a package named libgz-${LIB}
-  # except for the collection packages starting with Garden. Note that relying
-  # on the fact of having a packages available in a given arch does not imply
-  # that build is successful since arch=all debs are built once for amd64 and
-  # appear in all the arches.
   if [[ "${LIB}" != "gz-${COLLECTION}" && "${LIB}" != "ignition-${COLLECTION}" ]]; then
     LIB=lib${LIB}
   fi
@@ -82,10 +86,8 @@ for LIB in $(get_libraries_by_collection "${COLLECTION}" ); do
         if [[ $ARCH == "i386" && $VER != "bionic" && $VER != "buster" ]]; then
           PKG_VERSION="disabled"
         else
-          # The Source field is not mandatory and it is probably not present when
-          # the binary package has the same name than the source package
           PKG_VERSION=$(wget -qO- http://packages.osrfoundation.org/gazebo/${DISTRO}-${PACKAGE_REPO}/dists/${VER}/main/binary-${ARCH}/Packages | \
-            grep -2 -m 1 -e "Source: ${LIB}" -e "Package: ${LIB}" | \
+            grep -2 -m 1 -e "Package: ${LIB}$" -e "Package: ${LIB}-dev$"| \
             sed -n 's/^Version: \(.*\)/\1/p' | uniq)
         fi
 


### PR DESCRIPTION
The PR changes the approach used in the terminal dashboard since it is broken after the inclusion of the `ignition-*` transitional packages that arch-independent. When they are built for one arch, they appear in all the arches so the terminal dashboard wrongly assumes that there were packages built for the rest of arches.

New approach assumes that all the gz- libraries have a package named libgz-${LIB} except for the collection packages. This is now valid but somehow fragile. Real solution would imply a real parsing and add logic which is quite an effort much bigger.

PR also takes i386 out from new collections starting with Debian.