### PR TITLE
Fix outdated job cron trigger

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -11,7 +11,7 @@ class Globals
    static gazebodistro_branch = false
 
    static CRON_EVERY_THREE_DAYS = 'H H * * H/3'
-   static CRON_HOURLY = '* H * * *'
+   static CRON_HOURLY = 'H H * * *'
    static CRON_ON_WEEKEND = 'H H * * 6-7'
    // Run nightly scheduler during the nightly creation to be sure
    // that any possible node killed is replaced. Starting -15min


### PR DESCRIPTION
Currently, [_outdated_job_runner](https://build.osrfoundation.org/job/_outdated_job_runner/) it's running every minute instead of every hour as expected.