### PR TITLE
Fix cron syntax in Jenkins: use gnu_mcron compatible expression

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -12,11 +12,13 @@ class Globals
 
    static CRON_EVERY_THREE_DAYS = 'H H * * H/3'
    static CRON_ON_WEEKEND = 'H H * * 6-7'
-   static CRON_START_NIGHTLY = '0 9 * * *'
    // Run nightly scheduler during the nightly creation to be sure
    // that any possible node killed is replaced. Starting -15min
    // before CRON_NIGHTLY_NODES and evert 20min for 3 hours
-   static CRON_NIGHTLY_NODES = '45/20 8-11 * * *'
+   static CRON_NIGHTLY_NODES = '*/20 9-11 * * *'
+   // Start the nightly generation 10 minutes after the nigthly node
+   // initial generation
+   static CRON_START_NIGHTLY = '10 9 * * *'
 
    // Only one -E regex can be passed, so make a regex that matches both
    // _ign_TEST and _gz_TEST


### PR DESCRIPTION
The current cron expression is not supported in Jenkins, which seems to be compatible with the `gnu_mcron` implementation that supports `x-y/z` and `*/z` but does not `x/z` syntax.

The PR changes the starting time of the nightlies to `9:10` so the nightly node cron job runs from `9:00` each 20 minutes until `11:00`.
