### PR TITLE
Fixes for reprepro-importer

### DIFF
--- a/jenkins-scripts/docker/reprepro_updater.bash
+++ b/jenkins-scripts/docker/reprepro_updater.bash
@@ -40,7 +40,6 @@ git clone "${REPREPRO_GIT_REPO}" -b "${REPREPRO_GIT_BRANCH}" "${REPREPRO_REPO_PA
 echo '# END SECTION'
 
 export PYTHONPATH="${REPREPRO_REPO_PATH}/src"
-export GNUPGHOME=/var/lib/jenkins/.gnupg 
 
 echo '# BEGIN SECTION: run reprepro'
 cd "${REPREPRO_REPO_PATH}/scripts"

--- a/jenkins-scripts/docker/reprepro_updater.bash
+++ b/jenkins-scripts/docker/reprepro_updater.bash
@@ -44,9 +44,9 @@ export GNUPGHOME=/var/lib/jenkins/.gnupg
 
 echo '# BEGIN SECTION: run reprepro'
 cd "${REPREPRO_REPO_PATH}/scripts"
-sudo -E bash -c "PYTHONPATH=${REPREPRO_REPO_PATH}/src python3 import_upstream.py ${REPREPRO_PARAMS} \
-  ${UPLOAD_TO_REPO:-:_} \
-  ${REPREPRO_REPO_PATH}/config/packages.osrfoundation.org/${REPREPRO_IMPORT_YAML_FILE}"
+PYTHONPATH=${REPREPRO_REPO_PATH}/src python3 import_upstream.py ${REPREPRO_PARAMS} \
+  "${UPLOAD_TO_REPO:-:_}" \
+  "${REPREPRO_REPO_PATH}/config/packages.osrfoundation.org/${REPREPRO_IMPORT_YAML_FILE}"
 echo '# END SECTION'
 
 echo '#BEGIN: exit the venv'


### PR DESCRIPTION
The packages machines no longer uses sudo rights: b2f6a297c11331a936c81367f1a38f5e9d16bc4f
The GNUPGHOME directory no longer needs to be hardcoded: 3a2ac8fbbf6406ed044f4b89fc715db1e87beae8

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=reprepro_importer&build=86)](https://build.osrfoundation.org/job/reprepro_importer/86/)