### PR TITLE
Add -fPIC to abichecker for qt dependent builds

### DIFF
--- a/jenkins-scripts/docker/ignition-abichecker.bash
+++ b/jenkins-scripts/docker/ignition-abichecker.bash
@@ -73,6 +73,16 @@ then
   fi
 fi
 
+if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo"   && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 7 ]] || \
+  [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gui"       && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 7 ]] || \
+  [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-launch"    && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 6 ]] || \
+  [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-sensors"   && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 7 ]] || \
+  [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-rendering" && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 7 ]]
+then
+  # -fPIC needed to compile Qt
+  export ABI_JOB_EXTRA_GCC_OPTIONS="-fPIC"
+fi
+
 # default to use stable repos
 export ABI_JOB_REPOS="stable"
 

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -11,6 +11,8 @@
 # ABI_JOB_CMAKE_PARAMS: (option) cmake parameters to be pased to cmake configuration
 # ABI_JOB_IGNORE_HEADERS: (optional) relative (to root project path) list (space separated)
 #                         of path headers to ignore
+# ABI_JOB_EXTRA_GCC_OPTIONS: (optional) inject gcc_options in the descriptor file
+#                            one per line
 
 # Jenkins variables:
 # DEST_BRANCH
@@ -100,6 +102,7 @@ sudo perl Makefile.pl -install --prefix=/usr
 
 mkdir -p $WORKSPACE/abi_checker
 cd $WORKSPACE/abi_checker
+
 cat > pkg.xml << CURRENT_DELIM
  <version>
      branch: $DEST_BRANCH
@@ -126,6 +129,7 @@ cat >> pkg.xml << CURRENT_DELIM_LIBS
 
  <gcc_options>
      -std=${ABI_CXX_STANDARD}
+     ${ABI_JOB_EXTRA_GCC_OPTIONS}
  </gcc_options>
 CURRENT_DELIM_LIBS
 
@@ -156,6 +160,7 @@ cat >> devel.xml << DEVEL_DELIM_LIBS
 
  <gcc_options>
      -std=${ABI_CXX_STANDARD}
+     ${ABI_JOB_EXTRA_GCC_OPTIONS}
  </gcc_options>
 DEVEL_DELIM_LIBS
 echo '# END SECTION'


### PR DESCRIPTION
In combination with https://github.com/gazebosim/gz-sim/pull/1778 should fix the abichecker for gz-sim7.

Testing: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-abichecker-any_to_any-ubuntu_auto-amd64&build=5845)](https://build.osrfoundation.org/job/ignition_gazebo-abichecker-any_to_any-ubuntu_auto-amd64/5845/)