### PR TITLE
Make repository_uploader to support S3_FILES_TO_UPLOAD 

### DIFF
--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -131,8 +131,12 @@ case ${UPLOAD_TO_REPO} in
   ;;
 esac
 
-# .zip | (mostly) windows packages
-for pkg in `ls $pkgs_path/*.zip`; do
+
+# S3_FILES_TO_UPLOAD can contain a list of filenames relative to $pkgs_path that will be uploaded to S3
+# together with any .zip (mostly old windows packages) if they exists
+S3_FILES_TO_UPLOAD="${S3_FILES_TO_UPLOAD} $(find "$pkgs_path" -type f -name '*.zip' -printf '%f\n' || true)"
+
+for pkg in ${S3_FILES_TO_UPLOAD}; do
   # S3_UPLOAD_PATH should be send by the upstream job
   if [[ -z ${S3_UPLOAD_PATH} ]]; then
     echo "S3_UPLOAD_PATH was not defined. Not uploading"
@@ -140,7 +144,7 @@ for pkg in `ls $pkgs_path/*.zip`; do
   fi
 
   # Seems important to upload the path with a final slash
-  S3_upload ${pkg} "${S3_UPLOAD_PATH}"
+  S3_upload "${pkgs_path}/${pkg}" "${S3_UPLOAD_PATH}"
 done
 
 # .bottle | brew binaries


### PR DESCRIPTION
Change in repository_uploader to be able to pass files directly to the S3 uploaders by naming them exactly. This should help with the right upload of new tarballs generated in Jenkins.

The `repository_uploader_packages` job does not have a DSL definition yet but [I have tested](https://build.osrfoundation.org/job/repository_uploader_packages/43063/) the execution of the code in an expected failed build to be sure that the uploader does not fail when there is no package specified and just the normal use of uploading .deb packages and source packages.

```
...
+ case ${UPLOAD_TO_REPO} in
+ ENABLE_S3_UPLOAD=false
++ find /home/jenkins/workspace/repository_uploader_packages/pkgs -type f -name '*.zip' -printf '%f\n'
+ S3_FILES_TO_UPLOAD=' '
++ find /home/jenkins/workspace/repository_uploader_packages/pkgs -name '*.bottle*.json'
+ [[ nightly == \o\n\l\y\_\s\3\_\u\p\l\o\a\d ]]
+ LINUX_DISTRO=ubuntu
+ repo_path=/var/packages/gazebo/ubuntu-nightly
+ [[ ! -d /var/packages/gazebo/ubuntu-nightly ]]
...
```