### PR TITLE
Install gz-sim*-cli on ros_gz testing builds

### DIFF
--- a/jenkins-scripts/docker/ros_gz-install-test-job.bash
+++ b/jenkins-scripts/docker/ros_gz-install-test-job.bash
@@ -30,6 +30,10 @@ fi
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: test gz_sim via ros2 launch'
+# Workaround until ros_gz defines a dependency on gz-sim*-cli. Avoid to use
+# apt --install-suggests since it installs the whole universe of packages
+VER=dpkg -l | grep libgz-sim | grep ^ii | head -1 | awk '{ print \$3 '}
+apt-get install -y gz-sim\${VER:0:1}-cli
 TEST_START=\`date +%s\`
 # preserve-status did not work here
 timeout 180 ros2 launch ros_gz_sim gz_sim.launch.py gz_args:=shapes.sdf || true
@@ -42,9 +46,6 @@ if [ \$DIFF -lt 180 ]; then
 fi
 """
 
-# Need bc to proper testing and parsing the time
-# TODO: fix gz-sim-cli dependency on ros_gz package
-# to avoid hardcoded version on gz-sim
-export DEPENDENCY_PKGS="${DEPENDENCY_PKGS} wget ros-${ROS_DISTRO}-ros-base gz-sim7-cli"
+export DEPENDENCY_PKGS="${DEPENDENCY_PKGS} wget ros-${ROS_DISTRO}-ros-base"
 
 . ${SCRIPT_DIR}/lib/generic-install-base.bash

--- a/jenkins-scripts/docker/ros_gz-install-test-job.bash
+++ b/jenkins-scripts/docker/ros_gz-install-test-job.bash
@@ -32,7 +32,7 @@ echo '# END SECTION'
 echo '# BEGIN SECTION: test gz_sim via ros2 launch'
 # Workaround until ros_gz defines a dependency on gz-sim*-cli. Avoid to use
 # apt --install-suggests since it installs the whole universe of packages
-VER=\$(dpkg -l | grep libgz-sim | grep ^ii | head -1 | awk '{ print \$3 '})
+VER=\$(dpkg -l | grep libgz-sim | grep ^ii | head -1 | awk '{ print \$3 }')
 sudo apt-get install -y gz-sim\${VER:0:1}-cli
 TEST_START=\`date +%s\`
 # preserve-status did not work here

--- a/jenkins-scripts/docker/ros_gz-install-test-job.bash
+++ b/jenkins-scripts/docker/ros_gz-install-test-job.bash
@@ -32,8 +32,8 @@ echo '# END SECTION'
 echo '# BEGIN SECTION: test gz_sim via ros2 launch'
 # Workaround until ros_gz defines a dependency on gz-sim*-cli. Avoid to use
 # apt --install-suggests since it installs the whole universe of packages
-VER=dpkg -l | grep libgz-sim | grep ^ii | head -1 | awk '{ print \$3 '}
-apt-get install -y gz-sim\${VER:0:1}-cli
+VER=\$(dpkg -l | grep libgz-sim | grep ^ii | head -1 | awk '{ print \$3 '})
+sudo apt-get install -y gz-sim\${VER:0:1}-cli
 TEST_START=\`date +%s\`
 # preserve-status did not work here
 timeout 180 ros2 launch ros_gz_sim gz_sim.launch.py gz_args:=shapes.sdf || true


### PR DESCRIPTION
The `ros_gz_sim` package for being able to run with ros launch needs to have the `gz-sim*-cli` package. This is probably a bug in `ros_gz` code.

Until we get that fixed, this PR adds automatically that package into the testing job so the smoke test can be run.

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros_gz_bridge-install-pkg_unofficial-any-manual&build=55)](https://build.osrfoundation.org/job/ros_gz_bridge-install-pkg_unofficial-any-manual/55/)