### PR TITLE
Fix nvml error discovery in log

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -53,11 +53,12 @@ class OSRFUNIXBase extends OSRFBase
                   def node = build.getBuiltOn()
                   def old_labels = node.getLabelString()
 
-                  println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
+                  println("Checking if nvidia mismatch error is present in log")
                   if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
                     println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any recovery automatic recovery step")
                     return 1;
                   } else {
+                    println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
                     try {
                       println(" PROBLEM: NVIDIA driver/library version mismatch was detected in the log. Try to automatically resolve it:")
                       println("Removing labels and adding 'recovery-process' label to node")
@@ -85,7 +86,7 @@ class OSRFUNIXBase extends OSRFBase
     // Add the new regex to naginator tag
     // There is no need to specify checkRegexp and maxSchedule because they are the default values
     HelperRetryFailures.create(job, [
-      regexpForRerun: "nvml error driver/library version mismatch",
+      regexpForRerun: "nvml error: driver/library version mismatch",
       delay: 70
     ])
   }

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -55,7 +55,7 @@ class OSRFUNIXBase extends OSRFBase
 
                   println("Checking if nvidia mismatch error is present in log")
                   if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
-                    println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any recovery automatic recovery step")
+                    println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any automatic recovery steps")
                     return 1;
                   } else {
                     println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
@@ -69,8 +69,8 @@ class OSRFUNIXBase extends OSRFBase
                       node.setLabelString(old_labels)
                       throw ex
                     }
+                    println("# END SECTION: NVIDIA MISMATCH RECOVERY")
                   }
-                  println("# END SECTION: NVIDIA MISMATCH RECOVERY")
                   '''.stripIndent()
                 )
                 shell("""sudo shutdown -r +1""")


### PR DESCRIPTION
`nvml error: driver/library version mismatch` was missing a `:` character in the `regexpForRerun` attribute. This PR adds that character

I also moved the "# BEGIN SECTION: NVIDIA MISMATCH RECOVERY" to the real section where the recovery is made, replacing the original message with "Checking if nvidia mismatch error is present in log" for debug processes