### PR TITLE
Use right short name for Mac CI jobs using gz-sim branches

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -711,6 +711,10 @@ gz_software.each { gz_sw ->
       }
 
       def bottle_name = "ignition-${gz_sw}${major_version}"
+      // For transiting, use always gz-sim new name since new versions won't
+      // have ign-gazebo aliases
+      if ("${gz_sw}" == "sim" || "${gz_sw}" == "gazebo")
+        bottle_name = "gz-sim${major_version}"
 
       steps {
        shell("""\


### PR DESCRIPTION
Quick and ugly fix for https://github.com/gazebo-tooling/release-tools/pull/885#issuecomment-1460951173 . The whole file is quite messy and would needs a big cleanup. That or wait until Citadel and Fortress are EOL and we can remove all references to ignition-gazebo.