### PR TITLE
Update changelog generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Gazebo software.
     * Update the changelog.
         1. Use the [source_changelog.bash](source_changelog.bash) script to generate the Changelog.md entries newer than the most recent tag.
             * `cd <path to source code>`
-            * `bash <path to release-tools>/source_changelog.bash <previous tag>`
-            * e.g. `bash ../release-tools/source_changelog.bash 3.5.0`
+            * `bash <path to release-tools>/source-repo-scripts/source_changelog.bash <previous tag>`
+            * e.g. `bash ../release-tools/source-repo-scripts/source_changelog.bash 3.5.0`
         1. Verify the Changelog.md entries using the GitHub branch comparison.
     * Update the migration guide as needed.
     * Wait for this pull request to be merged before proceeding.


### PR DESCRIPTION
The script to generate source changelog lives in the ``source-repo-scripts`` directory, updating that in the PR.