### PR TITLE
brew CI: use python3 explicitly

### DIFF
--- a/jenkins-scripts/gazebo-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/gazebo-default-devel-homebrew-amd64.bash
@@ -6,7 +6,7 @@ SCRIPT_DIR="${SCRIPT_DIR%/*}"
 
 # Identify GAZEBO_MAJOR_VERSION to help with dependency resolution
 GAZEBO_MAJOR_VERSION=$(\
-  python ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
+  python3 ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
   ${WORKSPACE}/gazebo/CMakeLists.txt)
 
 if [ $GAZEBO_MAJOR_VERSION -ge 7 ]; then

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -27,7 +27,7 @@ PROJECT_PATH=${PROJECT_PATH/ign-sim/ign-gazebo}
 # Check for major version number
 # the PROJECT_FORMULA variable is only used for dependency resolution
 PROJECT_FORMULA=${PROJECT//[0-9]}$(\
-  python ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
+  python3 ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
   ${WORKSPACE}/${PROJECT_PATH}/CMakeLists.txt || true)
 
 export HOMEBREW_PREFIX=/usr/local


### PR DESCRIPTION
When testing a new Mac mini in build.osrfoundation.org, we found that python 2.X is no longer available in macOS Monterey in `/usr/bin/python`. This is fine, we should be using `python3` explicitly anyway.

## Failure with current `master` branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_cmake-ci-gz-cmake3-homebrew-amd64&build=1)](https://build.osrfoundation.org/job/_test_ignition_cmake-ci-gz-cmake3-homebrew-amd64/1/) https://build.osrfoundation.org/job/_test_ignition_cmake-ci-gz-cmake3-homebrew-amd64/1/

~~~
++ python ./scripts/jenkins-scripts/tools/detect_cmake_major_version.py /Users/jenkins/workspace/_test_ignition_cmake-ci-gz-cmake3-homebrew-amd64/ign-cmake/CMakeLists.txt
./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash: line 31: python: command not found
++ true
+ PROJECT_FORMULA=gz-cmake
~~~

## Testing with this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_cmake-ci-gz-cmake3-homebrew-amd64&build=2)](https://build.osrfoundation.org/job/_test_ignition_cmake-ci-gz-cmake3-homebrew-amd64/2/) https://build.osrfoundation.org/job/_test_ignition_cmake-ci-gz-cmake3-homebrew-amd64/2/

~~~
++ python3 ./scripts/jenkins-scripts/tools/detect_cmake_major_version.py /Users/jenkins/workspace/_test_ignition_cmake-ci-gz-cmake3-homebrew-amd64/ign-cmake/CMakeLists.txt
+ PROJECT_FORMULA=gz-cmake3
~~~