### PR TITLE
gazebo.dsl: use 20.04 for pull request CI builds

### DIFF
--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -8,8 +8,7 @@ def ubuntu_official_packages_distros = [ 'bionic' : 'gazebo9',
                                          'focal'  : 'gazebo9',
                                          'jammy'  : 'gazebo11']
 // Main platform using for quick CI
-// Using bionic until https://github.com/gazebosim/gazebo-classic/issues/3151 is fixed
-def ci_distro               = [ 'bionic' ]
+def ci_distro               = [ 'focal' ]
 def ci_gpu                  = Globals.get_ci_gpu()
 def abi_distro              = Globals.get_abi_distro()
 // Other supported platform to be checked but no for quick


### PR DESCRIPTION
We can switch to 20.04 for gazebo-classic CI when the fix for gazebo9 is merged in https://github.com/gazebosim/gazebo-classic/pull/3278, which will resolve the issue https://github.com/gazebosim/gazebo-classic/issues/3151.