### PR TITLE
remove legacy reference to 'extreme' option in docker cleanup process

### DIFF
--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -43,13 +43,6 @@ if [[ -z ${DO_NOT_CHECK_DOCKER_DISK_USAGE} ]]; then
        source ${SCRIPT_DIR}/lib/docker_cleanup.sh high
     fi
 
-    # if not enough, try to clean up build/ directories
-    PERCENT_DISK_USED=$(df -h ${docker_device} | grep ${docker_device} | sed 's:.* \([0-9]*\)%.*:\1:')
-    if [[ $PERCENT_DISK_USED -gt 85 ]]; then
-        echo "Space left is low again: ${PERCENT_DISK_USED}% used"
-        echo "Clean up the whole cache was not enough. Look for build/ directories bigger than ${MAX_SIZE_FOR_BUILD_DIRS}:"
-        source ${SCRIPT_DIR}/lib/docker_cleanup.sh extreme
-    fi
 fi
 
 # Timing

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -42,7 +42,6 @@ if [[ -z ${DO_NOT_CHECK_DOCKER_DISK_USAGE} ]]; then
         echo "Kill the whole docker cache !!"
        source ${SCRIPT_DIR}/lib/docker_cleanup.sh high
     fi
-
 fi
 
 # Timing

--- a/jenkins-scripts/docker/lib/docker_cleanup.sh
+++ b/jenkins-scripts/docker/lib/docker_cleanup.sh
@@ -28,7 +28,7 @@ docker_version="$(sudo docker version --format '{{.Server.APIVersion}}')"
             sudo docker system prune --all -f
             ;;
         *)
-            echo "Did not run docker cleaner, level $cleanup_level not recognized (accepted values low | medium | high !! "
+            echo "Did not run docker cleaner, level $cleanup_level not recognized (accepted values low | medium | high )"
             exit 1
             ;;
         esac

--- a/jenkins-scripts/docker/lib/docker_cleanup.sh
+++ b/jenkins-scripts/docker/lib/docker_cleanup.sh
@@ -28,7 +28,7 @@ docker_version="$(sudo docker version --format '{{.Server.APIVersion}}')"
             sudo docker system prune --all -f
             ;;
         *)
-            echo "Did not run docker cleaner, level $cleanup_level not recognized (accepted values low | medium | high | extreme!! "
+            echo "Did not run docker cleaner, level $cleanup_level not recognized (accepted values low | medium | high !! "
             exit 1
             ;;
         esac


### PR DESCRIPTION
### Description
This [issue](https://github.com/gazebo-tooling/release-tools/issues/929) appeared today due to legacy code expecting extreme option for the docker_cleanup process.
#### [Test build](https://build.osrfoundation.org/job/_test_gazebo-ci-pr_any-ubuntu_auto-amd64-gpu-nvidia/1/)
