### PR TITLE
Disable S3 uploads for the testing repository

### DIFF
--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -112,8 +112,8 @@ case ${UPLOAD_TO_REPO} in
       exit 1
     fi
   ;;
-  "nightly")
-    # No uploads for nightly packages test runs
+  "nightly" | "testing")
+    # No uploads for nightly or testing packages test runs
     ENABLE_S3_UPLOAD=false
   ;;
   "none")


### PR DESCRIPTION
When using the testing (experimental) repository, disable the S3 uploads.

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=repository_uploader_packages&build=43388)](https://build.osrfoundation.org/job/repository_uploader_packages/43388/)