### PR TITLE
asan dsl: skip _gz_TEST tests also

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -13,7 +13,9 @@ class Globals
    static CRON_EVERY_THREE_DAYS = 'H H * * H/3'
    static CRON_ON_WEEKEND = 'H H * * 6-7'
 
-   static MAKETEST_SKIP_GZ = "-E _gz_TEST -E _ign_TEST"
+   // Only one -E regex can be passed, so make a regex that matches both
+   // _ign_TEST and _gz_TEST
+   static MAKETEST_SKIP_GZ = "-E _i?g[nz]_TEST"
 
    static gpu_by_distro  = [ bionic  : [ 'nvidia' ]]
 

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -13,7 +13,7 @@ class Globals
    static CRON_EVERY_THREE_DAYS = 'H H * * H/3'
    static CRON_ON_WEEKEND = 'H H * * 6-7'
 
-   static MAKETEST_SKIP_IGN = "-E _ign_TEST"
+   static MAKETEST_SKIP_GZ = "-E _gz_TEST -E _ign_TEST"
 
    static gpu_by_distro  = [ bionic  : [ 'nvidia' ]]
 

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -487,7 +487,7 @@ void generate_asan_ci_job(gz_ci_job, gz_sw, branch, distro, arch)
 {
   generate_ci_job(gz_ci_job, gz_sw, branch, distro, arch,
                   '-DGZ_SANITIZER=Address',
-                  Globals.MAKETEST_SKIP_IGN)
+                  Globals.MAKETEST_SKIP_GZ)
 }
 
 void generate_ci_job(gz_ci_job, gz_sw, branch, distro, arch,

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -140,7 +140,7 @@ void generate_asan_ci_job(sdformat_ci_job, version, distro, arch)
 {
   generate_ci_job(sdformat_ci_job, version, distro, arch,
                   '-DGZ_SANITIZER=Address',
-                  Globals.MAKETEST_SKIP_IGN)
+                  Globals.MAKETEST_SKIP_GZ)
 }
 
 void generate_ci_job(sdformat_ci_job, version, distro, arch,


### PR DESCRIPTION
The _ign_TEST CLI tests are skipped for asan due to an LD_PRELOAD error, but the _gz_TESTs on garden
should be skipped as well.

Currently passes in fortress:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci_asan-sdformat12-focal-amd64&build=21)](https://build.osrfoundation.org/view/asan/job/sdformat-ci_asan-sdformat12-focal-amd64/21/) https://build.osrfoundation.org/view/asan/job/sdformat-ci_asan-sdformat12-focal-amd64/21/

Unstable in garden:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci_asan-sdformat13-focal-amd64&build=8)](https://build.osrfoundation.org/view/asan/job/sdformat-ci_asan-sdformat13-focal-amd64/8/) https://build.osrfoundation.org/view/asan/job/sdformat-ci_asan-sdformat13-focal-amd64/8/

~~~
119: [ RUN      ] inertial_stats.SDF
119: /home/jenkins/workspace/sdformat-ci_asan-sdformat13-focal-amd64/sdformat/src/gz_TEST.cc:1889: Failure
119: Expected equality of these values:
119:   expectedOutput
119:     Which is: "Inertial statistics for model: test_model\n---\nTotal mass of the model: 24\n---\nCentre of mass in model frame: \nX: 0\nY: 0\nZ: 0\n---\nMoment of inertia matrix: \n304  0    0    \n0    304  0    \n0    0    604  \n---\n"
119:   output
119:     Which is: "==6573==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.\n"
119: With diff:
119: @@ -1,14 +1,1 @@
119: -Inertial statistics for model: test_model
119: ----
119: -Total mass of the model: 24
119: ----
119: -Centre of mass in model frame: 
119: -X: 0
119: -Y: 0
119: -Z: 0
119: ----
119: -Moment of inertia matrix: 
119: -304  0    0    
119: -0    304  0    
119: -0    0    604  
119: ----\n
119: +==6573==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.\n
...
119: /home/jenkins/workspace/sdformat-ci_asan-sdformat13-focal-amd64/sdformat/src/gz_TEST.cc:1942: Failure
119: Expected equality of these values:
119:   expectedOutput
119:     Which is: "Error: Expected a model file but received a world file.\n"
119:   output
119:     Which is: "==6579==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.\n"
119: [  FAILED  ] inertial_stats.SDF (297 ms)
~~~