### PR TITLE
Make DSL generation to store jobs generated in a log file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,8 +52,9 @@ jobs:
           cd jenkins-scripts/dsl
           WRITE_JOB_LOG=1 java -jar tools/jobdsl.jar *.dsl
           # export files for later diff
-          mkdir /tmp/pr_xml_configuration
+          mkdir /tmp/pr_xml_configuration && mkdir /tmp/pr_log_generated/
           mv *.xml /tmp/pr_xml_configuration/
+          mv *.txt /tmp/pr_log_generated/
       - name: Geneate master DSL files
         if: steps.dsl_check.outputs.run_job == 'true'
         run: |
@@ -61,14 +62,16 @@ jobs:
           git checkout master
           cd jenkins-scripts/dsl
           WRITE_JOB_LOG=1 java -jar tools/jobdsl.jar *.dsl
-          mkdir /tmp/current_xml_configuration
+          mkdir /tmp/current_xml_configuration && mkdir /tmp/current_log_generated/
           mv *.xml /tmp/current_xml_configuration/
+          mv *.txt /tmp/current_log_generated/
       - name: Generating diffs
         if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           # somehow the Jenkins views changed the portlet_ id on every run.
           diff -qr -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration > /tmp/xml_config_files_changed.diff || true
           diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration > /tmp/xml_config_content_changed.diff || true
+          diff -ur /tmp/current_log_generated /tmp/pr_log_generated > /tmp/log_content_changed.diff || true
       - name: Archive files changes
         if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
@@ -81,3 +84,9 @@ jobs:
         with:
           name: xml_config_content_changed
           path: /tmp/xml_config_content_changed.diff
+      - name: Archive log changes
+        if: steps.dsl_check.outputs.run_job == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: log_content_changed
+          path: /tmp/log_content_changed.diff

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
           mkdir /tmp/pr_xml_configuration && mkdir /tmp/pr_log_generated/
           mv *.xml /tmp/pr_xml_configuration/
           mv *.txt /tmp/pr_log_generated/
-      - name: Geneate master DSL files
+      - name: Generate master DSL files
         if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           git clean -f -e jobdsl.jar
@@ -64,7 +64,7 @@ jobs:
           WRITE_JOB_LOG=1 java -jar tools/jobdsl.jar *.dsl
           mkdir /tmp/current_xml_configuration && mkdir /tmp/current_log_generated/
           mv *.xml /tmp/current_xml_configuration/
-          mv *.txt /tmp/current_log_generated/
+          mv *.txt /tmp/current_log_generated/ || true
       - name: Generating diffs
         if: steps.dsl_check.outputs.run_job == 'true'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           sudo mkdir -p /var/lib/jenkins/ && sudo touch /var/lib/jenkins/remote_token
           sudo chown -R ${USER} /var/lib/jenkins
           cd jenkins-scripts/dsl
-          java -jar tools/jobdsl.jar *.dsl
+          WRITE_JOB_LOG=1 java -jar tools/jobdsl.jar *.dsl
           # export files for later diff
           mkdir /tmp/pr_xml_configuration
           mv *.xml /tmp/pr_xml_configuration/
@@ -60,7 +60,7 @@ jobs:
           git clean -f -e jobdsl.jar
           git checkout master
           cd jenkins-scripts/dsl
-          java -jar tools/jobdsl.jar *.dsl
+          WRITE_JOB_LOG=1 java -jar tools/jobdsl.jar *.dsl
           mkdir /tmp/current_xml_configuration
           mv *.xml /tmp/current_xml_configuration/
       - name: Generating diffs

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -10,7 +10,8 @@ GLOBAL_SHELL_CMD=''
 ENABLE_CPPCHECK = true
 
 def WRITE_JOB_LOG = System.getenv('WRITE_JOB_LOG') ?: false
-logging_list = []
+logging_list = [:]
+logging_list['branch_ci'] = []
 
 // Jenkins needs the relative path to work and locally the simulation is done
 // using a symlink
@@ -174,7 +175,6 @@ configs_per_lib_index.each { lib_name, lib_configs ->
     } // end of ci_any_job
 
     // CI branch jobs (-ci-$branch-) (pulling check every 5 minutes)
-    logging_list = []
     branches_with_collections.each { branch_and_collection ->
       branch_name = branch_and_collection.branch
       def gz_ci_job = job("${gz_job_name_prefix}-ci-${branch_name}-${distro}-${arch}")
@@ -186,7 +186,9 @@ configs_per_lib_index.each { lib_name, lib_configs ->
         }
       }
 
-      logging_list.add([collection: branch_and_collection.collection, job_name: gz_ci_job.name])
+      logging_list['branch_ci'].add(
+        [collection: branch_and_collection.collection,
+         job_name: gz_ci_job.name])
     } // end_of_branch
 
   } //en of lib_configs
@@ -195,6 +197,8 @@ configs_per_lib_index.each { lib_name, lib_configs ->
 if (WRITE_JOB_LOG) {
   File log_file = new File("jobs.txt")
   log_file.withWriter{ file_writer ->
-    logging_list.each {file_writer.println "${it.collection} ${it.job_name}"}
+    logging_list.each { log_type, items ->
+      items.each {file_writer.println "${log_type} ${it.collection} ${it.job_name}"}
+    }
   }
 }

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -9,6 +9,9 @@ GLOBAL_SHELL_CMD=''
 // GZ COLLECTIONS
 ENABLE_CPPCHECK = true
 
+def WRITE_JOB_LOG = System.getenv('WRITE_JOB_LOG') ?: false
+logging_list = []
+
 // Jenkins needs the relative path to work and locally the simulation is done
 // using a symlink
 file = readFileFromWorkspace("scripts/jenkins-scripts/dsl/gz-collections.yaml")
@@ -57,12 +60,16 @@ boolean is_testing_enabled(lib_name, ci_config)
  * avoiding to parse them several times.
  *
  * ci_configs_by_lib index structure:
- *   lib_name : [ ci_config_name : [ branches ] ]
+ *   lib_name : [ ci_config_name : [ .branch .collection ] ]
  *
  *   The index main keys are the lib names (i.e: gz-cmake) and associated them
  *   another map of CI configuration names supported as keys (i.e: jammy) with the
- *   list of associated branches for that CI configuration  (i.e [gz-cmake3, gz-cmake4])
- *   as values.
+ *   list of associated items composed by a map: branch (and collection) that CI configuration
+ *   (i.e [[branch:gz-cmake3, collection: harmonic], [branch: gz-cmake3, collection: garden])
+ *   as values. In a graphic;
+ *
+ *   index[gz-cmake][jammy] -> [ branch: gz-cmake3, collection: garden ,
+ *                               branch: gz-cmake3, collection: harmonic]
  */
 void generate_ciconfigs_by_lib(config, configs_per_lib_index)
 {
@@ -76,7 +83,7 @@ void generate_ciconfigs_by_lib(config, configs_per_lib_index)
       def branch = lib.repo.current_branch
       collection.ci.configs.each { config_name ->
         configs_per_lib_index["$libName"]["${config_name}"] = configs_per_lib_index["$libName"]["${config_name}"]?: []
-        configs_per_lib_index["$libName"]["${config_name}"].contains(branch) ?: configs_per_lib_index["$libName"]["${config_name}"] << branch
+        configs_per_lib_index["$libName"]["${config_name}"].contains(branch) ?: configs_per_lib_index["$libName"]["${config_name}"] << [branch: branch, collection: collection.name]
       }
     }
   }
@@ -124,7 +131,8 @@ configs_per_lib_index.each { lib_name, lib_configs ->
   lib_configs.each { ci_configs ->
     def config_name = ci_configs.getKey()
     def ci_config = gz_collections_yaml.ci_configs.find{ it.name == config_name }
-    def branch_names = ci_configs.getValue()
+    def branches_with_collections = ci_configs.getValue()
+    def branch_names = branches_with_collections.collect { it.branch }.unique()
     if (ci_config.exclude.contains(lib_name))
       return
     assert(lib_name)
@@ -166,7 +174,9 @@ configs_per_lib_index.each { lib_name, lib_configs ->
     } // end of ci_any_job
 
     // CI branch jobs (-ci-$branch-) (pulling check every 5 minutes)
-    branch_names.each { branch_name ->
+    logging_list = []
+    branches_with_collections.each { branch_and_collection ->
+      branch_name = branch_and_collection.branch
       def gz_ci_job = job("${gz_job_name_prefix}-ci-${branch_name}-${distro}-${arch}")
       generate_ci_job(gz_ci_job, lib_name, branch_name, ci_config)
       gz_ci_job.with
@@ -175,7 +185,16 @@ configs_per_lib_index.each { lib_name, lib_configs ->
           scm('@daily')
         }
       }
+
+      logging_list.add([collection: branch_and_collection.collection, job_name: gz_ci_job.name])
     } // end_of_branch
 
   } //en of lib_configs
 } // end of lib
+
+if (WRITE_JOB_LOG) {
+  File log_file = new File("jobs.txt")
+  log_file.withWriter{ file_writer ->
+    logging_list.each {file_writer.println "${it.collection} ${it.job_name}"}
+  }
+}


### PR DESCRIPTION
An attempt to store generated job names into a variable and a save that variable to a file. This tries to help different tools that consume the names of the jobs generated by the DSL, mainly the buildfarmer dashboard and the different Jenkins views.

The code uses the enviroment variable `WRITE_JOB_LOG` to active the mechanism of storing the job names into a file called `jobs.txt`. It can be invoked by `WRITE_JOB_LOG=1 java -jar tools/jobdsl.jar *.dsl`. The format of the file generated is (space separated):
```bah
job_type collection job_name
```

The PR uses the approach is GitHub action for also testing the generation and control the contents of the file generated. 