### PR TITLE
Do use ign instead of gz for testing ROS imports on Fortress

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -432,6 +432,9 @@ gz_collections_yaml.collections.each { collection ->
              export ROS_BOOTSTRAP=true
              # needed for arm64 machines and other arch tests
              export ENABLE_GZ_SIM_RUNTIME_TEST=false
+             if [[ ${gz_collection_name} == 'citadel' || ${gz_collection_name} == 'fortress' ]]; then
+                export GZ_SIM_RUNTIME_TEST_USE_IGN=true
+             fi
              if [[ \${JENKINS_NODE_TAG} == 'gpu-reliable' ]]; then
                export ENABLE_GZ_SIM_RUNTIME_TEST=true
              fi


### PR DESCRIPTION
Minor fix for ROS bootstrap repository testing:

Before: [![Build Status](https://build.osrfoundation.org/job/ignition_fortress-install-pkg_ros_bootstrap-any-manual/22/badge/icon)](https://build.osrfoundation.org/job/ignition_fortress-install-pkg_ros_bootstrap-any-manual/22/)

After: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fortress-install-pkg_ros_bootstrap-any-manual&build=24)](https://build.osrfoundation.org/job/ignition_fortress-install-pkg_ros_bootstrap-any-manual/24/)

