### PR TITLE
Change caching dir to default one 

### DIFF
--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -304,8 +304,7 @@ if [%1] == [] (
   echo "_install_and_upgrade_vcpkg_package called with no argument"
   goto :error
 )
-:: workaround on permissions problems for default VCPKG_DEFAULT_BINARY_CACHE
-set VCPKG_DEFAULT_BINARY_CACHE=C:\Windows\Temp\vcpkg
+
 if not exist %VCPKG_DEFAULT_BINARY_CACHE% mkdir %VCPKG_DEFAULT_BINARY_CACHE%
 %VCPKG_CMD% install --recurse "%1" --overlay-ports="%VCPKG_OSRF_DIR%"
 :: vcpkg does not upgrade installed packages using the install command

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -304,7 +304,6 @@ if [%1] == [] (
   echo "_install_and_upgrade_vcpkg_package called with no argument"
   goto :error
 )
-
 if not exist %VCPKG_DEFAULT_BINARY_CACHE% mkdir %VCPKG_DEFAULT_BINARY_CACHE%
 %VCPKG_CMD% install --recurse "%1" --overlay-ports="%VCPKG_OSRF_DIR%"
 :: vcpkg does not upgrade installed packages using the install command

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -304,6 +304,9 @@ if [%1] == [] (
   echo "_install_and_upgrade_vcpkg_package called with no argument"
   goto :error
 )
+:: workaround on permissions problems for default VCPKG_DEFAULT_BINARY_CACHE
+set VCPKG_DEFAULT_BINARY_CACHE=C:\Users\Administrator\AppData\Local\vcpkg\archives
+if not exist %VCPKG_DEFAULT_BINARY_CACHE% mkdir %VCPKG_DEFAULT_BINARY_CACHE%
 %VCPKG_CMD% install --recurse "%1" --overlay-ports="%VCPKG_OSRF_DIR%"
 :: vcpkg does not upgrade installed packages using the install command
 :: since most of the packages are coming from a frozen snapshot, it is

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -304,7 +304,6 @@ if [%1] == [] (
   echo "_install_and_upgrade_vcpkg_package called with no argument"
   goto :error
 )
-if not exist %VCPKG_DEFAULT_BINARY_CACHE% mkdir %VCPKG_DEFAULT_BINARY_CACHE%
 %VCPKG_CMD% install --recurse "%1" --overlay-ports="%VCPKG_OSRF_DIR%"
 :: vcpkg does not upgrade installed packages using the install command
 :: since most of the packages are coming from a frozen snapshot, it is


### PR DESCRIPTION
### Description
This PR modifies the location of the cache files in the agent to mirror the default configuration where vcpkg builds it. The goal of this is to use the baked AMI cache instead of rebuilding it every time a new agent comes to life. 

#### Build test with new baked AMI
[![Build Status](https://build.osrfoundation.org/job/test_ignition_common-pr-win/7/badge/icon)](https://build.osrfoundation.org/job/test_ignition_common-pr-win/7/)