### PR TITLE
Need to run lsof with sudo from Jenkins CI

### DIFF
--- a/jenkins-scripts/lib/check_graphic_card.bash
+++ b/jenkins-scripts/lib/check_graphic_card.bash
@@ -8,7 +8,7 @@ export_display_variable()
     do
       # If a process is running with the open socket then
       # lsof will exit successfully.
-      if lsof -Fp $i ; then
+      if sudo bash -c "lsof -Fp $i" ; then
         # Strip the path and leading X from the X11 socket
         # but check that the resulting string is numeric and
         # non-empty before exporting.


### PR DESCRIPTION
Running lsof without sudo rights ends up in a silent error. `strace` displays multiple "Permission denied" on `/proc/` accessed. Error introduced in #916 . Problem not detected since the problem is not appearing in nodes with a valid DISPLAY setup and  Xorg running. 

Quick fix is to use sudo although this does not help towards the rootless CI builds. We can merge it to solve the current problem, which is severe, and think in an alternative to the `lsof`call.

Tested with DISPLAY disabled in [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors-ci-main-jammy-amd64&build=6)](https://build.osrfoundation.org/job/gz_sensors-ci-main-jammy-amd64/6/).

