### PR TITLE
Add brew sbin to PATH to fix doctor complaint

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -32,7 +32,7 @@ PROJECT_FORMULA=${PROJECT//[0-9]}$(\
 
 export HOMEBREW_PREFIX=/usr/local
 export HOMEBREW_CELLAR=${HOMEBREW_PREFIX}/Cellar
-export PATH=${HOMEBREW_PREFIX}/bin:$PATH
+export PATH=${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:$PATH
 
 export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python
 

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -12,7 +12,7 @@ BOTTLE_NAME=$1 # project will have the major version included (ex gazebo2)
 
 export HOMEBREW_PREFIX=/usr/local
 export HOMEBREW_CELLAR=${HOMEBREW_PREFIX}/Cellar
-export PATH=${HOMEBREW_PREFIX}/bin:$PATH
+export PATH=${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:$PATH
 
 # make verbose mode?
 MAKE_VERBOSE_STR=""


### PR DESCRIPTION
This fixes a `brew doctor` complaint for some of the bottle install testing jobs.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_common3-install_bottle-homebrew-amd64&build=1074)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_common3-install_bottle-homebrew-amd64/1074/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_common3-install_bottle-homebrew-amd64/1074/

~~~
+ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Homebrew's "sbin" was not found in your PATH but you have installed
formulae that put executables in /usr/local/sbin.
Consider setting your PATH for example like so:
  echo 'export PATH="/usr/local/sbin:$PATH"' >> ~/.zshrc
+ echo MARK_AS_UNSTABLE
MARK_AS_UNSTABLE
~~~