### PR TITLE
Unofficial ros_gz: script to release a new version of the ros_gz wrappers

### DIFF
--- a/bloom/ros_gz/Dockerfile
+++ b/bloom/ros_gz/Dockerfile
@@ -1,0 +1,26 @@
+FROM ros:humble-ros-base-jammy
+
+ENV LANG C
+ENV LC_ALL C
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+      python3-bloom \
+      wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install osrf-rosdep for Garden
+RUN sudo bash -c \
+  'wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list'
+# Replace Fortress with Garden to make bloom to work
+# since it does not support arbitrary environemnt variables
+RUN sudo bash -c \
+  'wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list -O /etc/ros/rosdep/sources.list.d/00-replace-gz-fortress-with-garden.list'
+
+# Not for using bloom but useful for rosdep calls
+ENV GZ_VERSION=garden
+ENV IGNITION_VERSION=garden
+
+WORKDIR /tmp
+COPY _rosdep_wrapper.bash .
+ENTRYPOINT ["/tmp/_rosdep_wrapper.bash"]

--- a/bloom/ros_gz/README.md
+++ b/bloom/ros_gz/README.md
@@ -5,6 +5,9 @@
 2. Initial setup
   * Create the alternative -release repository
   * Create a custom track in tracks.yaml
+3. Run a new release
+  * Prerequisites
+  * Bloom a new release 
 
 ## 1. Background
 
@@ -61,3 +64,32 @@ New versioning requires bumping to large numbers. Set:
 ```
 
 All non ubuntu generators can be removed.
+
+## 3. Run a new release
+
+To execute a new release of the ros_gz unofficial wrappers there are mainly two
+steps to do: use bloom to generate new metadata in the -release repo fork and
+use ros_gz-release.py script to trigger the builds builds.osrfoundation.org.
+
+The new version will be the latest one released in the rosdistro index of the
+official ros_gz packages.
+
+### Prerequisites
+
+The host system to release should have `docker` and `rocker` installed.
+
+### 3.1 Bloom a new release
+
+Blooming a new release of the ros_gz unofficial wrappers requires some changes
+to be done in the releasing enviroment affecting the rosdep rules. To facilitate
+this, there is a `Dockerfile` that provides the needed modifications and a script
+that encapsulates the bloom arguments to be passed and the use of this enviroment.
+
+```
+./bloom_from_special_env.bash
+```
+
+The script will create the docker enviroment with the rosdep modifications needed
+and invoke rocker with `--home` and `--user` flags to pass the credentials and
+customatizations needed for the bloom call. It will run the `bloom-release` command
+with the arguments required for the ros_gz wrappers.

--- a/bloom/ros_gz/_rosdep_wrapper.bash
+++ b/bloom/ros_gz/_rosdep_wrapper.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+rosdep update
+
+exec "$@"

--- a/bloom/ros_gz/bloom_from_special_env.bash
+++ b/bloom/ros_gz/bloom_from_special_env.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if ! command rocker &> /dev/null
+then
+  echo "Please install the rocker app https://github.com/osrf/rocker"
+  exit 1
+fi
+
+# TODO: update URL for the release repo
+BLOOM_CMD="/usr/bin/bloom-release --no-pull-request \
+   --rosdistro humble \
+   --track humble_gzgarden \
+   --override-release-repository-url \
+   https://github.com/j-rivero/ros_ign-release ros_gz"
+#
+TAG_NAME=${TAG_NAME:-ros_gz_fortress_garden_release}
+
+echo " * Build the docker release environment"
+docker build . -t "${TAG_NAME}"
+echo " * Using rocker to enter in the release environment"
+rocker --home --user "${TAG_NAME}" "${BLOOM_CMD}"
+echo " * Exit the docker release environment"
+echo " * Restoring the rosdep cache in the user"
+rosdep update

--- a/bloom/ros_gz/ros_gz-release.py.bash
+++ b/bloom/ros_gz/ros_gz-release.py.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Launch all the suite of ros_gazebo_pkgs:
+# Usage: ros_gz-release.py.bash <version>
+#
+
+if [[ $# -lt 2 ]]; then
+    echo "$0 <version> <release_repo> <ros_distro> <token> 'other arguments used in release.py'"
+    exit 1
+fi
+
+if [[ ${1%-*} != "${1}" ]]; then
+  echo "Version should not contain a revision number. Use -r argument"
+  exit 1
+fi
+
+for p in ros-gz ros-gz-bridge ros-gz-image ros-gz-interfaces ros-gz-sim ros-gz-sim-demos; do
+  ../release-bloom.py "${p}" $(for i in $@; do echo -n "$i "; done)
+done


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/895.

Reading the `README.md` file can give you an overview of the process implemented.

TODO: the `-release` repository should be changed from my personal account to a different location.
