### PR TITLE
Enable nighty mode when using nightly on VERSION instead of UPLOAD_TO_REPO

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 NIGHTLY_MODE=${NIGHTLY_MODE:-false}
-if [ "${UPLOAD_TO_REPO}" = "nightly" ]; then
+if [ "${VERSION}" = "nightly" ]; then
    OSRF_REPOS_TO_USE="${OSRF_REPOS_TO_USE:-stable nightly}"
    NIGHTLY_MODE=true
    # SOURCE_TARBALL_URI is reused in nightly mode to indicate the branch

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
@@ -42,7 +42,7 @@ class OSRFLinuxBuildPkg
                     "Package name to be built")
         stringParam("VERSION",
                     default_params.find{ it.key == "VERSION"}?.value,
-                    "Packages version to be built")
+                    "Packages version to be built or nightly (enable nightly build mode)")
         stringParam("RELEASE_VERSION",
                     default_params.find{ it.key == "RELEASE_VERSION"}?.value,
                     "Packages release version")


### PR DESCRIPTION
Nightly mode in debbuild base is enabled when "nightly" value is detected in `UPLOAD_TO_REPO`. This is preventing the `UPLOAD_TO_REPO` to set the value `none` for testing and test a nightly with it. Seems more logical to use the `VERSION` field since there is no case where you want to use the `nightly` value in that field for a different reason that to build a nightly.

The [nightly scheduler](https://github.com/gazebo-tooling/release-tools/blob/86049e20b4273a337bc999f68142c13d679c75c4/jenkins-scripts/dsl/ignition_collection.dsl#L662) pass the `nightly` value in the second arg ( `VERSION`) so the nightly builds should not be affected. 

Tested [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-math7-debbuilder&build=1566)](https://build.osrfoundation.org/job/gz-math7-debbuilder/1566/)