### PR TITLE
Enable -fPIC for ign-gazebo6

### DIFF
--- a/jenkins-scripts/docker/ignition-abichecker.bash
+++ b/jenkins-scripts/docker/ignition-abichecker.bash
@@ -92,7 +92,7 @@ then
   fi
 fi
 
-if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo"   && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 7 ]] || \
+if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo"   && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 6 ]] || \
   [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gui"       && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 7 ]] || \
   [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-launch"    && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 6 ]] || \
   [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-sensors"   && ${GZ_NAME_PREFIX_MAJOR_VERSION} -ge 7 ]] || \


### PR DESCRIPTION
Fixes #939 

I'm guessing we could just check for the distro version instead of the version of each package, but for now, I just changed it to include version 6.