### PR TITLE
Fix the calls to gz-gazebo compilation script

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -568,6 +568,8 @@ void generate_ci_job(gz_ci_job, gz_sw, branch, distro, arch,
   {
     if (gz_sw == 'physics')
       label Globals.nontest_label("large-memory")
+    if (gz_sw == 'gazebo')
+      gz_sw = 'sim'
 
     steps {
       shell("""\
@@ -579,7 +581,7 @@ void generate_ci_job(gz_ci_job, gz_sw, branch, distro, arch,
             export BUILDING_EXTRA_MAKETEST_PARAMS="${extra_test}"
             export DISTRO=${distro}
             export ARCH=${arch}
-            /bin/bash -xe ./scripts/jenkins-scripts/docker/gz_${software_name.replaceAll('-','_')}-compilation.bash
+            /bin/bash -xe ./scripts/jenkins-scripts/docker/gz_${gz_sw.replaceAll('-','_')}-compilation.bash
             """.stripIndent())
     }
   }


### PR DESCRIPTION
After https://github.com/gazebo-tooling/release-tools/pull/953 the compilation scripts were renamed. Fix the errors of gz_gazebo by using gz_sim in CI jobs.