### PR TITLE
brew_release.dsl: build monterey bottles

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Job
 Globals.default_emails = "jrivero@osrfoundation.org, scpeters@osrfoundation.org"
 
 // first distro in list is used as touchstone
-brew_supported_distros         = [ "catalina", "bigsur" ]
+brew_supported_distros         = [ "catalina", "bigsur", "monterey" ]
 bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_updater'
 bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'


### PR DESCRIPTION
We now have a Mac mini running macOS Monterey, so let's build some bottles.

Testing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_brew_release&build=741)](https://build.osrfoundation.org/job/_dsl_brew_release/741/) https://build.osrfoundation.org/job/_dsl_brew_release/741/
* https://github.com/osrf/homebrew-simulation/pull/2081#issuecomment-1275584239
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder&build=995)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/995/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/995/