### PR TITLE
Remove win_rendering tag from windows_ci  job

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -777,13 +777,6 @@ gz_software.each { gz_sw ->
                                     enable_cmake_warnings(gz_sw))
   gz_win_ci_any_job.with
   {
-      if (gz_sw == 'gui' ||
-          gz_sw == 'rendering' ||
-          gz_sw == 'sensors' ||
-          gz_sw == 'gazebo')
-        label('win_rendering')
-
-
       steps {
         batchFile("""\
               call "./scripts/jenkins-scripts/ign_${gz_sw}-default-devel-windows-amd64.bat"
@@ -837,12 +830,6 @@ gz_software.each { gz_sw ->
                 call "./scripts/jenkins-scripts/ign_${gz_sw}-default-devel-windows-amd64.bat"
                 """.stripIndent())
         }
-
-        if (gz_sw == 'gui' ||
-            gz_sw == 'rendering' ||
-            gz_sw == 'sensors' ||
-            gz_sw == 'gazebo')
-          label('win_rendering')
     }
   }
 }


### PR DESCRIPTION
**DESCRIPTION**
We remove win_rendering label since it's no longer needed given that all windows agents in the buildfarm can manage jobs that need gui/sensors/sim.
This reverts partially changes introduced in #847 .

**CHANGES**
 :heavy_minus_sign: win_rendering tag introduction when gui/sensors/sim is matched.