### PR TITLE
Patches and doc for GzHarmonic ros_gz creation

### DIFF
--- a/bloom/ros_gz/Dockerfile
+++ b/bloom/ros_gz/Dockerfile
@@ -17,11 +17,11 @@ RUN apt-get update && apt-get install -y \
       wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Install osrf-rosdep for Gazebo distributions not in ROS
+# Install osrf-rosdep for Gazebo distributions not in ROS.
+# Note that 01 is important to give priority to the replace list below
 RUN sudo bash -c \
-  'wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list'
-# Replace url
-# since it does not support arbitrary environment variables
+  'wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/01-gazebo.list'
+# Bloom does not support environment vars, use the trick or replacing one rosdep keys by others
 RUN sudo bash -c \
   "wget $URL_OSRF_ROSDEP_REPLACE -O /etc/ros/rosdep/sources.list.d/00-replace-gz.list"
 

--- a/bloom/ros_gz/README.md
+++ b/bloom/ros_gz/README.md
@@ -55,6 +55,19 @@ package name.
     - Usage: `$ rename-ros_gz-pkgs.bash <desired_gz_version> <space separted list of rosdistros to release>`
     - Example: `$ rename-ros_gz-pkgs.bash garden humble`
 
+The script supports to inject a custom RELEASE_REPO_URL that points to a bloom gbp
+repository different than https://github.com/gazebo-release/ros_ign-release.
+
+```
+i.e use a https://github.com/gazebo-testing/ros_ign-gzharmonic-release as gbp testing repository
+
+RELEASE_REPO_URL=https://github.com/gazebo-testing/ros_ign-gzharmonic-release \
+  ./bloom_from_special_env.bash \
+    humble \
+    garden \
+    https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
+```
+
 
 ### 2.2 Create a custom track in tracks.yml
 

--- a/bloom/ros_gz/README.md
+++ b/bloom/ros_gz/README.md
@@ -27,6 +27,14 @@ Although using the officially supported version is the recommended way
 specially for non experienced users, some use cases might need to use a
 newer version of Gazebo than the one selected in REP-2000.
 
+### List of active relases
+
+| Gazebo Release | ROS / ROS 2 Release | status     | ros_gz branch | -release repository |
+| ---------------|---------------------|------------|---------------|---------------------|
+| Garden         | Humble              | stable     | humble        | https://github.com/gazebo-release/ros_ign-release |
+| Garden         | Iron                | prerelease | iron          | https://github.com/gazebo-release/ros_ign-release |
+| Harmonic       | Iron                | prerelease | ros2          | https://github.com/j-rivero/ros_ign-gzharmonic-release |
+
 ### Upstream versions released using this tutorial
 
 The `gbp -release repository` hosts the latest version released by the
@@ -34,6 +42,7 @@ maintainers of `ros_gz`. When using these instructions to release a new custom
 version the version of `ros_gz` released will be the latest one existing in the
 official `gbp -release repository`. The version would be the same but the
 release number will start on 1000.
+
 
 ## 2. Initial setup
 

--- a/bloom/ros_gz/rename-ros_gz-pkgs.bash
+++ b/bloom/ros_gz/rename-ros_gz-pkgs.bash
@@ -47,7 +47,9 @@ for pkg in ${PKGS}; do
     git commit debian/control.em debian/changelog.em -m "Patch name to release ${GZ_RELEASE} version"
     # Include conflict with initial package name in ROS
     sed -i -e '/^Depends/a\Conflicts: \@(Package)' debian/control.em
-
+    if [[ -n ${GZ_RELEASE_TO_CONFLICT} ]]; then
+      sed -i -e "s/Conflicts: @(Package)/Conflicts: @(Package.replace('-gz','-gz${GZ_RELEASE_TO_CONFLICT}'))/" debian/control.em
+    fi
     git commit debian/control.em -m "Set up a conflict with official ROS packages"
     git push origin "debian/$distro/$pkg"
   done


### PR DESCRIPTION
Three small things to finish with changes in the scripting:

 * [Support conflicting versions of unofficial wrappers](https://github.com/gazebo-tooling/release-tools/commit/def8aa189b8869f7cc1c5a8a8b29b48f1cecdf40)
 * [Complete README with custom RELEASE_REPO_URL](https://github.com/gazebo-tooling/release-tools/commit/1f0675200b460de5505e12c666b313a1ac04e1ba)
 * [Important precedence when adding rosdep keys](https://github.com/gazebo-tooling/release-tools/commit/b0e7884e67ae0b46b09655db56d2cff902ca2cc9)
