### PR TITLE
Better support for "none" in UPLOAD_TO_REPO param in Jenkins debbuilders

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
@@ -99,21 +99,26 @@ class OSRFLinuxBuildPkg
             failBuildOnError(false)
         }
 
-        conditionalAction {
-          condition {
-            not {
-              expression('none|None|^$','${ENV,var="UPLOAD_TO_REPO"}')
+        flexiblePublish
+        {
+          conditionalAction {
+            condition {
+              not {
+                expression('none|None|^$','${ENV,var="UPLOAD_TO_REPO"}')
+              }
             }
-          }
-          downstreamParameterized {
-            trigger('repository_uploader_packages') {
-              condition('UNSTABLE_OR_BETTER')
-              parameters {
-                currentBuild()
-                predefinedProp("PROJECT_NAME_TO_COPY_ARTIFACTS", "\${JOB_NAME}")
-                // Workaround to avoid problems on repository uploader. Real
-                // issue: https://issues.jenkins-ci.org/browse/JENKINS-45005
-                predefinedProp("JENKINS_NODE_TAG", "master")
+            publishers {
+              downstreamParameterized {
+                trigger('repository_uploader_packages') {
+                  condition('UNSTABLE_OR_BETTER')
+                  parameters {
+                    currentBuild()
+                    predefinedProp("PROJECT_NAME_TO_COPY_ARTIFACTS", "\${JOB_NAME}")
+                    // Workaround to avoid problems on repository uploader. Real
+                    // issue: https://issues.jenkins-ci.org/browse/JENKINS-45005
+                    predefinedProp("JENKINS_NODE_TAG", "master")
+                  }
+                }
               }
             }
           }

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
@@ -65,7 +65,7 @@ class OSRFLinuxBuildPkg
                     "If not empty, package name to be used instead of PACKAGE")
         stringParam("UPLOAD_TO_REPO",
                     default_params.find{ it.key == "UPLOAD_TO_REPO"}?.value,
-                    "OSRF repo name to upload the package to")
+                    "OSRF repo name to upload the package to: stable | prerelease | nightly | none (for testing proposes)")
         stringParam("OSRF_REPOS_TO_USE",
                     default_params.find{ it.key == "OSRF_REPOS_TO_USE"}?.value,
                     "OSRF repos name to use when building the package")
@@ -99,23 +99,29 @@ class OSRFLinuxBuildPkg
             failBuildOnError(false)
         }
 
-        downstreamParameterized {
-	  trigger('repository_uploader_packages') {
-	    condition('UNSTABLE_OR_BETTER')
-	    parameters {
-	      currentBuild()
-	      predefinedProp("PROJECT_NAME_TO_COPY_ARTIFACTS", "\${JOB_NAME}")
-	      // Workaround to avoid problems on repository uploader. Real
-	      // issue: https://issues.jenkins-ci.org/browse/JENKINS-45005
-	      predefinedProp("JENKINS_NODE_TAG", "master")
-	    }
-	  }
+        conditionalAction {
+          condition {
+            not {
+              expression('none|None|^$','${ENV,var="UPLOAD_TO_REPO"}')
+            }
+          }
+          downstreamParameterized {
+            trigger('repository_uploader_packages') {
+              condition('UNSTABLE_OR_BETTER')
+              parameters {
+                currentBuild()
+                predefinedProp("PROJECT_NAME_TO_COPY_ARTIFACTS", "\${JOB_NAME}")
+                // Workaround to avoid problems on repository uploader. Real
+                // issue: https://issues.jenkins-ci.org/browse/JENKINS-45005
+                predefinedProp("JENKINS_NODE_TAG", "master")
+              }
+            }
+          }
         }
-      }
-
-      configure { project ->
-        project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
-          'string' 'repository_uploader_*'
+        configure { project ->
+          project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
+            'string' 'repository_uploader_*'
+          }
         }
       }
     } // end of job

--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -109,7 +109,7 @@ fi
 
 # Check destination repository
 if [[ -z ${UPLOAD_TO_REPO} ]]; then
-    echo "No UPLOAD_TO_REPO value was send. Which repository to use? (stable | prerelease | nightly)"
+    echo "No UPLOAD_TO_REPO value was send. Which repository to use? (stable | prerelease | nightly | none)"
     echo ""
     echo "Please check that the jenkins -debbuild job that called this uploader is defining the parameter"
     echo "UPLOAD_TO_REPO in the job configuration. If it is not, just define it as a string parameter"
@@ -117,32 +117,36 @@ if [[ -z ${UPLOAD_TO_REPO} ]]; then
 fi
 
 case ${UPLOAD_TO_REPO} in
-    "stable")
-	# Security checks not to upload nightly or prereleases
-        # No packages with ~git or ~pre
-	if [[ -n $(ls ${pkgs_path}/*~git*.*) && -n $(ls ${pkgs_path}/*~pre*.*) ]]; then
-	  echo "There are nightly packages in the upload directory. Not uploading to stable repo"
-	  exit 1
-	fi
-        # No source packages with ~git in version
-	if [[ -n $(cat ${pkgs_path}/*.dsc | grep ^Version: | grep '~git\|~pre') ]]; then
-          echo "There is a sorce package with nightly or pre in version. Not uploading to stable repo"
-	  exit 1
-        fi
-	;;
-    "nightly")
-	# No uploads for nightly packages
-	ENABLE_S3_UPLOAD=false
-	;;
-    "only_s3_upload")
-        # This should be fine, no repo, only s3 upload
-        ENABLE_S3_UPLOAD=true
-        ;;
-    *)
-	# Here we could find project repositories uploads or error values.
-	# Error values for UPLOAD_TO_REPO will be get in the next directory check
-	# some lines below so we do nothing.
-	;;
+  "stable")
+    # Security checks not to upload nightly or prereleases
+    # No packages with ~git or ~pre
+    if [[ -n $(ls ${pkgs_path}/*~git*.*) && -n $(ls ${pkgs_path}/*~pre*.*) ]]; then
+      echo "There are nightly packages in the upload directory. Not uploading to stable repo"
+      exit 1
+    fi
+          # No source packages with ~git in version
+    if [[ -n $(cat ${pkgs_path}/*.dsc | grep ^Version: | grep '~git\|~pre') ]]; then
+            echo "There is a sorce package with nightly or pre in version. Not uploading to stable repo"
+      exit 1
+    fi
+  ;;
+  "nightly")
+    # No uploads for nightly packages test runs
+    ENABLE_S3_UPLOAD=false
+  ;;
+  "none")
+    echo "UPLOAD_TO_REPO was set to none. No upload is done."
+    exit 0
+  ;;
+  "only_s3_upload")
+    # This should be fine, no repo, only s3 upload
+    ENABLE_S3_UPLOAD=true
+  ;;
+  *)
+    # Here we could find project repositories uploads or error values.
+    # Error values for UPLOAD_TO_REPO will be get in the next directory check
+    # some lines below so we do nothing.
+  ;;
 esac
 
 # .zip | (mostly) windows packages


### PR DESCRIPTION
For testing proposes when we test the -release repo changes or other packaging stuff, this PR improves the "unofficial" support for `none` value in the `UPLOAD_TO_REPO` parameter:

 * DSL code change: ddede4bcc609a4c28b5c2eba9be8337dd6bdfe30 Avoid the call to `repository_uploader` if none is passed in `UPLOAD_TO_REPO`.
 * Changes in repsitory_uploader script: in the case that the 'none' value is found in the `UPLOAD_TO_REPO` parameter do not execute any upload code and finish successfully. bad3c51f177f2e7a81efbc00c3cda2b587b3877d

Note: the tabs were very broken in the code, better see this PR [with ?w=1](https://github.com/gazebo-tooling/release-tools/pull/858/files?w=1)