### PR TITLE
Fix `CRON_HOURLY` string

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -11,7 +11,7 @@ class Globals
    static gazebodistro_branch = false
 
    static CRON_EVERY_THREE_DAYS = 'H H * * H/3'
-   static CRON_HOURLY = 'H H * * *'
+   static CRON_HOURLY = 'H * * * *'
    static CRON_ON_WEEKEND = 'H H * * 6-7'
    // Run nightly scheduler during the nightly creation to be sure
    // that any possible node killed is replaced. Starting -15min


### PR DESCRIPTION
CRON_HOURLY was unintentionally defined to run every minute in #962 

After #965 it was, again, unintentionally defined to run every day instead of every hour.

This PR corrects this problem by making sure it runs every hour using the correct syntax.