### PR TITLE
brew without sudo: part 1

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -111,8 +111,7 @@ echo '# END SECTION'
 # Step 3. Manually compile and install ${PROJECT}
 echo "# BEGIN SECTION: configure ${PROJECT}"
 cd ${WORKSPACE}/${PROJECT_PATH}
-# Need the sudo since the test are running with roots perms to access to GUI
-sudo rm -fr ${WORKSPACE}/build
+rm -fr ${WORKSPACE}/build
 mkdir -p ${WORKSPACE}/build
 cd ${WORKSPACE}/build
 


### PR DESCRIPTION
Remove build folder without sudo. I think this should work without `sudo`. Running some tests to confirm.

### Simple test

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_utils-ci-gz-utils2-homebrew-amd64&build=21)](https://build.osrfoundation.org/view/ign-garden/job/ignition_utils-ci-gz-utils2-homebrew-amd64/21/) https://build.osrfoundation.org/view/ign-garden/job/ignition_utils-ci-gz-utils2-homebrew-amd64/21/

### Sequential GUI tests

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-gz-gui7-homebrew-amd64&build=33)](https://build.osrfoundation.org/view/ign-garden/job/ignition_gui-ci-gz-gui7-homebrew-amd64/33/) https://build.osrfoundation.org/view/ign-garden/job/ignition_gui-ci-gz-gui7-homebrew-amd64/33/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-gz-gui7-homebrew-amd64&build=34)](https://build.osrfoundation.org/view/ign-garden/job/ignition_gui-ci-gz-gui7-homebrew-amd64/34/) https://build.osrfoundation.org/view/ign-garden/job/ignition_gui-ci-gz-gui7-homebrew-amd64/34/