### PR TITLE
Add OSRFReleasepy DSL class

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
@@ -1,0 +1,84 @@
+package _configs_
+
+import javaposse.jobdsl.dsl.Job
+import _configs_.Globals
+
+class OSRFReleasepy
+{
+  static void create(Job job, Map default_params = [:])
+  {
+    // Base class for the job
+    OSRFUNIXBase.create(job)
+
+    job.with
+    {
+      label Globals.nontest_label("master")
+
+      parameters
+      {
+        stringParam("PACKAGE",
+                    default_params.find{ it.key == "PACKAGE"}?.value,
+                    "Package name to be built")
+        stringParam("VERSION",
+                    default_params.find{ it.key == "VERSION"}?.value,
+                    "Packages version to be built or nightly (enable nightly build mode)")
+        stringParam("RELEASE_VERSION",
+                    default_params.find{ it.key == "RELEASE_VERSION"}?.value,
+                    "Packages release version")
+        stringParam("SOURCE_TARBALL_URI",
+                    default_params.find{ it.key == "SOURCE_TARBALL_URI"}?.value,
+                    "URL to the tarball containing the package sources")
+        stringParam("RELEASE_REPO_BRANCH",
+                    default_params.find{ it.key == "RELEASE_REPO_BRANCH"}?.value,
+                    "Branch from the -release repo to be used")
+        stringParam("UPLOAD_TO_REPO",
+                    default_params.find{ it.key == "UPLOAD_TO_REPO"}?.value,
+                    "OSRF repo name to upload the package to: stable | prerelease | nightly | none (for testing proposes)")
+        stringParam("EXTRA_OSRF_REPO",
+                    default_params.find{ it.key == "OSRF_REPOS_TO_USE"}?.value,
+                    "OSRF repos name to use when building the package")
+  
+        booleanParam('DRY_RUN',
+                    default_params.find{ it.key == "DRY_RUN"}?.value,
+                    'run a testing run with no effects')
+      }
+
+      steps {
+        systemGroovyCommand("""\
+          build.setDescription(
+          '<b>' + build.buildVariableResolver.resolve('PACKAGE') + '/' +
+          '' + build.buildVariableResolver.resolve('VERSION') + '-' +
+          build.buildVariableResolver.resolve('RELEASE_VERSION') + '</b>' +
+          '<br />' +
+          'branch: ' + build.buildVariableResolver.resolve('RELEASE_REPO_BRANCH') + ' | ' +
+          'upload to: ' + build.buildVariableResolver.resolve('UPLOAD_TO_REPO') +
+          '<br />' +
+          'RTOOLS_BRANCH: ' + build.buildVariableResolver.resolve('RTOOLS_BRANCH'));
+          """.stripIndent()
+        )
+
+        shell("""\
+            #!/bin/bash -xe
+            set +x # keep password secret
+            PASS=\$(cat \$HOME/build_pass)
+
+            dry_run_str=""
+            if \$DRY_RUN; then
+              dry_run_str="--dry-run"
+            fi
+
+            extra_osrf_repo=""
+            if [[ -n \${EXTRA_OSRF_REPO} ]]; then
+              extra_osrf_repo="--extra-osrf-repo \${EXTRA_OSRF_REPO}"
+            fi
+
+            echo "releasing \${n} (from branch \${src_branch})"
+              python3 ./scripts/release.py \${dry_run_str} "\${PACKAGE}" "\${VERSION}" "\${PASS}" \${extra_osrf_repo} \
+                      --release-repo-branch \${RELEASE_REPO_BRANCH} \
+                      --upload-to-repo \${UPLOAD_TO_REPO} > log || echo "MARK_AS_UNSTABLE"
+            echo " - done"
+            """.stripIndent())
+      }
+    }
+  }
+}

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -3,7 +3,7 @@ import javaposse.jobdsl.dsl.Job
 
 Globals.default_emails = "jrivero@osrfoundation.org"
 
-// Usual kobs
+// Usual CI jobs
 def ignition_ci_job = job("_test_job_from_dsl")
 OSRFLinuxBase.create(ignition_ci_job)
 def ignition_ci_job_mac = job("_test_job_from_dsl_mac")

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -3,7 +3,7 @@ import javaposse.jobdsl.dsl.Job
 
 Globals.default_emails = "jrivero@osrfoundation.org"
 
-// Jobs
+// Usual kobs
 def ignition_ci_job = job("_test_job_from_dsl")
 OSRFLinuxBase.create(ignition_ci_job)
 def ignition_ci_job_mac = job("_test_job_from_dsl_mac")
@@ -16,6 +16,10 @@ OSRFLinuxCompilationAnyGitHub.create(ignition_ci_pr_job,
                                      false,
                                      false,
                                      ['main'])
+
+// releasing testing job
+def releasepy_job = job("_test_releasepy")
+OSRFReleasepy.create(releasepy_job, [DRY_RUN: true])
 
 // -------------------------------------------------------------------
 def outdated_job_runner = job("_test_outdated_job_runner")


### PR DESCRIPTION
Wrapper to call release.py using Jenkins parameters as release.py arguments. Note that the script is not fully functional for standard releases since it currently requires a local software checkout to be run.

This can work with nightly builds or future calls to release.py that don't need to generate the tarballs.

The test inject DRY_RUN to avoid any real run.
Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_releasepy&build=7)](https://build.osrfoundation.org/job/_test_releasepy/7/)