### PR TITLE
Implement a locking system to orchestrate releasing of ros_gz

### DIFF
--- a/jenkins-scripts/dsl/ros_gz_bridge.dsl
+++ b/jenkins-scripts/dsl/ros_gz_bridge.dsl
@@ -69,6 +69,30 @@ bridge_packages.each { pkg ->
     }
 
 
+    // Blocks to control dependencies
+    projects_to_blockon = []
+    if ("${pkg}" == 'ros_gz_sim_demos')
+      projects_to_blockon = ["ros-gz-sim-${postfix_job_str}",
+                            "ros-gz-bridge-${postfix_job_str}",
+                            "ros-gz-image-${postfix_job_str}"]
+    else if ("${pkg}" == 'ros_gz_image')
+      projects_to_blockon = ["ros-gz-bridge-${postfix_job_str}"]
+    else if ("${pkg}" == 'ros_gz_bridge')
+      projects_to_blockon = ["ros-gz-interfaces-${postfix_job_str}"]
+    else if ("${pkg}" == 'ros_gz')
+      projects_to_blockon = ["ros-gz-sim-demos-${postfix_job_str}",
+                            "ros-gz-sim-${postfix_job_str}",
+                            "ros-gz-bridge-${postfix_job_str}",
+                            "ros-gz-image-${postfix_job_str}"]
+
+    if (projects_to_blockon) {
+      blockOn(projects_to_blockon) {
+        blockLevel('GLOBAL')
+        scanQueueFor('ALL')
+      }
+    }
+
+
     steps {
       systemGroovyCommand("""\
           build.setDescription(


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/895

Complements #896 by adding a locking system to avoid race conditions when releasing ros_gz bloom packages.
