### PR TITLE
Add a parser for OpenGL problems on Windows

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFWinBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFWinBase.groovy
@@ -28,7 +28,7 @@ class OSRFWinBase extends OSRFBase
         publishers {
           consoleParsing {
             projectRules('scripts/jenkins-scripts/parser_rules/opengl_problem.parser')
-            failBuildOnError(true)
+            unstableOnWarning()
           }
         }
      }

--- a/jenkins-scripts/dsl/_configs_/OSRFWinBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFWinBase.groovy
@@ -24,6 +24,13 @@ class OSRFWinBase extends OSRFBase
                 git clone https://github.com/gazebo-tooling/release-tools scripts -b %RTOOLS_BRANCH%
                 """.stripIndent())
         }
+
+        publishers {
+          consoleParsing {
+            projectRules('scripts/jenkins-scripts/parser_rules/opengl_problem.parser')
+            failBuildOnError(true)
+          }
+        }
      }
    }
 }

--- a/jenkins-scripts/parser_rules/opengl_problem.parser
+++ b/jenkins-scripts/parser_rules/opengl_problem.parser
@@ -1,0 +1,1 @@
+warning /.*Ogre::RenderingAPIException::RenderingAPIException: OpenGL .* is not supported in GLRenderSystem::initialiseContext.*/


### PR DESCRIPTION
Include a parser on Windows to detect problems with OpenGL installations. Ideally this should only run on GPU jobs but for now it should be fine to spend a bit of time detecting the problem on all the jobs since the changes required to make it happen only in GPU jobs are not trivial and I would prefer to wait until the `gz-collections.yaml` changes are deployed before doing so.

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_job_from_dsl_win&build=8)](https://build.osrfoundation.org/job/_test_job_from_dsl_win/8/)

//cc @iche033 