### PR TITLE
brew_release.dsl: stop catalina bottle builds

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Job
 Globals.default_emails = "jrivero@osrfoundation.org, scpeters@osrfoundation.org"
 
 // first distro in list is used as touchstone
-brew_supported_distros         = [ "catalina", "bigsur", "monterey" ]
+brew_supported_distros         = [ "bigsur", "monterey" ]
 bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_updater'
 bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'


### PR DESCRIPTION
homebrew-core has stopped building catalina bottles, so we will do the same.

Noticed in https://github.com/osrf/homebrew-simulation/pull/2146

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder%2Flabel%3Dosx_catalina&build=1062)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_catalina/1062/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_catalina/1062/
* https://github.com/Homebrew/homebrew-core/commit/791fce5b059caf7b1a3444cba69798809965ecc6