### PR TITLE
Scape $USER in Dockerfile to avoid bash expansion 

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -134,7 +134,7 @@ cat > Dockerfile << DELIM_DOCKER
 # Docker file to run build.sh
 
 FROM ${FROM_VALUE}
-MAINTAINER Jose Luis Rivero <jrivero@osrfoundation.org>
+LABEL maintainer="Jose Luis Rivero <jrivero@osrfoundation.org>"
 
 # setup environment
 ENV LANG C

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -456,8 +456,8 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R \$USER:\$USER /home/\$USER
 
 # permit access to USER variable inside docker
-ENV USER ${USER}
-USER $USER
+ENV USER \$USER
+USER \$USER
 # Must use sudo where necessary from this point on
 DELIM_DOCKER_USER
 


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/923 efforts. Should have no change in behavior.

Tested:
  * [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-utils2-debbuilder&build=994)](https://build.osrfoundation.org/job/gz-utils2-debbuilder/994/)
  * [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake-ci-pr_any-jammy-amd64&build=12)](https://build.osrfoundation.org/job/gz_cmake-ci-pr_any-jammy-amd64/12/)

