### PR TITLE
Use system s3cmd instead of using 1.5.0

### DIFF
--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -25,18 +25,7 @@ S3_upload()
 
     S3_DIR=$(mktemp -d ${HOME}/s3.XXXX)
     pushd ${S3_DIR}
-    # Hack for not failing when github is down
-    update_done=false
-    seconds_waiting=0
-    while (! $update_done); do
-      wget https://github.com/s3tools/s3cmd/archive/v1.5.0-rc1.tar.gz -O foo.tar.gz && update_done=true
-      sleep 1
-      seconds_waiting=$((seconds_waiting+1))
-      [ $seconds_waiting -gt 60 ] && exit 1
-    done
-    tar xzf foo.tar.gz
-    cd s3cmd-*
-    ./s3cmd put $pkg s3://osrf-distributions/${s3_destination_path}
+    s3cmd put $pkg s3://osrf-distributions/${s3_destination_path}
     popd
     rm -fr ${S3_DIR}
 }


### PR DESCRIPTION
Using old s3cmd is looking for python instead of python3. Remove and use the system provided one with new provision.