### PR TITLE
Rootless in packages.o.o 1/2: do not install packages

### DIFF
--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -87,13 +87,6 @@ upload_dsc_package()
 		echo "MARK_BUILD_UNSTABLE"
 }
 
-NEEDED_HOST_PACKAGES="reprepro openssh-client jq gridsite-clients"
-QUERY_HOST_PACKAGES=$(dpkg-query -Wf'${db:Status-abbrev}' ${NEEDED_HOST_PACKAGES} 2>&1) || true
-if [[ -n ${QUERY_HOST_PACKAGES} ]]; then
-  sudo apt-get update
-  sudo apt-get install -y ${NEEDED_HOST_PACKAGES}
-fi
-
 # By default, enable s3 upload of packages
 ENABLE_S3_UPLOAD=true
 


### PR DESCRIPTION
First step to remove sudo access in the packages server. Remove the code is acting as provisioning and use the right chef code for it. Probably safe to merge but we can sync both PRs before proceeding.