### PR TITLE
Add the unstable parser and master label to the nightly_labeler

### DIFF
--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -102,7 +102,7 @@ def nightly_labeler = job("_nightly_node_labeler")
 OSRFBase.create(nightly_labeler)
 nightly_labeler.with
 {
-  label Globals.nontest_label("built-in")
+  label Globals.nontest_label("master")
 
   triggers {
     cron(Globals.CRON_PREPARE_NIGHTLY)
@@ -112,5 +112,17 @@ nightly_labeler.with
   {
     // path root changes from standalone to Jenkins. Be careful
     systemGroovyCommand(readFileFromWorkspace('scripts/jenkins-scripts/tools/label-assignment-backstop.groovy'))
+  }
+
+  publishers
+  {
+    // Added the checker result parser (UNSTABLE if not success)
+    configure { project ->
+      project / publishers << 'hudson.plugins.logparser.LogParserPublisher' {
+        unstableOnWarning true
+        failBuildOnError false
+        parsingRulesPath('/var/lib/jenkins/logparser_warn_on_mark_unstable')
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes a couple of problems with #917:

 * The `built-in` label is not ready in our combination of Jenkins version and node plugin version. Use `master` until we execute the full migration.
 * The build is not marked as unstable since it lacks the configuration to run the console-log parser that transform the `MARK_AS_UNSTABLE` text into real unstable build status.