### PR TITLE
Source code generation Jenkins DSL support

### DIFF
--- a/jenkins-scripts/docker/gz-source-generation.bash
+++ b/jenkins-scripts/docker/gz-source-generation.bash
@@ -1,0 +1,40 @@
+#!/bin/bash -xe
+[[ -L ${0} ]] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
+SCRIPT_DIR="${SCRIPT_DIR%/*}"
+
+echo '# BEGIN SECTION: setup the testing enviroment'
+# Define the name to be used in docker
+export DOCKER_JOB_NAME="source_generation_job"
+. ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+echo '# END SECTION'
+
+cat > build.sh << DELIM
+#!/bin/bash
+set -ex
+
+PKG_DIR=\$WORKSPACE/pkgs
+SOURCES_DIR=\$WORKSPACE/sources
+BUILD_DIR=\$SOURCES_DIR/build
+
+cd \${WORKSPACE}
+rm -fr \$SOURCES_DIR && mkdir \$SOURCES_DIR
+git clone --depth 1 --branch ${PACKAGE_NAME}_${VERSION} ${SOURCE_REPO_URI} \${SOURCES_DIR}
+rm -fr \$BUILD_DIR && mkdir \$BUILD_DIR
+cd \${BUILD_DIR}
+cmake .. -DPACKAGE_SOURCE_ONLY:BOOL=ON
+make package_source
+
+rm -fr \$PKG_DIR && mkdir \$PKG_DIR
+find \${BUILD_DIR} -maxdepth 1 -name '*${VERSION}.tar.*' -exec mv {} \${PKG_DIR} \\;
+
+if [ $(ls 2>/dev/null -Ubad1 -- "\${PKG_DIR}" | wc -l) -gt 1 ]; then
+  echo "Found more than one file inside pkgs directory:"
+  ls \${PKG_DIR}
+  exit 1
+fi
+DELIM
+
+export DEPENDENCY_PKGS="cmake git"
+
+. ${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash
+. ${SCRIPT_DIR}/lib/docker_run.bash

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -1,0 +1,60 @@
+package _configs_
+
+import javaposse.jobdsl.dsl.Job
+import _configs_.Globals
+
+class OSRFSourceCreation
+{
+  static void addParameters(Job job, Map default_params = [:])
+  {
+    job.with
+    {
+      parameters {
+        stringParam("VERSION",
+                    default_params.find{ it.key == "VERSION"}?.value,
+                    "Packages version to be built or nightly (enable nightly build mode)")
+        stringParam("RELEASE_VERSION",
+                    default_params.find{ it.key == "RELEASE_VERSION"}?.value,
+                    "Packages release version")
+        stringParam("RELEASE_REPO_BRANCH",
+                    default_params.find{ it.key == "RELEASE_REPO_BRANCH"}?.value,
+                    "Branch from the -release repo to be used")
+        stringParam("UPLOAD_TO_REPO",
+                    default_params.find{ it.key == "UPLOAD_TO_REPO"}?.value,
+                    "OSRF repo name to upload the package to: stable | prerelease | nightly | none (for testing proposes)")
+      }
+    }
+  }
+
+  static void create(Job job, Map default_params = [:])
+  {
+    OSRFLinuxBuildPkgBase.create(job)
+    GenericRemoteToken.create(job)
+    OSRFSourceCreation.addParameters(job, default_params)
+
+    job.with
+    {
+      wrappers {
+        preBuildCleanup()
+      }
+
+      properties {
+        priority 100
+      }
+
+      steps {
+        systemGroovyCommand("""\
+          build.setDescription(
+          '<b>' + build.buildVariableResolver.resolve('VERSION') + '-' +
+          build.buildVariableResolver.resolve('RELEASE_VERSION') + '</b>' +
+          '<br />' +
+          'branch: ' + build.buildVariableResolver.resolve('RELEASE_REPO_BRANCH') + ' | ' +
+          'upload to: ' + build.buildVariableResolver.resolve('UPLOAD_TO_REPO') +
+          '<br />' +
+          'RTOOLS_BRANCH: ' + build.buildVariableResolver.resolve('RTOOLS_BRANCH'));
+          """.stripIndent()
+        )
+      }
+    }
+  }
+}

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -10,6 +10,12 @@ class OSRFSourceCreation
     job.with
     {
       parameters {
+        stringParam("PACKAGE_NAME",
+                    default_params.find{ it.key == "PACKAGE_NAME"}?.value,
+                    "Software name (i.e gz-cmake3)")
+        stringParam("SOURCE_REPO_URI",
+                    default_params.find{ it.key == "SOURCE_REPO_URI"}?.value,
+                    "GitHub URI to release the sources from (i.e: https://github.com/gazebosim/gz-cmake.git)")
         stringParam("VERSION",
                     default_params.find{ it.key == "VERSION"}?.value,
                     "Packages version to be built or nightly (enable nightly build mode)")
@@ -34,6 +40,8 @@ class OSRFSourceCreation
 
     job.with
     {
+      label Globals.nontest_label("docker")
+
       wrappers {
         preBuildCleanup()
       }
@@ -54,6 +62,14 @@ class OSRFSourceCreation
           'RTOOLS_BRANCH: ' + build.buildVariableResolver.resolve('RTOOLS_BRANCH'));
           """.stripIndent()
         )
+
+        shell("""\
+            #!/bin/bash -xe
+            export DISTRO=jammy
+            export ARCH=amd64
+
+            /bin/bash -x ./scripts/jenkins-scripts/docker/gz-source-generation.bash
+            """.stripIndent())
       }
     }
   }

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -17,6 +17,30 @@ OSRFLinuxCompilationAnyGitHub.create(ignition_ci_pr_job,
                                      false,
                                      ['main'])
 
+
+
+def gz_source_job = job("_test_gz_source")
+OSRFSourceCreation.create(gz_source_job)
+gz_source_job.with
+{
+  label Globals.nontest_label("docker")
+
+  def PACKAGE_NAME="gz-cmake3"
+
+  steps {
+    shell("""\
+          #!/bin/bash -xe
+
+          # Use Jammy/amd64 as base image to generate sources
+          export DISTRO=jammy
+          export ARCH=amd64
+          export PACKAGE_NAME=${PACKAGE_NAME}
+          export SOURCE_REPO_URI=https://github.com/gazebosim/gz-cmake.git
+
+          /bin/bash -x ./scripts/jenkins-scripts/docker/gz-source-generation.bash
+          """.stripIndent())
+  }
+}
 // -------------------------------------------------------------------
 def outdated_job_runner = job("_test_outdated_job_runner")
 OSRFBase.create(outdated_job_runner)

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -17,30 +17,11 @@ OSRFLinuxCompilationAnyGitHub.create(ignition_ci_pr_job,
                                      false,
                                      ['main'])
 
-
-
 def gz_source_job = job("_test_gz_source")
-OSRFSourceCreation.create(gz_source_job)
-gz_source_job.with
-{
-  label Globals.nontest_label("docker")
+OSRFSourceCreation.create(gz_source_job, [
+  PACKAGE_NAME: "gz-cmake3",
+  SOURCE_REPO_URI: "https://github.com/gazebosim/gz-cmake.git"])
 
-  def PACKAGE_NAME="gz-cmake3"
-
-  steps {
-    shell("""\
-          #!/bin/bash -xe
-
-          # Use Jammy/amd64 as base image to generate sources
-          export DISTRO=jammy
-          export ARCH=amd64
-          export PACKAGE_NAME=${PACKAGE_NAME}
-          export SOURCE_REPO_URI=https://github.com/gazebosim/gz-cmake.git
-
-          /bin/bash -x ./scripts/jenkins-scripts/docker/gz-source-generation.bash
-          """.stripIndent())
-  }
-}
 // -------------------------------------------------------------------
 def outdated_job_runner = job("_test_outdated_job_runner")
 OSRFBase.create(outdated_job_runner)


### PR DESCRIPTION
The PR implements the creation of Jenkins jobs that generates and export a tarball for software that uses `gz-cmake`. 

Three main actions:
 -  Script to generate tarballs from Gazebo libs source code 
 - DSL class for the tarball generation 
 - Add a test job for the source generation

Testing [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_gz_source&build=44)](https://build.osrfoundation.org/job/_test_gz_source/44/)