### PR TITLE
nvidia mismatch recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 .pyc
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+jenkins-scripts/dsl/job-dsl-core-1.77-standalone.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,1 @@
 .pyc
-### VS Code ###
-.vscode/
-
-### Mac OS ###
-.DS_Store
-jenkins-scripts/dsl/job-dsl-core-1.77-standalone.jar

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -42,6 +42,13 @@ class OSRFUNIXBase extends OSRFBase
              """.stripIndent())
       }
       publishers {
+        configure { project -> 
+          project / publishers / 'com.chikli.hudson.plugin.naginator.NaginatorPublisher' {
+            regexpForRerun(this.regexNvidiaLabel)
+            checkRegexp(true)
+          }
+
+        }
         postBuildScripts {
           steps{
             conditionalSteps {
@@ -85,10 +92,6 @@ class OSRFUNIXBase extends OSRFBase
         retryBuild {
           fixedDelay(70)
           retryLimit(1)
-          configure { 
-            regexpForRerun(this.regexNvidiaLabel)
-            checkRegexp(true)
-          }
         }
       }
     }

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -39,17 +39,6 @@ class OSRFUNIXBase extends OSRFBase
              """.stripIndent())
       }
       publishers {
-        // Manual insertion of xml for Naginator plugin because of this issue https://issues.jenkins.io/browse/JENKINS-66458
-        configure { project -> 
-          project / publishers / 'com.chikli.hudson.plugin.naginator.NaginatorPublisher' {
-            regexpForRerun("nvml error: driver/library version mismatch")
-            checkRegexp(true)
-            maxSchedule(1)
-            delay(class: 'com.chikli.hudson.plugin.naginator.FixedDelay') {
-              delay(70)
-            }
-          }
-        }
         postBuildScripts {
           steps{
             conditionalSteps {
@@ -89,6 +78,17 @@ class OSRFUNIXBase extends OSRFBase
           }
           onlyIfBuildSucceeds(false)
           onlyIfBuildFails(true)
+        }
+        // Manual insertion of xml for Naginator plugin because of this issue https://issues.jenkins.io/browse/JENKINS-66458
+        configure { project -> 
+          project / publishers / 'com.chikli.hudson.plugin.naginator.NaginatorPublisher' {
+            regexpForRerun("nvml error: driver/library version mismatch")
+            checkRegexp(true)
+            maxSchedule(1)
+            delay(class: 'com.chikli.hudson.plugin.naginator.FixedDelay') {
+              delay(70)
+            }
+          }
         }
       }
     }

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -10,10 +10,10 @@ import javaposse.jobdsl.dsl.Job
      - allow concurrent builds
      - bash: RTOOLS checkout
 */
-class OSRFUNIXBase extends OSRFBase 
+class OSRFUNIXBase extends OSRFBase
 {
-  static void create(Job job) 
-  { 
+  static void create(Job job)
+  {
     OSRFBase.create(job)
 
     job.with
@@ -96,5 +96,4 @@ class OSRFUNIXBase extends OSRFBase
         
     }
   }
-
 }

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -55,7 +55,7 @@ class OSRFUNIXBase extends OSRFBase
 
                         println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
                         if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
-                          println("Build failed for other reason than NVIDIA error - Not performing any more steps")
+                          println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any recovery automatic recovery step")
                           return 0;
                         } else {
                           try {

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -38,62 +38,61 @@ class OSRFUNIXBase extends OSRFBase
              git clone https://github.com/gazebo-tooling/release-tools scripts -b \$RTOOLS_BRANCH
              """.stripIndent())
       }
-          publishers {
-            postBuildScripts {
-              steps{
-              conditionalSteps {
-                  condition {
-                      expression('(.)*gpu-nvidia(.)*','${NODE_LABELS}')
-                  }
-                  steps {
-                     systemGroovyCommand('''\
-                        import hudson.model.Cause.UpstreamCause;
-                        import hudson.model.*;
-                    
-                        def node = build.getBuiltOn()
-                        def old_labels = node.getLabelString()
+      publishers {
+        postBuildScripts {
+          steps{
+            conditionalSteps {
+              condition {
+                // NOTE: The starting whitespace is important to match exactly to a label gpu-nvidia and not no-gpu-nvidia
+                expression(' gpu-nvidia+','${NODE_LABELS}')
+              }
+              steps {
+                systemGroovyCommand('''\
+                  import hudson.model.Cause.UpstreamCause;
+                  import hudson.model.*;
 
-                        println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
-                        if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
-                          println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any recovery automatic recovery step")
-                          return 0;
-                        } else {
-                          try {
-                            println("Removing labels and adding 'recovery-process' label to node")
-                            node.setLabelString("recovery-process")
+                  def node = build.getBuiltOn()
+                  def old_labels = node.getLabelString()
 
-                            println("Requeuing job :" + build.project.name)
-                            def job = Hudson.instance.getJob(build.project.name)
+                  println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
+                  if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
+                    println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any recovery automatic recovery step")
+                    return 0;
+                  } else {
+                    try {
+                      println(" PROBLEM: NVIDIA driver/library version mismatch was detected in the log. Try to automatically resolve it:")
+                      println("Removing labels and adding 'recovery-process' label to node")
+                      node.setLabelString("recovery-process")
+                      println("Requeuing job :" + build.project.name)
+                      def job = Hudson.instance.getJob(build.project.name)
                           
-                            def params = build.getAllActions().find{ it instanceof ParametersAction }?.parameters
-                            def cause = new UpstreamCause(build)
-                            // wait 70s to build again so that the computer has time to reboot (e.g only one agent available)
-                            def scheduled = job.scheduleBuild2(70, cause, new ParametersAction(params))
-                            if(!scheduled) {
-                              throw new Exception("Job could not be requeued!")
-                            }
-                            println("Job requeued!")
+                      def params = build.getAllActions().find{ it instanceof ParametersAction }?.parameters
+                      def cause = new UpstreamCause(build)
+                      // wait 70s to build again so that the computer has time to reboot (e.g only one agent available)
+                      def scheduled = job.scheduleBuild2(70, cause, new ParametersAction(params))
+                      if(!scheduled) {
+                        throw new Exception("Job could not be requeued!")
+                      }
+                      println("Job requeued!")
 
-                          } catch (Exception ex) {
-                            println("ERROR - CANNOT PERFORM RECOVERY ACTIONS FOR NVIDIA ERROR")
-                            println("Restoring to previous state")
-                            node.setLabelString(old_labels)
-                            throw ex
-                          }
-                        }
-                        println("# END SECTION: NVIDIA MISMATCH RECOVERY")
-                        '''.stripIndent()
-                      )
-                      shell("""sudo shutdown -r +1""")
+                    } catch (Exception ex) {
+                      println("ERROR - CANNOT PERFORM RECOVERY ACTIONS FOR NVIDIA ERROR")
+                      println("Restoring to previous state")
+                      node.setLabelString(old_labels)
+                      throw ex
+                    }
                   }
-                }
+                  println("# END SECTION: NVIDIA MISMATCH RECOVERY")
+                  '''.stripIndent()
+                )
+                shell("""sudo shutdown -r +1""")
               }
-                onlyIfBuildSucceeds(false)
-                onlyIfBuildFails(true)
-              }
-              
+            }
           }
-        
+          onlyIfBuildSucceeds(false)
+          onlyIfBuildFails(true)
+        }
+      }
     }
   }
 }

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -10,10 +10,10 @@ import javaposse.jobdsl.dsl.Job
      - allow concurrent builds
      - bash: RTOOLS checkout
 */
-class OSRFUNIXBase extends OSRFBase
+class OSRFUNIXBase extends OSRFBase 
 {
-  static void create(Job job)
-  {
+  static void create(Job job) 
+  { 
     OSRFBase.create(job)
 
     job.with
@@ -38,6 +38,63 @@ class OSRFUNIXBase extends OSRFBase
              git clone https://github.com/gazebo-tooling/release-tools scripts -b \$RTOOLS_BRANCH
              """.stripIndent())
       }
+          publishers {
+            postBuildScripts {
+              steps{
+              conditionalSteps {
+                  condition {
+                      expression('(.)*gpu-nvidia(.)*','${NODE_LABELS}')
+                  }
+                  steps {
+                     systemGroovyCommand('''\
+                        import hudson.model.Cause.UpstreamCause;
+                        import hudson.model.*;
+                    
+                        def node = build.getBuiltOn()
+                        def old_labels = node.getLabelString()
+
+                        println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
+                        if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
+                          println("Build failed for other reason than NVIDIA error - Not performing any more steps")
+                          return 0;
+                        } else {
+                          try {
+                            println("Removing labels and adding 'recovery-process' label to node")
+                            node.setLabelString("recovery-process")
+
+                            println("Requeuing job :" + build.project.name)
+                            def job = Hudson.instance.getJob(build.project.name)
+                          
+                            def params = build.getAllActions().find{ it instanceof ParametersAction }?.parameters
+                            def cause = new UpstreamCause(build)
+                            // wait 70s to build again so that the computer has time to reboot (e.g only one agent available)
+                            def scheduled = job.scheduleBuild2(70, cause, new ParametersAction(params))
+                            if(!scheduled) {
+                              throw new Exception("Job could not be requeued!")
+                            }
+                            println("Job requeued!")
+
+                          } catch (Exception ex) {
+                            println("ERROR - CANNOT PERFORM RECOVERY ACTIONS FOR NVIDIA ERROR")
+                            println("Restoring to previous state")
+                            node.setLabelString(old_labels)
+                            throw ex
+                          }
+                        }
+                        println("# END SECTION: NVIDIA MISMATCH RECOVERY")
+                        '''.stripIndent()
+                      )
+                      shell("""sudo shutdown -r +1""")
+                  }
+                }
+              }
+                onlyIfBuildSucceeds(false)
+                onlyIfBuildFails(true)
+              }
+              
+          }
+        
     }
   }
+
 }

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -12,9 +12,6 @@ import javaposse.jobdsl.dsl.Job
 */
 class OSRFUNIXBase extends OSRFBase
 {
-  // NOTE: The starting whitespace is important to match exactly to a label gpu-nvidia and not no-gpu-nvidia\
-  static regexNvidiaLabel = ' gpu-nvidia+'
-
   static void create(Job job)
   {
     OSRFBase.create(job)
@@ -45,7 +42,7 @@ class OSRFUNIXBase extends OSRFBase
         // Manual insertion of xml for Naginator plugin because of this issue https://issues.jenkins.io/browse/JENKINS-66458
         configure { project -> 
           project / publishers / 'com.chikli.hudson.plugin.naginator.NaginatorPublisher' {
-            regexpForRerun(this.regexNvidiaLabel)
+            regexpForRerun("nvml error: driver/library version mismatch")
             checkRegexp(true)
             maxSchedule(1)
             delay(class: 'com.chikli.hudson.plugin.naginator.FixedDelay') {
@@ -57,7 +54,7 @@ class OSRFUNIXBase extends OSRFBase
           steps{
             conditionalSteps {
               condition {
-                expression(this.regexNvidiaLabel,'${NODE_LABELS}')
+                expression("(.)* gpu-nvidia (.)*",'${NODE_LABELS}')
               }
               steps {
                 systemGroovyCommand('''\

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -42,12 +42,16 @@ class OSRFUNIXBase extends OSRFBase
              """.stripIndent())
       }
       publishers {
+        // Manual insertion of xml for Naginator plugin because of this issue https://issues.jenkins.io/browse/JENKINS-66458
         configure { project -> 
           project / publishers / 'com.chikli.hudson.plugin.naginator.NaginatorPublisher' {
             regexpForRerun(this.regexNvidiaLabel)
             checkRegexp(true)
+            maxSchedule(1)
+            delay(class: 'com.chikli.hudson.plugin.naginator.FixedDelay') {
+              delay(70)
+            }
           }
-
         }
         postBuildScripts {
           steps{
@@ -88,10 +92,6 @@ class OSRFUNIXBase extends OSRFBase
           }
           onlyIfBuildSucceeds(false)
           onlyIfBuildFails(true)
-        }
-        retryBuild {
-          fixedDelay(70)
-          retryLimit(1)
         }
       }
     }

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -56,7 +56,7 @@ class OSRFUNIXBase extends OSRFBase
                   println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
                   if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
                     println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any recovery automatic recovery step")
-                    return 0;
+                    return 1;
                   } else {
                     try {
                       println(" PROBLEM: NVIDIA driver/library version mismatch was detected in the log. Try to automatically resolve it:")


### PR DESCRIPTION
**DESCRIPTION**

Since  moving to cloud instances for the `nvidia agents` we have encountered issues with versioning resulting in `nvml version mismatch errors` (See [issue](https://github.com/gazebo-tooling/release-tools/issues/912)). This is an unrecoverable error for the builds, and requires manual steps to bring back the agent to a funtional state. 
This PR automates those steps as postbuild actions. If the build failed due to the Nvidia error, we do the following steps: 
1. Remove all labels from current agent and add a `recovery-process` label to indicate that that agent is performing recovery actions, preventing it from taking on any other build.
2. Requeue the job with same parameters with a delay of 70s to give time for the next step. 
3. Schedule a system restart on 1 minute (the delay is needed here so that the postbuild action finishes correctly)


**TESTS**

- [x] Post build actions only run on failed builds [![Build Status](https://build.osrfoundation.org/job/_test_job_from_dsl/41/badge/icon)](https://build.osrfoundation.org/job/_test_job_from_dsl/41/)
- [x]  Post build actions only run on nvidia agents [![Build Status](https://build.osrfoundation.org/job/_test_job_from_dsl/46/badge/icon)](https://build.osrfoundation.org/job/_test_job_from_dsl/46/)
- [x]  Steps run only if `regex` match [![Build Status](https://build.osrfoundation.org/job/_test_job_from_dsl/61/badge/icon)](https://build.osrfoundation.org/job/_test_job_from_dsl/61/)
- [x]  Adds`dummy` not actionable labels to agent to not build jobs between current and restart
<img height="30%" width="80%" src="https://user-images.githubusercontent.com/42071084/236288178-4c780f2a-6f95-49fc-999d-213b5600a26d.png">
- [x] Agent is put back online with correct labels after restart.
<img height="30%" width="80%" src="https://user-images.githubusercontent.com/42071084/236322790-e7b01dd3-6051-4d72-a646-992c4c894e32.png">

- [x] Rebuilds job with same parameters
        Manual rebuild: https://build.osrfoundation.org/job/_test_job_from_dsl/80/
        Automatic rebuild after recovery process: https://build.osrfoundation.org/job/_test_job_from_dsl/81/