### PR TITLE
Update outdated job condition from 8 to 4 days

### DIFF
--- a/jenkins-scripts/tools/outdated-job-runner.groovy
+++ b/jenkins-scripts/tools/outdated-job-runner.groovy
@@ -226,7 +226,7 @@ def jenkinsJobs = Hudson.instance
 
 def jobsToRun = [osx: [], win: [], docker: []]
 
-long eightDaysAgoMillis = System.currentTimeMillis() - 8 * 24 * 60 * 60 * 1000; // 8 days ago in milis
+long eightDaysAgoMillis = System.currentTimeMillis() - 4 * 24 * 60 * 60 * 1000; // 4 days ago in milis
 Date eightDaysAgoDate = new Date(eightDaysAgoMillis);
 
 jenkinsJobs.getItems(Project).each { project ->


### PR DESCRIPTION
The 8 days threshold from an outdated job was defined when we ran the gazebo jobs manually using daily report. Now that this work is automated, it would make sense to decrease the threshold, so the gazebo jobs are run more frequently by [_outdated_job_runner](https://build.osrfoundation.org/job/_outdated_job_runner/).

CC: @Blast545 @claraberendsen 