### PR TITLE
Fix -release repository check in release.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -183,12 +183,8 @@ def parse_args(argv):
     return args
 
 def get_release_repository_info(package):
-    # Do not use git@github method since it fails in non existant repositories
-    # asking for stdin user/pass. Same happen if no user/pass is provided
-    # using the fake foo:foo here seems to work
-    github_test_url = "https://foo:foo@github.com/gazebo-release/" + package + "-release"
-    if (github_repo_exists(github_test_url)):
-        github_url = "https://github.com/gazebo-release/" + package + "-release"
+    github_url = "https://github.com/gazebo-release/" + package + "-release"
+    if (github_repo_exists(github_url)):
         return 'git', github_url
 
     error("release repository not found in github.com/gazebo-release")


### PR DESCRIPTION
Fix the fail in the check for github repository, that now displays the error:
```bash
Error running command (git ls-remote -q --exit-code https://foo:foo@github.com/gazebo-release/gz-cmake-release).
stdout: 
stderr: remote: Support for password authentication was removed on August 13, 2021.
remote: Please see https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
fatal: Authentication failed for 'https://github.com/gazebo-release/gz-cmake-release/'
```
