### PR TITLE
Use large-memory nodes for nightlies

### DIFF
--- a/docs/BUILDFARM_NODES.md
+++ b/docs/BUILDFARM_NODES.md
@@ -22,16 +22,6 @@ used (can check this in the Jenkins UI)
 | win | Node is able to run Windows CI | Windows10 system |
 | win_testing | Node is ready to test a new vcpkg snapshot | Windows10 system |
 
-### Node labels for nightlies
-
-For generating nightlies controlling the generation order of every library, build.osrfoundation.org use the approach of [using a single node to process the whole ignition family for a given Ubuntu distribution](https://github.com/gazebo-tooling/release-tools/issues/644). Current assignment of nodes is as follow:
-
-| Label name | Description |
-| -------- | ----------- |
-| linux-nightly-bionic | r2d2  |
-| linux-nightly-focal | optimus |
-| linux-nightly-jammy | drogon |
-
 ## Provision of Node labels
 
 ### Agents

--- a/jenkins-scripts/tools/label-assignment-backstop.groovy
+++ b/jenkins-scripts/tools/label-assignment-backstop.groovy
@@ -11,16 +11,13 @@ import jenkins.model.*;
 import hudson.model.Label;
 
 /*
-  Each label is in a 2-tuple with a label expression that indicates its "pool"
-  of potential assignees.
-  The first field must be a single label (no spaces) but the second may be an
-  arbitrarily complex label expression like "(docker && linux) && !armhf"
+  Each label is in a 2-tuple with a label tag that indicates its "pool"
+  of potential assignees. The fields must be a single label (no spaces).
 */
 def nightly_label_prefix = "linux-nightly"
-def linux_pool_label_expression = "(large-memory) && !test-instance"
 def exactly_one_labels = [
-  ["${nightly_label_prefix}-focal", linux_pool_label_expression ],
-  ["${nightly_label_prefix}-jammy", linux_pool_label_expression ],
+  ["${nightly_label_prefix}-focal", "large-memory"],
+  ["${nightly_label_prefix}-jammy", "large-memory"],
 ]
 
 for (tup in exactly_one_labels) {
@@ -53,7 +50,6 @@ for (tup in exactly_one_labels) {
       node.computer.online &&
       node.getLabelString().contains(pool_label) &&
       !node.getLabelString().contains(nightly_label_prefix) &&
-      !node.getLabelString().contains("gpu-nvidia") &&
       !node.getLabelString().contains("test-instance")
     }
 

--- a/jenkins-scripts/tools/label-assignment-backstop.groovy
+++ b/jenkins-scripts/tools/label-assignment-backstop.groovy
@@ -17,9 +17,10 @@ import hudson.model.Label;
   arbitrarily complex label expression like "(docker && linux) && !armhf"
 */
 def nightly_label_prefix = "linux-nightly"
+def linux_pool_label_expression = "(large-memory) && !test-instance"
 def exactly_one_labels = [
-  ["${nightly_label_prefix}-focal", "docker"],
-  ["${nightly_label_prefix}-jammy", "docker"],
+  ["${nightly_label_prefix}-focal", linux_pool_label_expression ],
+  ["${nightly_label_prefix}-jammy", linux_pool_label_expression ],
 ]
 
 for (tup in exactly_one_labels) {


### PR DESCRIPTION
Closes: #967 

Modified the code (and comments) to use the label `large-memory` instead of `docker`. I also found not true that current code is able to support label expression, looking at the code `node.getLabelString().contains()` is probably unable to parser that expressions. Anyway, the filter of test instances is being done inside `findAll`.

I also removed outdate info in 7767c4f8e7715a999b1697beeecf4ef1ce0c0ae5