### PR TITLE
Fix detect_cmake_major_version.py to work with gz branches

### DIFF
--- a/jenkins-scripts/docker/gz_cmake-compilation.bash
+++ b/jenkins-scripts/docker/gz_cmake-compilation.bash
@@ -23,7 +23,7 @@ export BUILDING_EXTRA_CMAKE_PARAMS+=" -DBUILDSYSTEM_TESTING=True"
 # Identify GZ_CMAKE_MAJOR_VERSION to help with dependency resolution
 GZ_CMAKE_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-cmake/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_CMAKE version is integer
 if ! [[ ${GZ_CMAKE_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_common-compilation.bash
+++ b/jenkins-scripts/docker/gz_common-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_COMMON_DEPENDENCIES"
 # Identify GZ_COMMON_MAJOR_VERSION to help with dependency resolution
 GZ_COMMON_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-common/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_COMMON version is integer
 if ! [[ ${GZ_COMMON_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_fuel-tools-compilation.bash
+++ b/jenkins-scripts/docker/gz_fuel-tools-compilation.bash
@@ -21,7 +21,7 @@ export BUILDING_JOB_REPOSITORIES="stable"
 # Identify GZ_FUEL_TOOLS_MAJOR_VERSION to help with dependency resolution
 GZ_FUEL_TOOLS_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-fuel-tools/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_FUEL_TOOLS version is integer
 if ! [[ ${GZ_FUEL_TOOLS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_gazebo-compilation.bash
+++ b/jenkins-scripts/docker/gz_gazebo-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_SIM_DEPENDENCIES"
 # Identify GZ_SIM_MAJOR_VERSION to help with dependency resolution
 GZ_SIM_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-gazebo/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check IGN_GAZEBO version is integer
 if ! [[ ${GZ_SIM_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_gui-compilation.bash
+++ b/jenkins-scripts/docker/gz_gui-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_GUI_DEPENDENCIES"
 # Identify GZ_GUI_MAJOR_VERSION to help with dependency resolution
 GZ_GUI_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-gui/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_GUI_MAJOR_VERSION version is integer
 if ! [[ ${GZ_GUI_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_launch-compilation.bash
+++ b/jenkins-scripts/docker/gz_launch-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_LAUNCH_DEPENDENCIES"
 # Identify GZ_LAUNCH_MAJOR_VERSION to help with dependency resolution
 GZ_LAUNCH_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-launch/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_LAUNCH version is integer
 if ! [[ ${GZ_LAUNCH_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_math-compilation.bash
+++ b/jenkins-scripts/docker/gz_math-compilation.bash
@@ -21,7 +21,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_MATH_DEPENDENCIES"
 # Identify GZ_MATH_MAJOR_VERSION to help with dependency resolution
 GZ_MATH_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-math/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_MATH version is integer
 if ! [[ ${GZ_MATH_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_msgs-compilation.bash
+++ b/jenkins-scripts/docker/gz_msgs-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_MSGS_DEPENDENCIES"
 # Identify GZ_MSGS_MAJOR_VERSION to help with dependency resolution
 GZ_MSGS_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-msgs/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_MSGS version is integer
 if ! [[ ${GZ_MSGS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_physics-compilation.bash
+++ b/jenkins-scripts/docker/gz_physics-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_PHYSICS_DEPENDENCIES"
 # Identify GZ_PHYSICS_MAJOR_VERSION to help with dependency resolution
 GZ_PHYSICS_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-physics/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_PHYSICS version is integer
 if ! [[ ${GZ_PHYSICS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_plugin-compilation.bash
+++ b/jenkins-scripts/docker/gz_plugin-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_PLUGIN_DEPENDENCIES"
 # Identify GZ_PLUGIN_MAJOR_VERSION to help with dependency resolution
 GZ_PLUGIN_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-plugin/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_PLUGIN version is integer
 if ! [[ ${GZ_PLUGIN_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_rendering-compilation.bash
+++ b/jenkins-scripts/docker/gz_rendering-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_RENDERING_DEPENDENCIES"
 # Identify GZ_RENDERING_MAJOR_VERSION to help with dependency resolution
 GZ_RENDERING_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-rendering/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_RENDERING version is integer
 if ! [[ ${GZ_RENDERING_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_sensors-compilation.bash
+++ b/jenkins-scripts/docker/gz_sensors-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_SENSORS_DEPENDENCIES"
 # Identify GZ_SENSORS_MAJOR_VERSION to help with dependency resolution
 GZ_SENSORS_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-sensors/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_SENSORS version is integer
 if ! [[ ${GZ_SENSORS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_tools-compilation.bash
+++ b/jenkins-scripts/docker/gz_tools-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_DEPENDENCIES="ruby"
 
 GZ_TOOLS_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-tools/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_TOOLS version is integer
 if ! [[ ${GZ_TOOLS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_transport-compilation.bash
+++ b/jenkins-scripts/docker/gz_transport-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_SOFTWARE_DIRECTORY="${BUILDING_SOFTWARE_DIRECTORY:-ign-transport
 # Identify GZ_TRANSPORT_MAJOR_VERSION to help with dependency resolution
 GZ_TRANSPORT_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-transport/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_TRANSPORT version is integer
 if ! [[ ${GZ_TRANSPORT_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then

--- a/jenkins-scripts/docker/gz_utils-compilation.bash
+++ b/jenkins-scripts/docker/gz_utils-compilation.bash
@@ -20,7 +20,7 @@ export BUILDING_PKG_DEPENDENCIES_VAR_NAME="GZ_UTILS_DEPENDENCIES"
 # Identify GZ_UTILS_MAJOR_VERSION to help with dependency resolution
 GZ_UTILS_MAJOR_VERSION=$(\
   python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/ign-utils/CMakeLists.txt)
+  ${WORKSPACE}/${BUILDING_SOFTWARE_DIRECTORY}/CMakeLists.txt)
 
 # Check GZ_UTILS version is integer
 if ! [[ ${GZ_UTILS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then


### PR DESCRIPTION
Follow up #951 to make compilation scripts to work with `gz-.*` checkout directories.

Failing:[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake-ci-pr_any-jammy-amd64&build=1)](https://build.osrfoundation.org/job/gz_cmake-ci-pr_any-jammy-amd64/1/)
Testing: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake-ci-pr_any-jammy-amd64&build=2)](https://build.osrfoundation.org/job/gz_cmake-ci-pr_any-jammy-amd64/2/)