### PR TITLE
Avoid docker cache for SOURCE_DEFINED_DEPS

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -295,7 +295,7 @@ cat >> Dockerfile << DELIM_DOCKER31
 # to run apt-get update again
 RUN (apt-get update || (rm -rf /var/lib/apt/lists/* && apt-get update)) \
  && apt-get dist-upgrade -y \
- && apt-get install -y ${SOURCE_DEFINED_DEPS}
+ && apt-get install -y ${SOURCE_DEFINED_DEPS} \
  && apt-get clean
 
 # Map the workspace into the container

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -203,9 +203,6 @@ RUN apt-get ${APT_PARAMS} update && \\
     apt-get install -y dirmngr git python3 python3-docopt python3-yaml python3-distro
 DELIM_DOCKER_DIRMNGR
 
-# Install necessary repositories using gzdev
-dockerfile_install_gzdev_repos
-
 if ${USE_ROS_REPO}; then
   if ${ROS2}; then
 cat >> Dockerfile << DELIM_ROS_REPO
@@ -266,8 +263,9 @@ SOURCE_DEFINED_DEPS="$(sort -u $(find ${DEPENDENCIES_PATH_TO_SEARCH} -iname 'pac
 
 # Packages that will be installed and cached by docker. In a non-cache
 # run below, the docker script will check for the latest updates
-# SOURCE_DEFINED_DEPS can not be cached before this point since the
+# Note: SOURCE_DEFINED_DEPS can not be cached before this point since the
 # osrfoundation repositories can be different (stable, prerelease, nightly)
+# through the different builds if gzdev configuration changes.
 PACKAGES_CACHE_AND_CHECK_UPDATES="${BASE_DEPENDENCIES} ${DEPENDENCY_PKGS}"
 
 if $USE_GPU_DOCKER; then


### PR DESCRIPTION
Caching gz packages is generating problems when gzdev changes the configuration of project to install different packages.osrfoundation.org repositories (stable, nightly or prerelease), i.e: https://github.com/gazebo-tooling/gzdev/pull/64.

When using a new repository that expects to have newer versions (i.e: prerelease on top of stable) this is perfectly fine and the release scripts will work nicely. But when that change is reverted and the build needs to remove a repository with newer versions installed, that is problematic since the packages are already in docker cache installed.

This PR removes the caching of `SOURCE_DEFINED_DEPS` to leave mostly base system packages cached. It also removes the monthly invalidation since seems to me to have a little use and simplifies the code.
