### PR TITLE
dsl: disable monterey bottles for now

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Job
 Globals.default_emails = "jrivero@osrfoundation.org, scpeters@osrfoundation.org"
 
 // first distro in list is used as touchstone
-brew_supported_distros         = [ "bigsur", "monterey" ]
+brew_supported_distros         = [ "bigsur" ]
 bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_updater'
 bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'


### PR DESCRIPTION
We are having trouble with our macOS Monterey machine, so disable Monterey bottle builds for now. This is not a big deal, as we can build the missing Monterey bottles once a working machine is back online using the syntax for newly supported distros:

* https://github.com/osrf/homebrew-simulation#building-bottles-for-newly-supported-macos-distributions