### PR TITLE
dsl: disable ignition_garden-install-* jobs

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -360,7 +360,9 @@ gz_collections.each { gz_collection ->
   gz_collection.get('distros').each { distro ->
     // INSTALL JOBS:
     // --------------------------------------------------------------
-    generate_install_job('ignition', gz_collection_name, distro, arch)
+    if ((gz_collection_name == "citadel") || (gz_collection_name == "fortress")) {
+      generate_install_job('ignition', gz_collection_name, distro, arch)
+    }
     generate_install_job('gz', gz_collection_name, distro, arch)
   }
 


### PR DESCRIPTION
There is no stable release of an ignition-garden debian package, so don't create a CI job for it.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_garden-install-pkg-focal-amd64&build=101)](https://build.osrfoundation.org/job/ignition_garden-install-pkg-focal-amd64/101/) https://build.osrfoundation.org/job/ignition_garden-install-pkg-focal-amd64/101/