### PR TITLE
gz_extra_debbuild: launch8 -> launch7

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -84,7 +84,7 @@ gz_prerelease_branches = []
 // don't appear in gz_branches (like nightly builders or 0-debbuild
 // jobs for the special cases of foo0 packages)
 gz_extra_debbuild = [ 'gui8',
-                      'launch8',
+                      'launch7',
                       'rendering8',
                       'sensors8',
                       'sim8',


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

spotted this while learning about recent changes in release-tools

launch7 is the latest version in harmonic not launch8