### PR TITLE
Set HOMEBREW_NO_INSTALL_FROM_API for bottle builds

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -54,6 +54,7 @@ fi
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: clean up environment'
+export HOMEBREW_NO_INSTALL_FROM_API=1
 rm -fr ${PKG_DIR} && mkdir -p ${PKG_DIR}
 . ${SCRIPT_LIBDIR}/_homebrew_cleanup.bash
 # don't use HOMEBREW_UPDATE_TO_TAG for bottle builds


### PR DESCRIPTION
Follow up to #879. Should fix the Monterey build of https://github.com/osrf/homebrew-simulation/pull/2222.