### PR TITLE
Retry the build when `java.nio.channels.ClosedChannelException` found in failed log

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
@@ -38,5 +38,15 @@ class OSRFBase
           }
         }
       }
+      publishers {
+        configure { project ->
+          // When a build fails because an agent disconnects, retry it once
+          project / publishers / 'com.chikli.hudson.plugin.naginator.NaginatorPublisher' {
+            regexpForRerun("java.nio.channels.ClosedChannelException")
+            checkRegexp(true)
+            maxSchedule(1)
+          }
+        }
+      }
     }
 }


### PR DESCRIPTION
This PR adds a similar functionality as 9fbfe60 with the difference that is one is scoped to all the agents when `java.nio.channels.ClosedChannelException` is found in the build log.