### PR TITLE
Fix deprecation on github actions: use GITHUB_OUTPUT instead of set-output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Diff for DSL code
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Idenfify files changed in this PR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,17 +16,17 @@ jobs:
         id: files
         run: |
             git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}
-            echo "name=changed-files::$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}| tr '\n' ' ')"  >> $GITHUB_OUTPUT
+            echo "changed-files=$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}| tr '\n' ' ')"  >> $GITHUB_OUTPUT
       - name: Run testing on changed config files
         id: dsl_check
         run: |
           for changed_file in ${{ steps.files.outputs.changed-files }}; do
             if [[ ${changed_file} != ${changed_file/dsl\/*} ]]; then
               echo "+ Detected at leat one config file: ${changed_file}."
-              echo "name=run_job::true" >> $GITHUB_OUTPUT
+              echo "run_job=true" >> $GITHUB_OUTPUT
               break
             else
-              echo "name=run_job::false" >> $GITHUB_OUTPUT
+              echo "run_job=false" >> $GITHUB_OUTPUT
             fi
           done
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,17 +16,17 @@ jobs:
         id: files
         run: |
             git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}
-            echo "::set-output name=changed-files::$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}| tr '\n' ' ')"
+            echo "name=changed-files::$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}| tr '\n' ' ')"  >> $GITHUB_OUTPUT
       - name: Run testing on changed config files
         id: dsl_check
         run: |
           for changed_file in ${{ steps.files.outputs.changed-files }}; do
             if [[ ${changed_file} != ${changed_file/dsl\/*} ]]; then
               echo "+ Detected at leat one config file: ${changed_file}."
-              echo "::set-output name=run_job::true"
+              echo "name=run_job::true" >> $GITHUB_OUTPUT
               break
             else
-              echo "::set-output name=run_job::false"
+              echo "name=run_job::false" >> $GITHUB_OUTPUT
             fi
           done
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           done
       - name: Checkout
         if: steps.dsl_check.outputs.run_job == 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/setup-java@v3

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -3,7 +3,6 @@ import javaposse.jobdsl.dsl.Job
 
 Globals.default_emails = "jrivero@osrfoundation.org"
 
-// Testing jobs
 def ignition_ci_job = job("_test_job_from_dsl")
 OSRFLinuxBase.create(ignition_ci_job)
 def ignition_ci_job_mac = job("_test_job_from_dsl_mac")

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -3,6 +3,7 @@ import javaposse.jobdsl.dsl.Job
 
 Globals.default_emails = "jrivero@osrfoundation.org"
 
+// Testing jobs
 def ignition_ci_job = job("_test_job_from_dsl")
 OSRFLinuxBase.create(ignition_ci_job)
 def ignition_ci_job_mac = job("_test_job_from_dsl_mac")

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -3,6 +3,7 @@ import javaposse.jobdsl.dsl.Job
 
 Globals.default_emails = "jrivero@osrfoundation.org"
 
+// Jobs
 def ignition_ci_job = job("_test_job_from_dsl")
 OSRFLinuxBase.create(ignition_ci_job)
 def ignition_ci_job_mac = job("_test_job_from_dsl_mac")


### PR DESCRIPTION
Remove deprecated code in github actions https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/