### PR TITLE
Remove sudo for using reprepro in new packages.o.o server

### DIFF
--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -47,7 +47,7 @@ dsc_package_exists_and_equal_or_greater()
 {
     local pkg=${1} new_version=${2} distro=${3}
 
-    current_dsc_info=$(sudo GNUPGHOME=/var/lib/jenkins/.gnupg/ reprepro -T dsc list "${distro}" "${pkg}" | tail -n 1)
+    current_dsc_info=$(GNUPGHOME=$HOME/.gnupg/ reprepro -T dsc list "${distro}" "${pkg}" | tail -n 1)
 
     if [[ -z ${current_dsc_info} ]]; then
         return 1 # do not exits, false
@@ -68,7 +68,7 @@ upload_package()
     [[ -z ${pkg} ]] && echo "Bad parameter pkg" && exit 1
     [[ -z ${pkg_name} ]] && echo "Bad parameter pkg_name" && exit 1
 
-    sudo GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror includedeb $DISTRO ${pkg}
+    GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror includedeb $DISTRO ${pkg}
 
     # The path will end up being: s3://osrf-distributions/$pkg_root_name/releases/
     S3_upload ${pkg} ${pkg_name}/releases/
@@ -82,8 +82,8 @@ upload_dsc_package()
     # .dsc sometimes does not include priority or section,
     # try to upload and if failed, specify the values
     # see: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=768046
-    sudo GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror includedsc $DISTRO ${pkg} || \
-	sudo GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror --section science --priority extra includedsc $DISTRO ${pkg} || \
+    GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror includedsc $DISTRO ${pkg} || \
+	  GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror --section science --priority extra includedsc $DISTRO ${pkg} || \
 		echo "MARK_BUILD_UNSTABLE"
 }
 
@@ -224,7 +224,7 @@ for pkg in `ls $pkgs_path/*.deb`; do
       all.deb)
 	# Check if the package already exists. i386 and amd64 generates the same binaries.
 	# all should be multiarch, so supposed to work on every platform
-	existing_version=$(sudo GNUPGHOME=/var/lib/jenkins/.gnupg/ reprepro ls ${pkg_name} | grep ${DISTRO} | awk '{ print $3 }')
+	existing_version=$(GNUPGHOME=$HOME/.gnupg/ reprepro ls ${pkg_name} | grep ${DISTRO} | awk '{ print $3 }')
 	if $(dpkg --compare-versions ${pkg_version} le ${existing_version}); then
 	    echo "${pkg_relative} for ${DISTRO} is already in the repo with same version or greater"
 	    echo "SKIP UPLOAD"


### PR DESCRIPTION
***Requires:*** deployment of the new packages.o.o machine. Do not merge.

Linked to https://github.com/osrf/chef-osrf/pull/167

Mainly two actions:
 * Remove sudo calls
 * Remove hardcode references to /var/lib/packages in favor of $HOME.