### PR TITLE
Use gz insetead of ign for extra_debbuilders

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -261,7 +261,11 @@ ArrayList all_debbuilders()
   }
   // add all extra debbuilders
   gz_extra_debbuild.each { gz_name ->
-    branches.add("ign-${gz_name}")
+    // utils1 is still using the ign preffix
+    if (gz_name == 'utils1')
+      branches.add("ign-${gz_name}")
+    else
+      branches.add("gz-${gz_name}")
   }
 
   return branches


### PR DESCRIPTION
The extra debbuilders, mostly used for nightlies are using the `ign-` prefix, what is breaking nightlies. I think that makes more sense to move all them to `gz` and make the exception of `utils1` which is the only one not belonging to the Harmonic release.
