### PR TITLE
Change huge-memory to large-memory

### DIFF
--- a/docs/BUILDFARM_NODES.md
+++ b/docs/BUILDFARM_NODES.md
@@ -11,7 +11,7 @@ used (can check this in the Jenkins UI)
 | -------- | ----------- | ------------ |
 | docker   | Node has capabilities to run Docker CI (standard Linux CI) | Linux system with docker installed |
 | gpu-reliable | Node has a real GPU able to run simulation for Gazebo | Nvidia card and nvidia-docker installed on Linux |
-| huge-memory  | Node has enough RAM to run really demanding RAM compilations | Hardware has no less than 16Gb of RAM and can run abichecker on ign-physics |
+| large-memory  | Node has enough RAM to run really demanding RAM compilations | Hardware has no less than 16Gb of RAM and can run abichecker on ign-physics |
 | large-memory | Node has enough RAM to run non trivial compilations | Hardware has no less than 16GB of RAM on Linux |
 | linux-arm64 | Node has capabilities to run native arm64 code (mostly used in packaging) | Bare-metal ARM machine |
 | linux-armhf | Node has capabilities to run native armhf code (mostly used in packaging) | Bare-metal ARM machine |

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -373,7 +373,7 @@ gz_software.each { gz_sw ->
         extra_str=""
         if (gz_sw == 'physics')
         {
-          label Globals.nontest_label("huge-memory")
+          label Globals.nontest_label("large-memory")
           // on ARM native nodes in buildfarm we need to restrict to 1 the
           // compilation threads to avoid OOM killer
           extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=1; fi'
@@ -421,7 +421,7 @@ gz_software.each { gz_sw ->
     gz_ci_any_job.with
     {
       if (gz_sw == 'physics')
-        label Globals.nontest_label("huge-memory")
+        label Globals.nontest_label("large-memory")
 
       steps
       {
@@ -529,7 +529,7 @@ void generate_ci_job(gz_ci_job, gz_sw, branch, distro, arch,
   gz_ci_job.with
   {
     if (gz_sw == 'physics')
-      label Globals.nontest_label("huge-memory")
+      label Globals.nontest_label("large-memory")
 
     steps {
       shell("""\


### PR DESCRIPTION
This PR changes node labels, so we're using the same convention for the agents that have a lot of memory to run heavy jobs.