### PR TITLE
ABI script: get correct header paths

### DIFF
--- a/jenkins-scripts/docker/gazebo-abichecker.bash
+++ b/jenkins-scripts/docker/gazebo-abichecker.bash
@@ -17,6 +17,7 @@ fi
 . ${SCRIPT_DIR}/lib/_gazebo_version_hook.bash
 
 export ABI_JOB_SOFTWARE_NAME="gazebo-classic"
+export ABI_JOB_HEADER_PREFIX="gazebo-*"
 export ABI_JOB_REPOS="stable"
 export ABI_JOB_PKG_DEPENDENCIES_VAR_NAME="GAZEBO_BASE_DEPENDENCIES"
 export ABI_JOB_IGNORE_HEADERS="gazebo/GIMPACT gazebo/opcode gazebo/test"

--- a/jenkins-scripts/docker/ignition-abichecker.bash
+++ b/jenkins-scripts/docker/ignition-abichecker.bash
@@ -32,6 +32,8 @@ export GZ_NAME_PREFIX_MAJOR_VERSION=$(\
   ${WORKSPACE}/${ABI_JOB_SOFTWARE_NAME}/CMakeLists.txt)
 export ${GZ_NAME_PREFIX}_MAJOR_VERSION=${GZ_NAME_PREFIX_MAJOR_VERSION}
 
+export ABI_JOB_HEADER_PREFIX=${ABI_JOB_SOFTWARE_NAME/[ignz]*-/}[0-9]*
+
 # check if NEED_C17_COMPILER should be set
 if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo" ]] || \
   [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-physics" ]] || \

--- a/jenkins-scripts/docker/ignition-abichecker.bash
+++ b/jenkins-scripts/docker/ignition-abichecker.bash
@@ -32,7 +32,24 @@ export GZ_NAME_PREFIX_MAJOR_VERSION=$(\
   ${WORKSPACE}/${ABI_JOB_SOFTWARE_NAME}/CMakeLists.txt)
 export ${GZ_NAME_PREFIX}_MAJOR_VERSION=${GZ_NAME_PREFIX_MAJOR_VERSION}
 
-export ABI_JOB_HEADER_PREFIX=${ABI_JOB_SOFTWARE_NAME/[ignz]*-/}[0-9]*
+# Set the ABI_JOB_HEADER_PREFIX variable to help find the header locations.
+#
+# Since gz-cmake include paths are like the following:
+# <prefix>/include/ignition/gazebo6/*
+# <prefix>/include/ignition/math6/*
+# <prefix>/include/gz/math7/*
+# <prefix>/include/gz/sim7/*
+#
+# Set ABI_JOB_HEADER_PREFIX to match the last subfolder:
+#   gazebo6, math6, math7, sim7
+if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo" && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 7 ]]
+then
+  # special case for gz-sim7+
+  export ABI_JOB_HEADER_PREFIX=sim[0-9]*
+else
+  # otherwise, strip the ign- or gz- prefix and append "[0-9]*"
+  export ABI_JOB_HEADER_PREFIX=${ABI_JOB_SOFTWARE_NAME/[ignz]*-/}[0-9]*
+fi
 
 # check if NEED_C17_COMPILER should be set
 if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo" ]] || \

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -9,6 +9,7 @@
 # ABI_JOB_PKG_DEPENDENCIES: (optional) list (space separated) of pkg dependencies
 # ABI_JOB_PKG_DEPENDENCIES_VAR_NAME: (option) variable in archive to get dependencies from
 # ABI_JOB_CMAKE_PARAMS: (option) cmake parameters to be pased to cmake configuration
+# ABI_JOB_HEADER_PREFIX: (optional) hint for identifying header install prefix
 # ABI_JOB_IGNORE_HEADERS: (optional) relative (to root project path) list (space separated)
 #                         of path headers to ignore
 # ABI_JOB_EXTRA_GCC_OPTIONS: (optional) inject gcc_options in the descriptor file
@@ -32,6 +33,9 @@ if [[ "${ABI_JOB_PKG_DEPENDENCIES_VAR_NAME}" != "" ]]; then
 fi
 if [[ -n "${DART_FROM_PKGS_VAR_NAME}" ]]; then
   eval DART_FROM_PKGS="\$${DART_FROM_PKGS_VAR_NAME}"
+fi
+if [[ -z "${ABI_JOB_HEADER_PREFIX}" ]]; then
+  eval ABI_JOB_HEADER_PREFIX="\$${ABI_JOB_SOFTWARE_NAME}-*"
 fi
 
 ABI_CXX_STANDARD=c++11
@@ -68,7 +72,7 @@ cmake ${ABI_JOB_CMAKE_PARAMS} \\
   /tmp/${ABI_JOB_SOFTWARE_NAME}
 make -j${MAKE_JOBS}
 sudo make install
-DEST_DIR=\$(find /usr/local/destination_branch/include -name ${ABI_JOB_SOFTWARE_NAME}-* -type d | sed -e 's:.*/::')
+DEST_DIR=\$(find /usr/local/destination_branch/include -name ${ABI_JOB_HEADER_PREFIX} -type d | sed -e 's:.*/include/::')
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: compile and install branch: ${SRC_BRANCH}'
@@ -89,7 +93,7 @@ cmake ${ABI_JOB_CMAKE_PARAMS} \\
   /tmp/${ABI_JOB_SOFTWARE_NAME}
 make -j${MAKE_JOBS}
 sudo make install
-SRC_DIR=\$(find /usr/local/source_branch/include -name ${ABI_JOB_SOFTWARE_NAME}-* -type d | sed -e 's:.*/::')
+SRC_DIR=\$(find /usr/local/source_branch/include -name ${ABI_JOB_HEADER_PREFIX} -type d | sed -e 's:.*/include/::')
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install the ABI checker'

--- a/jenkins-scripts/docker/sdformat-abichecker.bash
+++ b/jenkins-scripts/docker/sdformat-abichecker.bash
@@ -23,6 +23,10 @@ if [[ ${SDFORMAT_MAJOR_VERSION} -ge 8 ]]; then
   export NEED_C17_COMPILER=true
 fi
 
+if [[ ${SDFORMAT_MAJOR_VERSION} -ge 10 ]]; then
+  export ABI_JOB_HEADER_PREFIX=sdformat[0-9]*
+fi
+
 # default to use stable repos
 export ABI_JOB_REPOS="stable"
 


### PR DESCRIPTION
Fixes #890.

The ABI script currently assumes that the headers are installed in a subfolder that
starts with the `ABI_JOB_HEADER_PREFIX` variable and a `-`, which only works for `sdformat-9` but requires adjustment for most other packages. This adds an `ABI_JOB_HEADER_PREFIX` variable to help locate the header folder.