### PR TITLE
Resurrect "Robust display detection" with a variable fix

### DIFF
--- a/jenkins-scripts/lib/check_graphic_card.bash
+++ b/jenkins-scripts/lib/check_graphic_card.bash
@@ -12,7 +12,7 @@ export_display_variable()
         # Strip the path and leading X from the X11 socket
         # but check that the resulting string is numeric and
         # non-empty before exporting.
-        DISPLAY=:$(basename $i | sed -n -E 's/^X([0-9]+)/:\1/p')
+        DISPLAY=$(basename $i | sed -n -E 's/^X([0-9]+)/:\1/p')
         if [ -n "$DISPLAY" ]; then
           export DISPLAY
         fi

--- a/jenkins-scripts/lib/check_graphic_card.bash
+++ b/jenkins-scripts/lib/check_graphic_card.bash
@@ -3,16 +3,19 @@ GRAPHIC_CARD_PKG=""
 
 export_display_variable()
 {
-    # Hack to found the current display (if available) two steps:
-    # Check for /tmp/.X11-unix/ socket and check if the process is running
-    for i in $(ls /tmp/.X11-unix/ | sed -e 's@^X@:@')
+    # Check for an active X11 display socket.
+    for i in $(find /tmp/.X11-unix -type s)
     do
-      # grep can fail so let's disable the fail or error during its call
-      set +e
-      ps aux | grep bin/X.*$i | grep -v grep
-      set -e
-      if [ $? -eq 0 ] ; then
-	export DISPLAY=$i
+      # If a process is running with the open socket then
+      # lsof will exit successfully.
+      if sudo bash -c "lsof -Fp $i" ; then
+        # Strip the path and leading X from the X11 socket
+        # but check that the resulting string is numeric and
+        # non-empty before exporting.
+        DISPLAY=:$(basename $i | sed -n -E 's/^X([0-9]+)/:\1/p')
+        if [ -n "$DISPLAY" ]; then
+          export DISPLAY
+        fi
       fi
     done
 }
@@ -79,7 +82,9 @@ if $GPU_SUPPORT_NEEDED; then
     if [[ ${DISPLAY} == "" ]]; then
       echo "GPU support needed by the script but DISPLAY var is empty"
       # Try to restart lightdm. It should stop the script in the case of failure
-      sudo service lightdm restart
+      sudo systemctl restart lightdm
+      # Wait for lightdm service to restart X11.
+      sleep 5
       # Second try to get display variable
       export_display_variable
       if [[ ${DISPLAY} == "" ]]; then


### PR DESCRIPTION
Should fix #979 

I noticed that the DISPLAY variable contains a weird `:unix::0` with two `::` instead of just one. Removed in 3b48a3ce06cbb7e29314e53ac4934fa6aa51fcae.

Tested for gz-sim7 in:  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-pr_any-ubuntu_auto-amd64&build=10665)](https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64/10665/)