### PR TITLE
DSL: ignore nodes labeled as test-instance

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -119,4 +119,8 @@ class Globals
    static String get_ros2_development_distro() {
      return 'rolling'
    }
+
+   static String nontest_label(String original_label) {
+    return "(${original_label}) && !test-instance"
+   }
 }

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -59,7 +59,7 @@ release_job.with
    String PR_URL_export_file_name = 'pull_request_created.properties'
    String PR_URL_export_file = '${WORKSPACE}/' + PR_URL_export_file_name
 
-   label "master"
+   label Globals.nontest_label("master")
 
    wrappers {
         preBuildCleanup()
@@ -246,7 +246,7 @@ GenericRemoteToken.create(bottle_job_hash_updater)
 include_common_params(bottle_job_hash_updater)
 bottle_job_hash_updater.with
 {
-  label "master"
+  label Globals.nontest_label("master")
 
   wrappers
   {

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -44,7 +44,7 @@ testing_vcpkg_job.with
 
     steps
     {
-      label "win_testing"
+      label Globals.nontest_label("win_testing")
 
       batchFile("""\
             call "%WORKSPACE%/scripts/jenkins-scripts/vcpkg-bootstrap.bat" || exit /B %errorlevel%
@@ -58,7 +58,7 @@ def reprepro = job("reprepro_importer")
 OSRFUNIXBase.create(reprepro)
 reprepro.with
 {
-  label "packages"
+  label Globals.nontest_label("packages")
 
   parameters
   {

--- a/jenkins-scripts/dsl/debian.dsl
+++ b/jenkins-scripts/dsl/debian.dsl
@@ -89,7 +89,7 @@ OSRFLinuxBase.create(ratt_pkg_job)
 ratt_pkg_job.with
 {
   // use only the most powerful nodes
-  label "large-memory"
+  label Globals.nontest_label("large-memory")
 
   parameters
   {

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -23,7 +23,7 @@ release_repo_debbuilds.each { software ->
   build_pkg_job.with
   {
     // use only the most powerful nodes
-    label "large-memory"
+    label Globals.nontest_label("large-memory")
 
     steps {
       shell("""\
@@ -43,7 +43,7 @@ gbp_repo_debbuilds.each { software ->
   build_pkg_job.with
   {
     // use only the most powerful nodes
-    label "large-memory"
+    label Globals.nontest_label("large-memory")
 
     parameters
     {

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -57,7 +57,7 @@ void generate_install_job(Job job, gz_branch, distro, arch, use_osrf_repos = fal
         gzdev_str = "export GZDEV_PROJECT_NAME=${gz_branch}"
 
     // Need gpu for running the runtime test
-    label "gpu-reliable"
+    label Globals.nontest_label("gpu-reliable")
 
     steps {
       shell("""\
@@ -91,7 +91,7 @@ abi_distro.each { distro ->
     GenericAnyJobGitHub.create(abi_job, 'gazebosim/gazebo-classic', gazebo_supported_branches)
     abi_job.with
     {
-      label "large-memory"
+      label Globals.nontest_label("large-memory")
 
       steps {
         shell("""\
@@ -122,7 +122,7 @@ ci_distro.each { distro ->
       OSRFLinuxCompilationAnyGitHub.create(gazebo_ci_any_job, "gazebosim/gazebo-classic")
       gazebo_ci_any_job.with
       {
-        label "gpu-reliable && large-memory"
+        label Globals.nontest_label("gpu-reliable && large-memory")
 
         steps
         {
@@ -164,7 +164,7 @@ other_supported_distros.each { distro ->
 
         // gazebo builds require a powerful node not to take too long and
         // block backup for hours
-        label "gpu-reliable && large-memory"
+        label Globals.nontest_label("gpu-reliable && large-memory")
 
         triggers {
           scm('@daily')
@@ -205,7 +205,7 @@ ci_distro.each { distro ->
           stringParam('IGN_TRANSPORT_BRANCH', 'main', 'ignition transport branch to use')
         }
 
-        label "gpu-reliable"
+        label Globals.nontest_label("gpu-reliable")
 
         steps {
             shell("""\
@@ -242,7 +242,7 @@ gazebo_supported_branches.each { branch ->
 
         gazebo_ci_job.with
         {
-          label "gpu-reliable && large-memory"
+          label Globals.nontest_label("gpu-reliable && large-memory")
 
           triggers {
             scm('@daily')
@@ -276,7 +276,7 @@ ci_distro.each { distro ->
 
     gazebo_ci_job.with
     {
-      label "gpu-reliable && large-memory"
+      label Globals.nontest_label("gpu-reliable && large-memory")
 
       triggers {
         scm('@weekly')
@@ -309,7 +309,7 @@ ci_distro.each { distro ->
           scm('@daily')
         }
 
-        label "gpu-reliable && large-memory"
+        label Globals.nontest_label("gpu-reliable && large-memory")
 
         // Problem with the compilation of Gazebo under bullseyes
         // See: https://github.com/gazebo-tooling/release-tools/issues/129
@@ -341,7 +341,7 @@ ci_distro.each { distro ->
 
       gazebo_ci_job.with
       {
-        label "gpu-reliable && large-memory"
+        label Globals.nontest_label("gpu-reliable && large-memory")
 
         triggers {
           scm('@daily')
@@ -376,7 +376,7 @@ all_supported_distros.each { distro ->
         cron(Globals.CRON_EVERY_THREE_DAYS)
       }
 
-      label "gpu-reliable"
+      label Globals.nontest_label("gpu-reliable")
 
       steps {
         shell("""\
@@ -447,7 +447,7 @@ def gazebo_brew_ci_any_job = job(ci_build_any_job_name_brew)
 OSRFBrewCompilationAnyGitHub.create(gazebo_brew_ci_any_job, "gazebosim/gazebo-classic")
 gazebo_brew_ci_any_job.with
 {
-    label "osx"
+    label Globals.nontest_label("osx")
 
     steps {
       shell("""\

--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -115,7 +115,7 @@ void include_common_params(Job gazebo_ros_pkgs_job,
         ros2_str = "export ROS2=false"
       }
 
-      label "gpu-reliable"
+      label Globals.nontest_label("gpu-reliable")
 
       steps {
         shell("""\

--- a/jenkins-scripts/dsl/gzdev.dsl
+++ b/jenkins-scripts/dsl/gzdev.dsl
@@ -55,7 +55,7 @@ supported_distros.each { distro ->
     gzdev_any_job.with
     {
       // use only the most powerful nodes
-      label "large-memory"
+      label Globals.nontest_label("large-memory")
 
       steps {
         shell("""\

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -308,7 +308,7 @@ void include_gpu_label_if_needed(Job job, String gz_software_name)
     gz_gpu.each { gz_each ->
       if (gz_software_name == gz_each)
       {
-        label "gpu-reliable"
+        label Globals.nontest_label("gpu-reliable")
 
         // unstable build if missing valid gpu display
         publishers {
@@ -373,7 +373,7 @@ gz_software.each { gz_sw ->
         extra_str=""
         if (gz_sw == 'physics')
         {
-          label "huge-memory"
+          label Globals.nontest_label("huge-memory")
           // on ARM native nodes in buildfarm we need to restrict to 1 the
           // compilation threads to avoid OOM killer
           extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=1; fi'
@@ -421,7 +421,7 @@ gz_software.each { gz_sw ->
     gz_ci_any_job.with
     {
       if (gz_sw == 'physics')
-        label "huge-memory"
+        label Globals.nontest_label("huge-memory")
 
       steps
       {
@@ -529,7 +529,7 @@ void generate_ci_job(gz_ci_job, gz_sw, branch, distro, arch,
   gz_ci_job.with
   {
     if (gz_sw == 'physics')
-      label "huge-memory"
+      label Globals.nontest_label("huge-memory")
 
     steps {
       shell("""\

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -361,7 +361,7 @@ void generate_install_job(prefix, gz_collection_name, distro, arch)
     def dev_package = "${prefix}-${gz_collection_name}"
     def job_name = 'ign_launch-install-test-job.bash'
 
-    label "gpu-reliable"
+    label Globals.nontest_label("gpu-reliable")
 
     steps {
      shell("""\
@@ -425,7 +425,7 @@ gz_collections.each { gz_collection ->
       }
 
       // Designed to be run manually. No triggers.
-      label "gpu-reliable"
+      label Globals.nontest_label("gpu-reliable")
 
       steps {
         systemGroovyCommand("""\
@@ -599,7 +599,7 @@ OSRFUNIXBase.create(nightly_scheduler_job)
 
 nightly_scheduler_job.with
 {
-  label "master"
+  label Globals.nontest_label("master")
 
   parameters
   {

--- a/jenkins-scripts/dsl/ros_gz_bridge.dsl
+++ b/jenkins-scripts/dsl/ros_gz_bridge.dsl
@@ -156,7 +156,7 @@ install_test_job.with
   }
 
   // Designed to be run manually. No triggers.
-  label "gpu-reliable"
+  label Globals.nontest_label("gpu-reliable")
 
   steps {
     systemGroovyCommand("""\


### PR DESCRIPTION
Support to define a node label called `test-instance` that will be ignored by all the works.

The implementation adds a new helper function to Globals to supply the logic to ignore the test label.