### PR TITLE
Initial work to move gz-collections metadata to a yaml file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           sudo mkdir -p /var/lib/jenkins/ && sudo touch /var/lib/jenkins/remote_token
           sudo chown -R ${USER} /var/lib/jenkins
           cd jenkins-scripts/dsl
-          java -jar ../../jobdsl.jar *.dsl
+          java -jar tools/jobdsl.jar *.dsl
           # export files for later diff
           mkdir /tmp/pr_xml_configuration
           mv *.xml /tmp/pr_xml_configuration/
@@ -60,7 +60,7 @@ jobs:
           git clean -f -e jobdsl.jar
           git checkout master
           cd jenkins-scripts/dsl
-          java -jar ../../jobdsl.jar *.dsl
+          java -jar tools/jobdsl.jar *.dsl
           mkdir /tmp/current_xml_configuration
           mv *.xml /tmp/current_xml_configuration/
       - name: Generating diffs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Download job dsl jar
+      - name: Download and setup job dsl jar
         if: steps.dsl_check.outputs.run_job == 'true'
-        run: curl -sSL https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/job-dsl-core/1.77/job-dsl-core-1.77-standalone.jar -o jobdsl.jar
+        run: ./jenkins-scripts/dsl/tools/setup_local_generation.bash
+
       - name: Generate all DSL files
         if: steps.dsl_check.outputs.run_job == 'true'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .pyc
+jenkins-scripts/dsl/tools/*.jar

--- a/jenkins-scripts/README.md
+++ b/jenkins-scripts/README.md
@@ -12,11 +12,10 @@ The release-tools repository uses the [DSL Jenkins plugin](https://plugins.jenki
 
 To test locally the build of the different `dsl` jobs you need the following: 
 
-1. Download `job_dsl-core.standalone.jar` to be able to build the dsl jobs locally. It's necessary to use the [same version](https://github.com/osrf/chef-osrf/blob/latest/cookbooks/osrfbuild/attributes/plugins.rb#L70) for the jarfrom the dsl plugin. [Download here](https://repo.jenkins-ci.org/artifactory/releases/org/jenkins-ci/plugins/job-dsl-core)
-2. Add the downloaded file to a folder not tracked in the repo.
+1. Run the `dsl/tools/setup_local_generation.bash` script to produce the necessary jar files
 3. In the terminal execute: 
 ``` bash
-java -jar `PATH/job_dsl-core.jar` `PATH/job_name.dsl`
+java -jar <path-to-dsl-tools>/jobdsl.jar <file.dsl>
 ```
 For more information go [here](https://github.com/jenkinsci/job-dsl-plugin/wiki/User-Power-Moves#run-a-dsl-script-locally).
 

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -32,22 +32,22 @@ spec_version: 0
 collections:
   - name: 'citadel'
     ci:
-     - linux:
+      - linux:
         reference_distro:
           - bionic
   - name: 'fortress'
     ci:
-     - linux:
+      - linux:
         reference_distro:
           - focal
   - name: 'garden'
     ci:
-     - linux:
+      - linux:
         reference_distro:
           - focal
   - name: 'harmonic'
     ci:
-     - linux:
+      - linux:
         reference_distro:
           - jammy
     nightly:

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -1,0 +1,57 @@
+#
+# SPEC: no yet approved, used as draft
+#
+#---
+# spec_version: 0
+# collections:
+#   - name: gz-collection1
+#     libs:
+#       - gz-lib:
+#           target_branch: gz-lib1
+#           current_branch: main
+#     ci:
+#      - linux:
+#         pr_distro:
+#         abi_distro: 
+#         install_distros:
+#           - distro1
+#           - distro2
+#      - systems:
+#          - Jenkins:
+#            view:
+#             auto: false
+#             jobs:
+#               - job1
+#               - job2
+#     nightly:
+#       - linux:
+#           nightly_distros:
+#             - distro1
+
+spec_version: 0
+collections:
+  - name: 'citadel'
+    ci:
+     - linux:
+        reference_distro:
+          - bionic
+  - name: 'fortress'
+    ci:
+     - linux:
+        reference_distro:
+          - focal
+  - name: 'garden'
+    ci:
+     - linux:
+        reference_distro:
+          - focal
+  - name: 'harmonic'
+    ci:
+     - linux:
+        reference_distro:
+          - jammy
+    nightly:
+      - linux:
+          nightly_distros:
+            - jammy
+

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -32,26 +32,26 @@ spec_version: 0
 collections:
   - name: 'citadel'
     ci:
-      - linux:
+      linux:
         reference_distro:
           - bionic
   - name: 'fortress'
     ci:
-      - linux:
+      linux:
         reference_distro:
           - focal
   - name: 'garden'
     ci:
-      - linux:
+      linux:
         reference_distro:
           - focal
   - name: 'harmonic'
     ci:
-      - linux:
+      linux:
         reference_distro:
           - jammy
     nightly:
-      - linux:
+      linux:
           nightly_distros:
             - jammy
 

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -1,5 +1,5 @@
 #
-# SPEC: no yet approved, used as draft
+# SPEC: not yet approved, used as draft
 #
 #---
 # spec_version: 0

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -377,7 +377,7 @@ void generate_install_job(prefix, gz_collection_name, distro, arch)
 // Testing compilation from source
 gz_collections_yaml.collections.each { collection ->
   gz_collection_name = collection.name
-  distros = collection.ci[0].linux.reference_distro
+  distros = collection.ci.linux.reference_distro
 
   // COLCON - Windows
   def gz_win_ci_job = job("ign_${gz_collection_name}-ci-win")

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -1,6 +1,6 @@
 import _configs_.*
 import javaposse.jobdsl.dsl.Job
-# If failed to import locally be sure of using tools/ scripts
+// If failed to import locally be sure of using tools/ scripts
 import org.yaml.snakeyaml.Yaml
 
 // GZ COLLECTIONS
@@ -10,9 +10,6 @@ gz_collections_yaml = new Yaml().load(new FileReader('gz-collections.yaml'))
 
 gz_nightly = 'harmonic'
 gz_collections = [
-  [ name : 'citadel' ],
-  [ name : 'fortress' ],
-  [ name : 'garden' ],
   [ name : 'harmonic',
     distros : [ 'focal' ],
     // These are the branches currently targeted at the upcoming collection

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -1,21 +1,18 @@
 import _configs_.*
 import javaposse.jobdsl.dsl.Job
+# If failed to import locally be sure of using tools/ scripts
+import org.yaml.snakeyaml.Yaml
 
 // GZ COLLECTIONS
 arch = 'amd64'
 
-gz_nightly = 'harmonic'
+gz_collections_yaml = new Yaml().load(new FileReader('gz-collections.yaml'))
 
+gz_nightly = 'harmonic'
 gz_collections = [
-  [ name : 'citadel',
-    distros : [ 'bionic' ],
-  ],
-  [ name : 'fortress',
-    distros : [ 'focal' ],
-  ],
-  [ name : 'garden',
-    distros : [ 'focal' ],
-  ],
+  [ name : 'citadel' ],
+  [ name : 'fortress' ],
+  [ name : 'garden' ],
   [ name : 'harmonic',
     distros : [ 'focal' ],
     // These are the branches currently targeted at the upcoming collection
@@ -381,9 +378,13 @@ void generate_install_job(prefix, gz_collection_name, distro, arch)
 }
 
 // Testing compilation from source
-gz_collections.each { gz_collection ->
+gz_collections_yaml.collections.each { collection ->
+  gz_collection_name = collection.name
+  distros = collection.ci[0].linux.reference_distro
+
+  println("Processing ${gz_collection_name}")
+
   // COLCON - Windows
-  gz_collection_name = gz_collection.get('name')
 
   def gz_win_ci_job = job("ign_${gz_collection_name}-ci-win")
   Globals.gazebodistro_branch = true
@@ -399,7 +400,7 @@ gz_collections.each { gz_collection ->
   }
   Globals.gazebodistro_branch = false
 
-  gz_collection.get('distros').each { distro ->
+  distros.each { distro ->
     // INSTALL JOBS:
     // --------------------------------------------------------------
     if ((gz_collection_name == "citadel") || (gz_collection_name == "fortress")) {

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -6,7 +6,9 @@ import org.yaml.snakeyaml.Yaml
 // GZ COLLECTIONS
 arch = 'amd64'
 
-script_dir = new File(".").absolutePath
+// Jenkins needs the relative path to work and locally the simulation is done
+// using a symlink
+script_dir = "scripts/jenkins-scripts/dsl/"
 gz_collections_yaml = new Yaml().load(new FileReader(script_dir + "/gz-collections.yaml"))
 
 gz_nightly = 'harmonic'

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -6,7 +6,8 @@ import org.yaml.snakeyaml.Yaml
 // GZ COLLECTIONS
 arch = 'amd64'
 
-gz_collections_yaml = new Yaml().load(new FileReader('gz-collections.yaml'))
+script_dir = new File(".").absolutePath
+gz_collections_yaml = new Yaml().load(new FileReader(script_dir + "/gz-collections.yaml")
 
 gz_nightly = 'harmonic'
 gz_collections = [

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -8,8 +8,8 @@ arch = 'amd64'
 
 // Jenkins needs the relative path to work and locally the simulation is done
 // using a symlink
-script_dir = "scripts/jenkins-scripts/dsl/"
-gz_collections_yaml = new Yaml().load(new FileReader(script_dir + "/gz-collections.yaml"))
+file = readFileFromWorkspace("scripts/jenkins-scripts/dsl/gz-collections.yaml")
+gz_collections_yaml = new Yaml().load(file)
 
 gz_nightly = 'harmonic'
 gz_collections = [

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -379,10 +379,7 @@ gz_collections_yaml.collections.each { collection ->
   gz_collection_name = collection.name
   distros = collection.ci[0].linux.reference_distro
 
-  println("Processing ${gz_collection_name}")
-
   // COLCON - Windows
-
   def gz_win_ci_job = job("ign_${gz_collection_name}-ci-win")
   Globals.gazebodistro_branch = true
   OSRFWinCompilation.create(gz_win_ci_job, false)

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -7,7 +7,7 @@ import org.yaml.snakeyaml.Yaml
 arch = 'amd64'
 
 script_dir = new File(".").absolutePath
-gz_collections_yaml = new Yaml().load(new FileReader(script_dir + "/gz-collections.yaml")
+gz_collections_yaml = new Yaml().load(new FileReader(script_dir + "/gz-collections.yaml"))
 
 gz_nightly = 'harmonic'
 gz_collections = [

--- a/jenkins-scripts/dsl/tools/setup_local_generation.bash
+++ b/jenkins-scripts/dsl/tools/setup_local_generation.bash
@@ -1,9 +1,12 @@
 #!/bin/bash 
 set -e
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 SNAKEYAML_PATH="lib/snakeyaml.jar"
 JOB_DSL_VER="1.77"
 
+pushd "${SCRIPT_DIR}" 2>/dev/null
 echo " * Download job-dsl-core jar"
 curl -ssl https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/job-dsl-core/${JOB_DSL_VER}/job-dsl-core-${JOB_DSL_VER}-standalone.jar -o jobdsl.jar
 echo " * Download snakeyaml jar"
@@ -16,3 +19,4 @@ tar uf jobdsl.jar ${SNAKEYAML_PATH}
 rm -fr ${SNAKEYAML_PATH}
 rmdir lib
 echo " >> Run 'java -jar ${PWD}/jobdsl.jar <file.dsl>' to generate locally the Jenkins XML config"
+popd "${SCRIPT_DIR}" 2>/dev/null

--- a/jenkins-scripts/dsl/tools/setup_local_generation.bash
+++ b/jenkins-scripts/dsl/tools/setup_local_generation.bash
@@ -1,0 +1,18 @@
+#!/bin/bash 
+set -e
+
+SNAKEYAML_PATH="lib/snakeyaml.jar"
+JOB_DSL_VER="1.77"
+
+echo " * Download job-dsl-core jar"
+curl -ssl https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/job-dsl-core/${JOB_DSL_VER}/job-dsl-core-${JOB_DSL_VER}-standalone.jar -o jobdsl.jar
+echo " * Download snakeyaml jar"
+# need to inject the yaml module into the jar file. lib subdir is needed to ineject into
+# tar in the right place.
+mkdir lib
+curl -ssl https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.32/snakeyaml-1.32.jar -o ${SNAKEYAML_PATH}
+echo " * Inject snakeyaml in job-dsl-core jar"
+tar uf jobdsl.jar ${SNAKEYAML_PATH}
+rm -fr ${SNAKEYAML_PATH}
+rmdir lib
+echo " >> Run 'java -jar ${PWD}/jobdsl.jar <file.dsl>' to generate locally the Jenkins XML config"

--- a/jenkins-scripts/dsl/tools/setup_local_generation.bash
+++ b/jenkins-scripts/dsl/tools/setup_local_generation.bash
@@ -6,17 +6,17 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SNAKEYAML_PATH="lib/snakeyaml.jar"
 JOB_DSL_VER="1.77"
 
-pushd "${SCRIPT_DIR}" 2>/dev/null
+pushd "${SCRIPT_DIR}" >/dev/null
 echo " * Download job-dsl-core jar"
-curl -ssl https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/job-dsl-core/${JOB_DSL_VER}/job-dsl-core-${JOB_DSL_VER}-standalone.jar -o jobdsl.jar
+curl -sSL https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/job-dsl-core/${JOB_DSL_VER}/job-dsl-core-${JOB_DSL_VER}-standalone.jar -o jobdsl.jar
 echo " * Download snakeyaml jar"
 # need to inject the yaml module into the jar file. lib subdir is needed to ineject into
 # tar in the right place.
-mkdir lib
-curl -ssl https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.32/snakeyaml-1.32.jar -o ${SNAKEYAML_PATH}
+mkdir -p lib
+curl -sSL https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.32/snakeyaml-1.32.jar -o ${SNAKEYAML_PATH}
 echo " * Inject snakeyaml in job-dsl-core jar"
-tar uf jobdsl.jar ${SNAKEYAML_PATH}
+jar uf jobdsl.jar ${SNAKEYAML_PATH}
 rm -fr ${SNAKEYAML_PATH}
 rmdir lib
 echo " >> Run 'java -jar ${PWD}/jobdsl.jar <file.dsl>' to generate locally the Jenkins XML config"
-popd "${SCRIPT_DIR}" 2>/dev/null
+popd >/dev/null


### PR DESCRIPTION
This PR is the initial work for trying to move the current gz-collections (or releases) metadata out from the Groovy code and write a yaml file that can provide all the necessary metadata to generate the Jenkins jobs and reuse the same file potentially for other users. By now the file is hosted in the same `dsl` directory.

The structure of the yaml file is yet to be properly proposed and defined, I've included a comment in the yaml with some ideas and will evolve it in the next PR as I need info to replace other parts of Groovy.

In this first PR the goal is to replace the generation of `-install-` and `-ci-` jobs for the Gazebo collections moving the initial data from Groovy to the yaml file. Mainly this comment: 08daf596df5e0696aed3cd4a64e33d65d1e5fd7b. The goal is not modify the generated configurations in CI.

Parsing yaml code in the DSL Jenkins scripts has a bad side effect for generating the jobs locally: the .jar file does not provide the snakeyaml (or other project) class to parse yaml something that Jenkins seems to provide natively for the scripts. For doing it, the PR creates a [simple script to download the DSL .jar file and inject the snakeyaml.jar inside it.](jenkins-scripts/dsl/tools/setup_local_generation.bash)  It is also used in github actions to keep the action working.