### PR TITLE
Explicit support for MSVC_VERSION_REQUIRED in release-tools

### DIFF
--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -1,3 +1,8 @@
+:: legacy option was to use MSVC19 by default with no configuration
+if NOT DEFINED MSVC_VERSION_REQUIRED (
+  set MSVC_VERSION_REQUIRED=2019
+)
+
 if exist D:\vcpkg (
   set VCPKG_DIR=D:\vcpkg
 ) else if exist C:\vcpkg (

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -38,7 +38,7 @@ IF %PLATFORM_TO_BUILD% == x86 (
 
 echo "Configure the VC++ compilation"
 set MSVC22_ON_WIN32_C=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat
-:: 2019 versions
+:: 2019 versions 
 set MSVC_ON_WIN64_E=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
 set MSVC_ON_WIN32_E=C:\Program Files\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
 set MSVC_ON_WIN64_C=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat
@@ -48,19 +48,22 @@ set LIB_DIR="%~dp0"
 call %LIB_DIR%\windows_env_vars.bat
 set PATH=%PATH%;%VCPKG_DIR%\installed\%VCPKG_DEFAULT_TRIPLET%\bin
 
-IF exist "%MSVC22_ON_WIN32_C%" (
+IF %MSVC_VERSION_REQUIRED% == 22 (
    call "%MSVC22_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
-) ELSE IF exist "%MSVC_ON_WIN64_E%" (
-   call "%MSVC_ON_WIN64_E%" %MSVC_KEYWORD% || goto %win_lib% :error
-) ELSE IF exist "%MSVC_ON_WIN32_E%" (
-   call "%MSVC_ON_WIN32_E%" %MSVC_KEYWORD% || goto %win_lib% :error
-) ELSE IF exist "%MSVC_ON_WIN64_C%" (
-   call "%MSVC_ON_WIN64_C%" %MSVC_KEYWORD% || goto %win_lib% :error
-) ELSE IF exist "%MSVC_ON_WIN32_C%" (
-   call "%MSVC_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
-) ELSE (
-   echo "Could not find the vcvarsall.bat file"
-   exit -1
+) else (
+  :: legacy option was to use MSVC19 by default with no configuration
+  IF exist "%MSVC_ON_WIN64_E%" (
+     call "%MSVC_ON_WIN64_E%" %MSVC_KEYWORD% || goto %win_lib% :error
+  ) ELSE IF exist "%MSVC_ON_WIN32_E%" (
+     call "%MSVC_ON_WIN32_E%" %MSVC_KEYWORD% || goto %win_lib% :error
+  ) ELSE IF exist "%MSVC_ON_WIN64_C%" (
+     call "%MSVC_ON_WIN64_C%" %MSVC_KEYWORD% || goto %win_lib% :error
+  ) ELSE IF exist "%MSVC_ON_WIN32_C%" (
+     call "%MSVC_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
+  ) ELSE (
+     echo "Could not find the vcvarsall.bat file"
+     exit -1
+  )
 )
 
 goto :EOF

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -48,27 +48,32 @@ set LIB_DIR="%~dp0"
 call %LIB_DIR%\windows_env_vars.bat
 set PATH=%PATH%;%VCPKG_DIR%\installed\%VCPKG_DEFAULT_TRIPLET%\bin
 
-IF [%MSVC_VERSION_REQUIRED%] == [2022] (
-  IF exist "%MSVC22_ON_WIN32_C%" (
-   call "%MSVC22_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
- ) ELSE (
-   :: TODO: implement other versions of MSVC 2022 if needed
-   echo "Not found a valid version of 2022 MSVC. Only Community is supported"
-   exit 1
- )
-) ELSE IF [%MSVC_VERSION_REQUIRED%] == [2019] (
-  IF exist "%MSVC_ON_WIN64_E%" (
-     call "%MSVC_ON_WIN64_E%" %MSVC_KEYWORD% || goto %win_lib% :error
-  ) ELSE IF exist "%MSVC_ON_WIN32_E%" (
-     call "%MSVC_ON_WIN32_E%" %MSVC_KEYWORD% || goto %win_lib% :error
-  ) ELSE IF exist "%MSVC_ON_WIN64_C%" (
-     call "%MSVC_ON_WIN64_C%" %MSVC_KEYWORD% || goto %win_lib% :error
-  ) ELSE IF exist "%MSVC_ON_WIN32_C%" (
-     call "%MSVC_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
-  ) ELSE (
-     echo "Not found a valid version of 
-     exit 1
-  )
+:: Leave disabled until https://github.com/gazebo-tooling/release-tools/issues/910 is fix and MSVC2022
+:: is being required by a version of Gazebo.
+::
+:: IF [%MSVC_VERSION_REQUIRED%] == [2022] (
+::   IF exist "%MSVC22_ON_WIN32_C%" (
+::    call "%MSVC22_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
+::  ) ELSE (
+::    :: TODO: implement other versions of MSVC 2022 if needed
+::    echo "Not found a valid version of 2022 MSVC. Only Community is supported"
+::    exit 1
+::  )
+:: ) ELSE 
+
+IF [%MSVC_VERSION_REQUIRED%] == [2019] (
+    IF exist "%MSVC_ON_WIN64_E%" (
+       call "%MSVC_ON_WIN64_E%" %MSVC_KEYWORD% || goto %win_lib% :error
+    ) ELSE IF exist "%MSVC_ON_WIN32_E%" (
+       call "%MSVC_ON_WIN32_E%" %MSVC_KEYWORD% || goto %win_lib% :error
+    ) ELSE IF exist "%MSVC_ON_WIN64_C%" (
+       call "%MSVC_ON_WIN64_C%" %MSVC_KEYWORD% || goto %win_lib% :error
+    ) ELSE IF exist "%MSVC_ON_WIN32_C%" (
+       call "%MSVC_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
+    ) ELSE (
+       echo "Not found a valid version of the MSVC19 vcvarsall file"
+       exit 1
+    )
 ) ELSE (
   echo "MSVC_VERSION_REQUIRED variable not found. This is a bug"
   exit 1

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -48,10 +48,15 @@ set LIB_DIR="%~dp0"
 call %LIB_DIR%\windows_env_vars.bat
 set PATH=%PATH%;%VCPKG_DIR%\installed\%VCPKG_DEFAULT_TRIPLET%\bin
 
-IF %MSVC_VERSION_REQUIRED% == 22 (
+IF [%MSVC_VERSION_REQUIRED%] == [2022] (
+  IF exist "%MSVC22_ON_WIN32_C%" (
    call "%MSVC22_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
-) else (
-  :: legacy option was to use MSVC19 by default with no configuration
+ ) ELSE (
+   :: TODO: implement other versions of MSVC 2022 if needed
+   echo "Not found a valid version of 2022 MSVC. Only Community is supported"
+   exit 1
+ )
+) ELSE IF [%MSVC_VERSION_REQUIRED%] == [2019] (
   IF exist "%MSVC_ON_WIN64_E%" (
      call "%MSVC_ON_WIN64_E%" %MSVC_KEYWORD% || goto %win_lib% :error
   ) ELSE IF exist "%MSVC_ON_WIN32_E%" (
@@ -61,9 +66,12 @@ IF %MSVC_VERSION_REQUIRED% == 22 (
   ) ELSE IF exist "%MSVC_ON_WIN32_C%" (
      call "%MSVC_ON_WIN32_C%" %MSVC_KEYWORD% || goto %win_lib% :error
   ) ELSE (
-     echo "Could not find the vcvarsall.bat file"
-     exit -1
+     echo "Not found a valid version of 
+     exit 1
   )
+) ELSE (
+  echo "MSVC_VERSION_REQUIRED variable not found. This is a bug"
+  exit 1
 )
 
 goto :EOF


### PR DESCRIPTION
Initial work to support multiple compilers on Windows and make the script to explicitly declared which one to use.

The 2022 MSVC support is left commented until #910 is fixed . Leave the code enabled will introduce a hidden bug since vcpkg will be using 2022 is available when the existing distributions are using 2019.

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_utils-pr-win&build=301)](https://build.osrfoundation.org/job/ign_utils-pr-win/301/)