### PR TITLE
Limit physics to jobs to use MAKE_JOBS=1

### DIFF
--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -87,6 +87,8 @@ void generate_ci_job(gz_ci_job, lib_name, branch, ci_config,
 {
   def distro = ci_config.system.version
   def arch = ci_config.system.arch
+  def pre_setup_script = ci_config.pre_setup_script_hook.get(lib_name)?.join('\n')
+  extra_cmd = [extra_cmd, pre_setup_script].findAll({ it != null }).join()
 
   OSRFLinuxCompilation.create(gz_ci_job, is_testing_enabled(lib_name, ci_config))
   OSRFGitHub.create(gz_ci_job,
@@ -141,6 +143,8 @@ configs_per_lib_index.each { lib_name, lib_configs ->
     def gz_job_name_prefix = lib_name.replaceAll('-','_')
     def gz_ci_job_name = "${gz_job_name_prefix}-ci-pr_any-${distro}-${arch}"
     def gz_ci_any_job = job(gz_ci_job_name)
+    def pre_setup_script = ci_config.pre_setup_script_hook.get(lib_name)?.join('\n')
+    def extra_cmd = pre_setup_script ?: ""
     OSRFLinuxCompilationAnyGitHub.create(gz_ci_any_job,
                                          "gazebosim/${lib_name}",
                                          is_testing_enabled(lib_name, ci_config),
@@ -157,6 +161,7 @@ configs_per_lib_index.each { lib_name, lib_configs ->
               export DISTRO=${distro}
 
               ${GLOBAL_SHELL_CMD}
+              ${extra_cmd}
 
               export BUILDING_SOFTWARE_DIRECTORY=${lib_name}
               export ARCH=${arch}

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -87,7 +87,7 @@ void generate_ci_job(gz_ci_job, lib_name, branch, ci_config,
 {
   def distro = ci_config.system.version
   def arch = ci_config.system.arch
-  def pre_setup_script = ci_config.pre_setup_script_hook.get(lib_name)?.join('\n')
+  def pre_setup_script = ci_config.pre_setup_script_hook?.get(lib_name)?.join('\n')
   extra_cmd = [extra_cmd, pre_setup_script].findAll({ it != null }).join()
 
   OSRFLinuxCompilation.create(gz_ci_job, is_testing_enabled(lib_name, ci_config))
@@ -143,7 +143,7 @@ configs_per_lib_index.each { lib_name, lib_configs ->
     def gz_job_name_prefix = lib_name.replaceAll('-','_')
     def gz_ci_job_name = "${gz_job_name_prefix}-ci-pr_any-${distro}-${arch}"
     def gz_ci_any_job = job(gz_ci_job_name)
-    def pre_setup_script = ci_config.pre_setup_script_hook.get(lib_name)?.join('\n')
+    def pre_setup_script = ci_config.pre_setup_script_hook?.get(lib_name)?.join('\n')
     def extra_cmd = pre_setup_script ?: ""
     OSRFLinuxCompilationAnyGitHub.create(gz_ci_any_job,
                                          "gazebosim/${lib_name}",

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -142,6 +142,9 @@ ci_configs:
         - ign-gui
         - ign-rendering
         - ign-sensors
+    pre_setup_script_hook:
+      gz-physics:
+        - "export MAKE_JOBS=1"
     tests_disabled:
   - name: focal
     system:
@@ -160,6 +163,9 @@ ci_configs:
     exclude:
       - gz-fortress
       - gz-garden
+    pre_setup_script_hook:
+      ign-physics:
+        - "export MAKE_JOBS=1"
     tests_disabled:
   - name: jammy
     system:
@@ -177,4 +183,7 @@ ci_configs:
         - gz-sensors
     exclude:
       - gz-harmonic
+    pre_setup_script_hook:
+      gz-physics:
+        - "export MAKE_JOBS=1"
     tests_disabled:

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -419,7 +419,7 @@ gz_software.each { gz_sw ->
           label Globals.nontest_label("large-memory")
           // on ARM native nodes in buildfarm we need to restrict to 1 the
           // compilation threads to avoid OOM killer
-          extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=1; fi'
+          extra_str += '\nexport MAKE_JOBS=1'
         }
 
         steps {
@@ -458,8 +458,10 @@ gz_software.each { gz_sw ->
     include_gpu_label_if_needed(gz_ci_any_job, software_name)
     gz_ci_any_job.with
     {
-      if (gz_sw == 'physics')
+      if (gz_sw == 'physics') {
         label Globals.nontest_label("large-memory")
+        extra_str += '\nexport MAKE_JOBS=1'
+      }
 
       steps
       {
@@ -567,8 +569,10 @@ void generate_ci_job(gz_ci_job, gz_sw, branch, distro, arch,
   include_gpu_label_if_needed(gz_ci_job, gz_sw)
   gz_ci_job.with
   {
-    if (gz_sw == 'physics')
+    if (gz_sw == 'physics') {
       label Globals.nontest_label("large-memory")
+      extra_str += '\nexport MAKE_JOBS=1'
+    }
     if (gz_sw == 'gazebo')
       gz_sw = 'sim'
 
@@ -598,7 +602,7 @@ all_debbuilders().each { debbuilder_name ->
   // Gazebo physics consumes huge amount of memory making arm node to FAIL
   // Force here to use one compilation thread
   if (debbuilder_name.contains("-physics"))
-    extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=1; fi'
+    extra_str += '\nexport MAKE_JOBS=1'
 
   def build_pkg_job = job("${debbuilder_name}-debbuilder")
   OSRFLinuxBuildPkg.create(build_pkg_job)


### PR DESCRIPTION
Two different implementations:

 * Legacy code `ignition.dsl` 3336df73c134384f094bab20c77413e6e18d4f2c ; harcoding the check and the instructions in all the places.
 * New code based on yaml in `gazebo_libs` e564c79a03ed9f1bacc68551bd520a866905c502: implement `pre_setup_script_hook:` as part of the spec to support the injecting of random setup scripts for the different libraries. Define the MAKE_JOBS=1 for physics. 