### PR TITLE
Use gazebo-classic in more scripts

### DIFF
--- a/jenkins-scripts/docker/gazebo-abichecker.bash
+++ b/jenkins-scripts/docker/gazebo-abichecker.bash
@@ -16,7 +16,7 @@ fi
 
 . ${SCRIPT_DIR}/lib/_gazebo_version_hook.bash
 
-export ABI_JOB_SOFTWARE_NAME="gazebo"
+export ABI_JOB_SOFTWARE_NAME="gazebo-classic"
 export ABI_JOB_REPOS="stable"
 export ABI_JOB_PKG_DEPENDENCIES_VAR_NAME="GAZEBO_BASE_DEPENDENCIES"
 export ABI_JOB_IGNORE_HEADERS="gazebo/GIMPACT gazebo/opcode gazebo/test"

--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -58,6 +58,7 @@ echo # END SECTION
   echo # BEGIN SECTION: reusing workspace
   :: Remove gazebo copy
   IF EXIST %LOCAL_WS%\gazebo ( rmdir /s /q %LOCAL_WS%\gazebo ) || goto :error
+  IF EXIST %LOCAL_WS%\gazebo-classic ( rmdir /s /q %LOCAL_WS%\gazebo-classic ) || goto :error
   echo # END SECTION
 )
 
@@ -86,7 +87,7 @@ echo # END SECTION
 echo # BEGIN SECTION: compile and install sdformat
 set SDFORMAT_DIR=%WORKSPACE%\sdformat
 if EXIST %SDFORMAT_DIR% ( rmdir /s /q %SDFORMAT_DIR% )
-git clone https://github.com/osrf/sdformat %SDFORMAT_DIR% -b sdf9
+git clone https://github.com/gazebosim/sdformat %SDFORMAT_DIR% -b sdf9
 set VCS_DIRECTORY=sdformat
 set KEEP_WORKSPACE=TRUE
 set ENABLE_TESTS=FALSE
@@ -100,9 +101,9 @@ xcopy %WORKSPACE_INSTALL_DIR%\boost_1_67_0\lib64-msvc-14.1 %WORKSPACE_INSTALL_DI
 echo # END SECTION
 
 echo # BEGIN SECTION: copy gazebo sources to workspace
-:: Note that your jenkins job should put source in %WORKSPACE%/gazebo
-xcopy %WORKSPACE%\gazebo %LOCAL_WS%\gazebo /s /i /e > xcopy.log
-cd %LOCAL_WS%\gazebo
+:: Note that your jenkins job should put source in %WORKSPACE%/gazebo-classic
+xcopy %WORKSPACE%\gazebo-classic %LOCAL_WS%\gazebo-classic /s /i /e > xcopy.log
+cd %LOCAL_WS%\gazebo-classic
 echo # END SECTION
 
 echo # BEGIN SECTION: configure gazebo

--- a/jenkins-scripts/lib/gazebo9_10-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo9_10-base-windows.bat
@@ -49,6 +49,7 @@ echo # END SECTION
   echo # BEGIN SECTION: reusing workspace
   :: Remove gazebo copy
   IF EXIST %LOCAL_WS%\gazebo ( rmdir /s /q %LOCAL_WS%\gazebo ) || goto :error
+  IF EXIST %LOCAL_WS%\gazebo-classic ( rmdir /s /q %LOCAL_WS%\gazebo-classic ) || goto :error
   echo # END SECTION
 )
 
@@ -66,7 +67,7 @@ echo # END SECTION
 echo # BEGIN SECTION: compile and install sdformat
 set SDFORMAT_DIR=%WORKSPACE%\sdformat
 if EXIST %SDFORMAT_DIR% ( rmdir /s /q %SDFORMAT_DIR% )
-git clone https://github.com/osrf/sdformat %SDFORMAT_DIR% -b sdf6
+git clone https://github.com/gazebosim/sdformat %SDFORMAT_DIR% -b sdf6
 set VCS_DIRECTORY=sdformat
 set KEEP_WORKSPACE=TRUE
 set ENABLE_TESTS=FALSE
@@ -80,9 +81,9 @@ xcopy %WORKSPACE_INSTALL_DIR%\boost_1_67_0\lib64-msvc-14.1 %WORKSPACE_INSTALL_DI
 echo # END SECTION
 
 echo # BEGIN SECTION: copy gazebo sources to workspace
-:: Note that your jenkins job should put source in %WORKSPACE%/gazebo
-xcopy %WORKSPACE%\gazebo %LOCAL_WS%\gazebo /s /i /e > xcopy.log
-cd %LOCAL_WS%\gazebo
+:: Note that your jenkins job should put source in %WORKSPACE%/gazebo-classic
+xcopy %WORKSPACE%\gazebo-classic %LOCAL_WS%\gazebo-classic /s /i /e > xcopy.log
+cd %LOCAL_WS%\gazebo-classic
 echo # END SECTION
 
 echo # BEGIN SECTION: configure gazebo


### PR DESCRIPTION
Follow-up to #846. Some gazebo abichecker jobs are failing on certain machines:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-abichecker-any_to_any-ubuntu_auto-amd64&build=1243)](https://build.osrfoundation.org/job/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/1243/) https://build.osrfoundation.org/job/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/1243/

~~~
 > git rev-parse --resolve-git-dir /home/jenkins/workspace/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/gazebo-classic/.git # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/gazebosim/gazebo-classic.git # timeout=10
Fetching upstream changes from https://github.com/gazebosim/gazebo-classic.git
...
+ cp -a /home/jenkins/workspace/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/gazebo /tmp/gazebo
cp: cannot stat '/home/jenkins/workspace/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/gazebo': No such file or directory
~~~

I think the abichecker is fixed by https://github.com/gazebo-tooling/release-tools/commit/3a1d881b8c8d54f27108d80be7c7080bcdc8135c

I also updated some windows scripts that aren't yet using `gazebo-classic`