### PR TITLE
Do not add ubuntu repository twice on i386

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -177,14 +177,6 @@ DELIM_DOCKER_ARCH
   fi
 fi
 
-# i386 image only have main by default
-if [[ ${LINUX_DISTRO} == 'ubuntu' && ${ARCH} == 'i386' ]]; then
-cat >> Dockerfile << DELIM_DOCKER_I386_APT
-RUN echo "deb ${SOURCE_LIST_URL} ${DISTRO} restricted universe" \\
-                                                       >> /etc/apt/sources.list
-DELIM_DOCKER_I386_APT
-fi
-
 # Workaround for: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=932019
 if [[ ${DISTRO} == 'buster' ]]; then
 cat >> Dockerfile << DELIM_BUSTER_DWZ


### PR DESCRIPTION
This triggered a failure on debbuilder for gz-transport8 on autopkgtest [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-transport8-debbuilder&build=134)](https://build.osrfoundation.org/job/ign-transport8-debbuilder/134/)

```
W: Target Packages (restricted/binary-i386/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:4
W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:4
W: Target Packages (universe/binary-i386/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:4
W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:4
[31mautopkgtest [15:30:55]: ERROR: "apt-get --simulate --quiet -o APT::Get::Show-User-Simulation-Note=False --auto-remove purge autopkgtest-satdep" failed with stderr "W: Target Packages (restricted/binary-i386/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:4
W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:4
W: Target Packages (universe/binary-i386/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:4
W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:4
```

With this PR: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-transport8-debbuilder&build=136)](https://build.osrfoundation.org/job/ign-transport8-debbuilder/136/)