### PR TITLE
Default timeout value in _gazebo_utils

### DIFF
--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -84,12 +84,14 @@ cd build-deps
 # nightlies uploads.
 update_done=false
 seconds_waiting=0
+timeout=\${timeout:-0}
 while (! \$update_done); do
   sudo DEBIAN_FRONTEND=noninteractive mk-build-deps \
     -r -i ../debian/control \
     --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes' \
   && break
   sleep 60 && seconds_waiting=\$((seconds_waiting+60))
+  apt-get update
   [ \$seconds_waiting -ge \$timeout ] && exit 1
 done
 cd ..


### PR DESCRIPTION
Tested [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros-gz-image-bloom-debbuilder&build=18)](https://build.osrfoundation.org/job/ros-gz-image-bloom-debbuilder/18/)