### PR TITLE
Set HOMEBREW_NO_INSTALL_FROM_API for CI jobs

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -44,6 +44,7 @@ fi
 
 # Step 1. Set up homebrew
 echo "# BEGIN SECTION: clean up ${HOMEBREW_PREFIX}"
+export HOMEBREW_NO_INSTALL_FROM_API=1
 . ${SCRIPT_DIR}/lib/_homebrew_cleanup.bash
 . ${SCRIPT_DIR}/lib/_homebrew_base_setup.bash
 brew cleanup || echo "brew cleanup couldn't be run"

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -22,6 +22,7 @@ fi
 
 # Step 1. Set up homebrew
 echo "# BEGIN SECTION: clean up ${HOMEBREW_PREFIX}"
+export HOMEBREW_NO_INSTALL_FROM_API=1
 . ${SCRIPT_DIR}/lib/_homebrew_cleanup.bash
 . ${SCRIPT_DIR}/lib/_homebrew_base_setup.bash
 brew cleanup || echo "brew cleanup couldn't be run"


### PR DESCRIPTION
Homebrew 4.0 now installs from an API by default instead of requiring a large git clone, but it doesn't work for all operations. Set an environment variable for our CI jobs to avoid API installs for now.

This should fix the following failures:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat13-install_bottle-homebrew-amd64&build=192)](https://build.osrfoundation.org/job/sdformat13-install_bottle-homebrew-amd64/192/) https://build.osrfoundation.org/job/sdformat13-install_bottle-homebrew-amd64/192/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_math7-install_bottle-homebrew-amd64&build=113)](https://build.osrfoundation.org/job/ignition_math7-install_bottle-homebrew-amd64/113/) https://build.osrfoundation.org/job/ignition_math7-install_bottle-homebrew-amd64/113/