### PR TITLE
Add ci_matching_branch/ for bottle install jobs

### DIFF
--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -47,12 +47,12 @@ brew tap osrf/simulation
 echo '# END SECTION'
 
 if [[ -n "${RTOOLS_BRANCH}" ]] && \
-   python3 ${SCRIPT_DIR}/tools/detect_ci_matching_branch.py "${RTOOLS_BRANCH}"
+   python3 "${SCRIPT_DIR}/tools/detect_ci_matching_branch.py" "${RTOOLS_BRANCH}"
 then
   echo "# BEGIN SECTION: trying to checkout branch ${RTOOLS_BRANCH} from osrf/simulation"
-  pushd $(brew --repo osrf/simulation)
-  git fetch origin ${RTOOLS_BRANCH} || true
-  git checkout ${RTOOLS_BRANCH} || true
+  pushd "$(brew --repo osrf/simulation)"
+  git fetch origin "${RTOOLS_BRANCH}" || true
+  git checkout "${RTOOLS_BRANCH}" || true
   popd
   echo '# END SECTION'
 fi

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -46,8 +46,7 @@ echo '# BEGIN SECTION: setup the osrf/simulation tap'
 brew tap osrf/simulation
 echo '# END SECTION'
 
-if [[ -n "${RTOOLS_BRANCH}" ]] && \
-   python3 "${SCRIPT_DIR}/tools/detect_ci_matching_branch.py" "${RTOOLS_BRANCH}"
+if python3 "${SCRIPT_DIR}/tools/detect_ci_matching_branch.py" "${RTOOLS_BRANCH}"
 then
   echo "# BEGIN SECTION: trying to checkout branch ${RTOOLS_BRANCH} from osrf/simulation"
   pushd "$(brew --repo osrf/simulation)"

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -46,6 +46,17 @@ echo '# BEGIN SECTION: setup the osrf/simulation tap'
 brew tap osrf/simulation
 echo '# END SECTION'
 
+if [[ -n "${RTOOLS_BRANCH}" ]] && \
+   python3 ${SCRIPT_DIR}/tools/detect_ci_matching_branch.py "${RTOOLS_BRANCH}"
+then
+  echo "# BEGIN SECTION: trying to checkout branch ${RTOOLS_BRANCH} from osrf/simulation"
+  pushd $(brew --repo osrf/simulation)
+  git fetch origin ${RTOOLS_BRANCH} || true
+  git checkout ${RTOOLS_BRANCH} || true
+  popd
+  echo '# END SECTION'
+fi
+
 echo "# BEGIN SECTION: install ${BOTTLE_NAME}"
 brew install --include-test ${BOTTLE_NAME}
 


### PR DESCRIPTION
We have started documenting how to use the `ci_matching_branch/` naming pattern to use custom branches from tooling repositories in pull request CI in https://github.com/gazebosim/docs/pull/377. This PR will add the `ci_matching_branch/` functionality to the `install_bottle` jobs in the following way:

* If the release-tools branch (`RTOOLS_BRANCH`) for an `install_bottle` job starts with `ci_matching_branch/`, then it will try to check out a matching branch from the `osrf/homebrew-simulation` tap.

As an example for when this could be used, I'd like to re-enable a test for the `gz-sim7` formula that has been disabled for macOS Monterey since a fix in https://github.com/gazebosim/gz-physics/pull/529 has been merged and released. The test is enabled in https://github.com/osrf/homebrew-simulation/commit/2bf74acf05b9388fe12ae5942f9dc7866ebd1e1c in the `ci_matching_branch/install_bottle` branch (which matches the branch name of this release-tools pull request) and tested in the following job, which happened to run on [mac-five.monterey](https://build.osrfoundation.org/computer/mac-five.monterey/) and passed the enabled test:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_sim7-install_bottle-homebrew-amd64&build=185)](https://build.osrfoundation.org/job/ignition_sim7-install_bottle-homebrew-amd64/185/) https://build.osrfoundation.org/job/ignition_sim7-install_bottle-homebrew-amd64/185/

~~~
# BEGIN SECTION: run tests
+ brew linkage --test gz-sim7
+ brew ruby -e 'exit '\''gz-sim7'\''.f.test_defined?'
+ brew test gz-sim7
==> Testing osrf/simulation/gz-sim7
[34m==>[0m [1m/usr/local/opt/ruby/bin/ruby /usr/local/opt/gz-tools2/bin/gz sim -s --iterat[0m
[34m==>[0m [1mcmake ..[0m
[34m==>[0m [1mmake[0m
[34m==>[0m [1m./test_cmake[0m
[34m==>[0m [1m! grep -rnI 'Applications[/]Xcode' /usr/local/Cellar/gz-sim7/7.5.0_8[0m
+ brew audit --strict gz-sim7
+ echo '# END SECTION'
# END SECTION
~~~