### PR TITLE
Fix gazebo-classic folder name and clean up

### DIFF
--- a/jenkins-scripts/docker/gazebo-abichecker.bash
+++ b/jenkins-scripts/docker/gazebo-abichecker.bash
@@ -19,9 +19,6 @@ fi
 export ABI_JOB_SOFTWARE_NAME="gazebo"
 export ABI_JOB_REPOS="stable"
 export ABI_JOB_PKG_DEPENDENCIES_VAR_NAME="GAZEBO_BASE_DEPENDENCIES"
-if [[ $GAZEBO_MAJOR_VERSION -lt 8 ]]; then
-  export ABI_JOB_CMAKE_PARAMS="-DENABLE_TESTS_COMPILATION:BOOL=False"
-fi
 export ABI_JOB_IGNORE_HEADERS="gazebo/GIMPACT gazebo/opcode gazebo/test"
 
 . ${SCRIPT_DIR}/lib/generic-abi-base.bash

--- a/jenkins-scripts/docker/lib/_gazebo_version_hook.bash
+++ b/jenkins-scripts/docker/lib/_gazebo_version_hook.bash
@@ -1,7 +1,7 @@
 # Identify GAZEBO_MAJOR_VERSION to help with dependency resolution
 GAZEBO_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/gazebo/CMakeLists.txt)
+  ${WORKSPACE}/gazebo-classic/CMakeLists.txt)
 
 # Check gazebo version is integer
 if ! [[ ${GAZEBO_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/lib/_gazebo_version_hook.bash
+++ b/jenkins-scripts/docker/lib/_gazebo_version_hook.bash
@@ -1,12 +1,7 @@
 # Identify GAZEBO_MAJOR_VERSION to help with dependency resolution
-if [ "${GAZEBO_EXPERIMENTAL_BUILD}" = true ]; then
-  # Identify GAZEBO_MAJOR_VERSION to help with dependency resolution
-  GAZEBO_MAJOR_VERSION=0
-else
-  GAZEBO_MAJOR_VERSION=$(\
-    python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-    ${WORKSPACE}/gazebo/CMakeLists.txt)
-fi
+GAZEBO_MAJOR_VERSION=$(\
+  python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
+  ${WORKSPACE}/gazebo/CMakeLists.txt)
 
 # Check gazebo version is integer
 if ! [[ ${GAZEBO_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/lib/gazebo-base-default.bash
+++ b/jenkins-scripts/docker/lib/gazebo-base-default.bash
@@ -44,7 +44,7 @@ if ${COVERAGE_ENABLED} ; then
   EXTRA_PACKAGES="${EXTRA_PACKAGES} wget"
 fi
 
-SOFTWARE_DIR="gazebo"
+SOFTWARE_DIR="gazebo-classic"
 
 cat > build.sh << DELIM_DART
 ###################################################
@@ -79,8 +79,8 @@ if ${COVERAGE_ENABLED} ; then
   set -x # back to debug
   # Set up Bullseyes for compiling
   export PATH=/usr/bullseyes/bin:\$PATH
-  export COVFILE=$WORKSPACE/gazebo/test.cov
-  cd $WORKSPACE/gazebo
+  export COVFILE=$WORKSPACE/${SOFTWARE_DIR}/test.cov
+  cd $WORKSPACE/${SOFTWARE_DIR}
   covselect --file test.cov --add .
   cov01 --on
   echo '# END SECTION'
@@ -205,7 +205,7 @@ if ${COVERAGE_ENABLED} ; then
   rm -fr $WORKSPACE/bullshtml
   mkdir -p $WORKSPACE/coverage
   covselect --add '!$WORKSPACE/build/' '!../build/' '!test/' '!tools/test/' '!deps/' '!/opt/' '!gazebo/rendering/skyx/' '!/tmp/'
-  covhtml --srcdir $WORKSPACE/gazebo/ $WORKSPACE/coverage
+  covhtml --srcdir $WORKSPACE/${SOFTWARE_DIR}/ $WORKSPACE/coverage
   # Generate valid cover.xml file using the bullshtml software
   # java is needed to run bullshtml
   apt-get install -y default-jre

--- a/jenkins-scripts/docker/lib/gazebo-base-default.bash
+++ b/jenkins-scripts/docker/lib/gazebo-base-default.bash
@@ -44,10 +44,6 @@ if ${COVERAGE_ENABLED} ; then
   EXTRA_PACKAGES="${EXTRA_PACKAGES} wget"
 fi
 
-if [[ $GAZEBO_MAJOR_VERSION -lt 8 ]]; then
-  GAZEBO_BASE_CMAKE_ARGS="${GAZEBO_BASE_CMAKE_ARGS} -DENABLE_TESTS_COMPILATION=True"
-fi
-
 SOFTWARE_DIR="gazebo"
 
 cat > build.sh << DELIM_DART
@@ -166,13 +162,11 @@ make -j${MAKE_JOBS}
 stop_stopwatch COMPILATION
 echo '# END SECTION'
 
-if [[ $GAZEBO_MAJOR_VERSION -ge 8 ]]; then
-  echo '# BEGIN SECTION: Tests compilation'
-  init_stopwatch TESTS_COMPILATION
-  make -j${MAKE_JOBS} tests
-  stop_stopwatch TESTS_COMPILATION
-  echo '# END SECTION'
-fi
+echo '# BEGIN SECTION: Tests compilation'
+init_stopwatch TESTS_COMPILATION
+make -j${MAKE_JOBS} tests
+stop_stopwatch TESTS_COMPILATION
+echo '# END SECTION'
 
 echo '# BEGIN SECTION: Gazebo installation'
 sudo make install

--- a/jenkins-scripts/docker/lib/gazebo-base-default.bash
+++ b/jenkins-scripts/docker/lib/gazebo-base-default.bash
@@ -49,9 +49,6 @@ if [[ $GAZEBO_MAJOR_VERSION -lt 8 ]]; then
 fi
 
 SOFTWARE_DIR="gazebo"
-if [ "${GAZEBO_EXPERIMENTAL_BUILD}" = true ]; then
-  SOFTWARE_DIR="${SOFTWARE_DIR}_experimental"
-fi
 
 cat > build.sh << DELIM_DART
 ###################################################

--- a/jenkins-scripts/gazebo-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/gazebo-default-devel-homebrew-amd64.bash
@@ -4,22 +4,13 @@
 [[ -L ${0} ]] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
 SCRIPT_DIR="${SCRIPT_DIR%/*}"
 
-# Identify GAZEBO_MAJOR_VERSION to help with dependency resolution
-GAZEBO_MAJOR_VERSION=$(\
-  python3 ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/gazebo/CMakeLists.txt)
+RERUN_FAILED_TESTS=1
 
-if [ $GAZEBO_MAJOR_VERSION -ge 7 ]; then
-  RERUN_FAILED_TESTS=1
-fi
-
-if [[ $GAZEBO_MAJOR_VERSION -ge 8 ]]; then
 PRE_TESTS_EXECUTION_HOOK="""
 echo '#BEGIN SECTION: compile the tests suite'
 make tests -j\${MAKE_JOBS} \${MAKE_VERBOSE_STR}
 echo '# END SECTION'
 """
-fi
 
 # clear the heightmap paging cache
 rm -rf $HOME/.gazebo/paging

--- a/jenkins-scripts/gazebo-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/gazebo-default-devel-homebrew-amd64.bash
@@ -15,4 +15,4 @@ echo '# END SECTION'
 # clear the heightmap paging cache
 rm -rf $HOME/.gazebo/paging
 
-. ${SCRIPT_DIR}/lib/project-default-devel-homebrew-amd64.bash gazebo
+. ${SCRIPT_DIR}/lib/project-default-devel-homebrew-amd64.bash gazebo-classic

--- a/jenkins-scripts/gazebo-default-devel-windows7-amd64.bat
+++ b/jenkins-scripts/gazebo-default-devel-windows7-amd64.bat
@@ -1,6 +1,6 @@
 set SCRIPT_DIR=%~dp0
 set PLATFORM_TO_BUILD=amd64
-set VCS_DIRECTORY=gazebo
+set VCS_DIRECTORY=gazebo-classic
 
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set GAZEBO_MAJOR_VERSION=%%i
 

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -142,79 +142,63 @@ if $DART_FROM_PKGS; then
   fi
 fi
 
-# By default, the stable version of gazebo
-[[ -z ${GAZEBO_EXPERIMENTAL_BUILD} ]] && GAZEBO_EXPERIMENTAL_BUILD=false
-if ! ${GAZEBO_EXPERIMENTAL_BUILD}; then
-  # --------------------------------------
-  # GAZEBO - current version
-  # --------------------------------------
+# --------------------------------------
+# GAZEBO classic
+# --------------------------------------
 
-  GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT="libfreeimage-dev     \\
-                            libprotoc-dev                    \\
-                            libprotobuf-dev                  \\
-                            protobuf-compiler                \\
-                            freeglut3-dev                    \\
-                            libcurl4-openssl-dev             \\
-                            libtinyxml-dev                   \\
-                            libtinyxml2-dev                  \\
-                            libtar-dev                       \\
-                            libtbb-dev                       \\
-                            ${ogre_pkg}                      \\
-                            libxml2-dev                      \\
-                            pkg-config                       \\
-                            qtbase5-dev                      \\
-                            libqwt-qt5-dev                   \\
-                            libltdl-dev                      \\
-                            libgts-dev                       \\
-                            libboost-thread-dev              \\
-                            libboost-system-dev              \\
-                            libboost-filesystem-dev          \\
-                            libboost-program-options-dev     \\
-                            libboost-regex-dev               \\
-                            libboost-iostreams-dev           \\
-                            ${bullet_pkg}                    \\
-                            libsimbody-dev                   \\
-                            ${dart_pkgs}"
+GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT="libfreeimage-dev     \\
+                          libprotoc-dev                    \\
+                          libprotobuf-dev                  \\
+                          protobuf-compiler                \\
+                          freeglut3-dev                    \\
+                          libcurl4-openssl-dev             \\
+                          libtinyxml-dev                   \\
+                          libtinyxml2-dev                  \\
+                          libtar-dev                       \\
+                          libtbb-dev                       \\
+                          ${ogre_pkg}                      \\
+                          libxml2-dev                      \\
+                          pkg-config                       \\
+                          qtbase5-dev                      \\
+                          libqwt-qt5-dev                   \\
+                          libltdl-dev                      \\
+                          libgts-dev                       \\
+                          libboost-thread-dev              \\
+                          libboost-system-dev              \\
+                          libboost-filesystem-dev          \\
+                          libboost-program-options-dev     \\
+                          libboost-regex-dev               \\
+                          libboost-iostreams-dev           \\
+                          ${bullet_pkg}                    \\
+                          libsimbody-dev                   \\
+                          ${dart_pkgs}"
 
-  if [[ ${GAZEBO_MAJOR_VERSION} -ge 11 ]]; then
-      GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT="${GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT} \\
-                                           libignition-common3-dev \\
-                                           libignition-fuel-tools4-dev \\
-                                           libignition-transport8-dev \\
-                                           libignition-math6-dev \\
-                                           libignition-msgs5-dev"
-  elif [[ ${GAZEBO_MAJOR_VERSION} -ge 9 ]]; then
-      GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT="${GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT} \\
-                                           libignition-common-dev \\
-                                           libignition-fuel-tools1-dev \\
-                                           libignition-transport4-dev \\
-                                           libignition-math4-dev \\
-                                           libignition-msgs-dev"
-  fi
-
-  GAZEBO_BASE_DEPENDENCIES="${GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT} \\
-                            ${sdformat_pkg}"
-
-  GAZEBO_EXTRA_DEPENDENCIES="libavformat-dev  \\
-                             libavcodec-dev   \\
-                             libgdal-dev      \\
-                             libgraphviz-dev  \\
-                             libswscale-dev   \\
-                             libavdevice-dev   \\
-                             ruby-ronn"
-else
-  # --------------------------------------
-  # GAZEBO - experimental version
-  # --------------------------------------
-  GAZEBO_BASE_DEPENDENCIES="libgflags-dev            \\
-                            pkg-config               \\
-                            libprotoc-dev            \\
-                            libprotobuf-dev          \\
-                            protobuf-compiler        \\
-                            ${pythonv}-protobuf      \\
-                            libignition-common-dev   \\
-                            libignition-msgs-dev"
+if [[ ${GAZEBO_MAJOR_VERSION} -ge 11 ]]; then
+    GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT="${GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT} \\
+                                         libignition-common3-dev \\
+                                         libignition-fuel-tools4-dev \\
+                                         libignition-transport8-dev \\
+                                         libignition-math6-dev \\
+                                         libignition-msgs5-dev"
+elif [[ ${GAZEBO_MAJOR_VERSION} -ge 9 ]]; then
+    GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT="${GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT} \\
+                                         libignition-common-dev \\
+                                         libignition-fuel-tools1-dev \\
+                                         libignition-transport4-dev \\
+                                         libignition-math4-dev \\
+                                         libignition-msgs-dev"
 fi
+
+GAZEBO_BASE_DEPENDENCIES="${GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT} \\
+                          ${sdformat_pkg}"
+
+GAZEBO_EXTRA_DEPENDENCIES="libavformat-dev  \\
+                           libavcodec-dev   \\
+                           libgdal-dev      \\
+                           libgraphviz-dev  \\
+                           libswscale-dev   \\
+                           libavdevice-dev   \\
+                           ruby-ronn"
 
 
 if [[ -z $ROS_DISTRO ]]; then


### PR DESCRIPTION
This has a follow-up to #843 that is needed to fix some CI failures, built on top of some clean up of the gazebo-classic scripts. It's easiest to review by commit:

* https://github.com/gazebo-tooling/release-tools/commit/eb5a0d1010adf4263f603016a9076cd0790ea48d?w=1 (without whitespace): remove `GAZEBO_EXPERIMENTAL_BUILD` variable related to outdated https://github.com/osrf/gazebo_experimental repository.
* https://github.com/gazebo-tooling/release-tools/commit/29774df20d9ca5f6be2e9e6cfa61125813386e38?w=1 (without whitespace): remove logic that checks for EOL versions of gazebo-classic
* https://github.com/gazebo-tooling/release-tools/commit/ea81afcd005d90499f81e720cd7388f6ce682d6d: update source folder names to `gazebo-classic`

Needed to fix [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-abichecker-any_to_any-ubuntu_auto-amd64&build=1227)](https://build.osrfoundation.org/job/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/1227/) https://build.osrfoundation.org/job/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/1227/

~~~
 > git rev-parse --resolve-git-dir
 /home/jenkins/workspace/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/gazebo-classic/.git # timeout=10
...
+++ python3 ./scripts/jenkins-scripts/docker/../tools/detect_cmake_major_version.py /home/jenkins/workspace/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/gazebo/CMakeLists.txt
Traceback (most recent call last):
  File "./scripts/jenkins-scripts/docker/../tools/detect_cmake_major_version.py", line 11, in <module>
    f = open(fileName, 'r')
FileNotFoundError: [Errno 2] No such file or directory:
 '/home/jenkins/workspace/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/gazebo/CMakeLists.txt'
~~~