### PR TITLE
Parametrize ros_gz bloom tooling to accept different ROS_DISTRO values

### DIFF
--- a/bloom/release-bloom.py
+++ b/bloom/release-bloom.py
@@ -15,6 +15,7 @@ UBUNTU_ARCHS = ['amd64']
 UBUNTU_DISTROS_IN_ROS = {'noetic': ['focal']}
 UBUNTU_DISTROS_IN_ROS2 = {'foxy': ['focal'],
                           'humble': ['jammy'],
+                          'iron': ['jammy'],
                           'rolling': ['jammy']}
 DRY_RUN = False
 

--- a/bloom/ros_gz/Dockerfile
+++ b/bloom/ros_gz/Dockerfile
@@ -7,6 +7,8 @@ ENV LC_ALL C
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
+      coreutils \
+      dpkg-dev \
       python3-bloom \
       wget \
     && rm -rf /var/lib/apt/lists/*
@@ -24,5 +26,6 @@ ENV GZ_VERSION=garden
 ENV IGNITION_VERSION=garden
 
 WORKDIR /tmp
+COPY _check_metadata.bash .
 COPY _rosdep_wrapper.bash .
 ENTRYPOINT ["/tmp/_rosdep_wrapper.bash"]

--- a/bloom/ros_gz/Dockerfile
+++ b/bloom/ros_gz/Dockerfile
@@ -1,4 +1,6 @@
-FROM ros:humble-ros-base-jammy
+ARG ROS_DISTRO=humble
+
+FROM ros:$ROS_DISTRO-ros-base
 
 ENV LANG C
 ENV LC_ALL C

--- a/bloom/ros_gz/_check_metadata.bash
+++ b/bloom/ros_gz/_check_metadata.bash
@@ -11,19 +11,23 @@ fi
 RELEASE_REPO_URL=${1}
 ROS_DISTRO=${2}
 
+echo " * Checking that ${RELEASE_REPO_URL} has a correct gzgarden metadata for ROS ${ROS_DISTRO}"
+
 TMP_DIR=$(mktemp -d) 
-git clone "${RELEASE_REPO_URL}" "${TMP_DIR}"
-pushd "${TMP_DIR}" 2> /dev/null || exit
-cd "${TMP_DIR}" || exit
+git clone -q "${RELEASE_REPO_URL}" "${TMP_DIR}"
+pushd "${TMP_DIR}" 2> /dev/null > /dev/null || exit
 DEBIAN_LATEST_TAG=$(git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | \
           grep "debian/ros-${ROS_DISTRO}" | \
           tail -1 | sed 's:refs/tags/::')
-git checkout "${DEBIAN_LATEST_TAG}"
-dpkg-parsechangelog -SSource 
-if ! dpkg-parsechangelog -SSource | grep -q 'gzgarden' > /dev/null; then
-  echo "Latest changelog entry does not have gzgarden name"
-  echo "in the repo tag ${DEBIAN_LATEST_TAG} for repo ${RELEASE_REPO_URL}"
-  echo "Maybe the rename in the bloom templates was not done."
+git checkout -q "${DEBIAN_LATEST_TAG}"
+if ! dpkg-parsechangelog -SSource 2> /dev/null | grep -q 'gzgarden'; then
+  echo " !! Latest changelog entry does not have gzgarden name"
+  echo " !! in the repo tag '${DEBIAN_LATEST_TAG}' for repo '${RELEASE_REPO_URL}'"
+  echo -n " !! Latest changelog is:"
+  dpkg-parsechangelog -SSource 2> /dev/null || exit
+  echo " !! Maybe the rename in the bloom templates was not done."
   exit 1
 fi
-popd 2>/dev/null || exit
+popd >/dev/null || exit
+
+echo "  + Changelog has correct gzgarden metadata for ${DEBIAN_LATEST_TAG}"

--- a/bloom/ros_gz/_check_metadata.bash
+++ b/bloom/ros_gz/_check_metadata.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <RELEASE_REPO_URL> <ROS_DISTRO>"
+  exit 1
+fi
+
+RELEASE_REPO_URL=${1}
+ROS_DISTRO=${2}
+
+TMP_DIR=$(mktemp -d) 
+git clone "${RELEASE_REPO_URL}" "${TMP_DIR}"
+pushd "${TMP_DIR}" 2> /dev/null || exit
+cd "${TMP_DIR}" || exit
+DEBIAN_LATEST_TAG=$(git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | \
+          grep "debian/ros-${ROS_DISTRO}" | \
+          tail -1 | sed 's:refs/tags/::')
+git checkout "${DEBIAN_LATEST_TAG}"
+dpkg-parsechangelog -SSource 
+if ! dpkg-parsechangelog -SSource | grep -q 'gzgarden' > /dev/null; then
+  echo "Latest changelog entry does not have gzgarden name"
+  echo "in the repo tag ${DEBIAN_LATEST_TAG} for repo ${RELEASE_REPO_URL}"
+  echo "Maybe the rename in the bloom templates was not done."
+  exit 1
+fi
+popd 2>/dev/null || exit

--- a/bloom/ros_gz/bloom_from_special_env.bash
+++ b/bloom/ros_gz/bloom_from_special_env.bash
@@ -8,6 +8,7 @@ fi
 ROS_DISTRO=${1}
 # Might be used with testing proposes to change gbp-release repo
 GBP_ORG=${GBP_ORG:-gazebo-release}
+RELEASE_REPO_URL=https://github.com/${GBP_ORG}/ros_ign-release
 
 if ! command rocker --version &> /dev/null
 then
@@ -20,7 +21,7 @@ BLOOM_CMD="/usr/bin/bloom-release --no-pull-request \
    --rosdistro ${ROS_DISTRO}\
    --track ${ROS_DISTRO}_gzgarden \
    --override-release-repository-url \
-   https://github.com/${GBP_ORG}/ros_ign-release ros_gz"
+   ${RELEASE_REPO_URL} ros_gz"
 
 TAG_NAME=${TAG_NAME:-ros_gz-${ROS_DISTRO}-fortress-garden-release}
 
@@ -31,3 +32,5 @@ rocker --home --user "${TAG_NAME}" "${BLOOM_CMD}"
 echo " * Exit the docker release environment"
 echo " * Restoring the rosdep cache in the user"
 rosdep update
+echo " * Running safety check in generated metadata"
+docker run "${TAG_NAME}" /tmp/_check_metadata.bash "${RELEASE_REPO_URL}" "${ROS_DISTRO}"

--- a/bloom/ros_gz/bloom_from_special_env.bash
+++ b/bloom/ros_gz/bloom_from_special_env.bash
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <ros_distro>"
+  exit 1
+fi
+
+ROS_DISTRO=${1}
+# Might be used with testing proposes to change gbp-release repo
+GBP_ORG=${GBP_ORG:-gazebo-release}
+
 if ! command rocker --version &> /dev/null
 then
   echo "Please install the rocker app https://github.com/osrf/rocker"
@@ -8,15 +17,15 @@ fi
 
 # TODO: update URL for the release repo
 BLOOM_CMD="/usr/bin/bloom-release --no-pull-request \
-   --rosdistro humble \
-   --track humble_gzgarden \
+   --rosdistro ${ROS_DISTRO}\
+   --track ${ROS_DISTRO}_gzgarden \
    --override-release-repository-url \
-   https://github.com/gazebo-release/ros_ign-release ros_gz"
+   https://github.com/${GBP_ORG}/ros_ign-release ros_gz"
 
-TAG_NAME=${TAG_NAME:-ros_gz_fortress_garden_release}
+TAG_NAME=${TAG_NAME:-ros_gz-${ROS_DISTRO}-fortress-garden-release}
 
 echo " * Build the docker release environment"
-docker build . -t "${TAG_NAME}"
+docker build . -t "${TAG_NAME}" --build-arg ROS_DISTRO="${ROS_DISTRO}"
 echo " * Using rocker to enter in the release environment"
 rocker --home --user "${TAG_NAME}" "${BLOOM_CMD}"
 echo " * Exit the docker release environment"

--- a/bloom/ros_gz/ros_gz-release.py.bash
+++ b/bloom/ros_gz/ros_gz-release.py.bash
@@ -1,7 +1,12 @@
 #!/bin/bash
 # Launch all the suite of ros_gazebo_pkgs:
 # Usage: ros_gz-release.py.bash <version>
-#
+
+# Knowing Script dir beware of symlink
+[[ -L ${0} ]] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
+SCRIPT_DIR="${SCRIPT_DIR%/*}"
+
+set -e
 
 if [[ $# -lt 2 ]]; then
     echo "$0 <version> <release_repo> <ros_distro> <token> 'other arguments used in release.py'"
@@ -12,6 +17,8 @@ if [[ ${1%-*} != "${1}" ]]; then
   echo "Version should not contain a revision number. Use -r argument"
   exit 1
 fi
+
+"${SCRIPT_DIR}/_check_metadata.bash" "${2}" "${3}"
 
 for p in ros-gz ros-gz-bridge ros-gz-image ros-gz-interfaces ros-gz-sim ros-gz-sim-demos; do
   ../release-bloom.py "${p}" $(for i in $@; do echo -n "$i "; done)


### PR DESCRIPTION
The PR mainly change the humble use to support different ROS_DISTROs and particularly Iron. The change is simple and made in 511c60535b2d2bd75cf48cf3799673b599b49f20.

To avoid problems when blooming without the right bloom template changes, I've added a check for the modified metadata. It will run after blooming to check the results d7bd5e8e0bea21925064e63e4edfe7be7e595d62 and when someone is trying to trigger the builds in 2d18b37d5b7afc9d3a5253d4f64eda3d759ecd6e