### PR TITLE
Change all PR ci jobs (-ci-pr_any-) to use the yaml configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 # base_ref / head_reaf are only available in PRs
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   dsl_ci:
@@ -12,18 +12,39 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Idenfify files changed in this PR
+        id: files
+        run: |
+            git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}
+            echo "changed-files=$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}| tr '\n' ' ')"  >> $GITHUB_OUTPUT
+      - name: Run testing on changed config files
+        id: dsl_check
+        run: |
+          for changed_file in ${{ steps.files.outputs.changed-files }}; do
+            if [[ ${changed_file} != ${changed_file/dsl\/*} ]]; then
+              echo "+ Detected at leat one config file: ${changed_file}."
+              echo "run_job=true" >> $GITHUB_OUTPUT
+              break
+            else
+              echo "run_job=false" >> $GITHUB_OUTPUT
+            fi
+          done
       - name: Checkout
+        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/setup-java@v3
+        if: steps.dsl_check.outputs.run_job == 'true'
         with:
           distribution: 'temurin'
           java-version: '11'
       - name: Download and setup job dsl jar
+        if: steps.dsl_check.outputs.run_job == 'true'
         run: ./jenkins-scripts/dsl/tools/setup_local_generation.bash
 
       - name: Generate all DSL files
+        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           # simulate token for brew_release
           sudo mkdir -p /var/lib/jenkins/ && sudo touch /var/lib/jenkins/remote_token
@@ -35,6 +56,7 @@ jobs:
           mv *.xml /tmp/pr_xml_configuration/
           mv *.txt /tmp/pr_log_generated/
       - name: Generate master DSL files
+        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           git clean -f -e jobdsl.jar
           git checkout master
@@ -44,22 +66,26 @@ jobs:
           mv *.xml /tmp/current_xml_configuration/
           mv *.txt /tmp/current_log_generated/ || true
       - name: Generating diffs
+        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           # somehow the Jenkins views changed the portlet_ id on every run.
           diff -qr -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration > /tmp/xml_config_files_changed.diff || true
           diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration > /tmp/xml_config_content_changed.diff || true
           diff -ur /tmp/current_log_generated /tmp/pr_log_generated > /tmp/log_content_changed.diff || true
       - name: Archive files changes
+        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: xml_config_files_changed
           path: /tmp/xml_config_files_changed.diff
       - name: Archive content changes
+        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: xml_config_content_changed
           path: /tmp/xml_config_content_changed.diff
       - name: Archive log changes
+        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: log_content_changed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 # base_ref / head_reaf are only available in PRs
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   dsl_ci:
@@ -12,39 +12,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Idenfify files changed in this PR
-        id: files
-        run: |
-            git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}
-            echo "changed-files=$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}| tr '\n' ' ')"  >> $GITHUB_OUTPUT
-      - name: Run testing on changed config files
-        id: dsl_check
-        run: |
-          for changed_file in ${{ steps.files.outputs.changed-files }}; do
-            if [[ ${changed_file} != ${changed_file/dsl\/*} ]]; then
-              echo "+ Detected at leat one config file: ${changed_file}."
-              echo "run_job=true" >> $GITHUB_OUTPUT
-              break
-            else
-              echo "run_job=false" >> $GITHUB_OUTPUT
-            fi
-          done
       - name: Checkout
-        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/setup-java@v3
-        if: steps.dsl_check.outputs.run_job == 'true'
         with:
           distribution: 'temurin'
           java-version: '11'
       - name: Download and setup job dsl jar
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: ./jenkins-scripts/dsl/tools/setup_local_generation.bash
 
       - name: Generate all DSL files
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           # simulate token for brew_release
           sudo mkdir -p /var/lib/jenkins/ && sudo touch /var/lib/jenkins/remote_token
@@ -56,7 +35,6 @@ jobs:
           mv *.xml /tmp/pr_xml_configuration/
           mv *.txt /tmp/pr_log_generated/
       - name: Generate master DSL files
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           git clean -f -e jobdsl.jar
           git checkout master
@@ -66,26 +44,22 @@ jobs:
           mv *.xml /tmp/current_xml_configuration/
           mv *.txt /tmp/current_log_generated/ || true
       - name: Generating diffs
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           # somehow the Jenkins views changed the portlet_ id on every run.
           diff -qr -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration > /tmp/xml_config_files_changed.diff || true
           diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration > /tmp/xml_config_content_changed.diff || true
           diff -ur /tmp/current_log_generated /tmp/pr_log_generated > /tmp/log_content_changed.diff || true
       - name: Archive files changes
-        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: xml_config_files_changed
           path: /tmp/xml_config_files_changed.diff
       - name: Archive content changes
-        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: xml_config_content_changed
           path: /tmp/xml_config_content_changed.diff
       - name: Archive log changes
-        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: log_content_changed

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -75,10 +75,6 @@ boolean is_testing_enabled(lib_name, ci_config)
 void generate_ciconfigs_by_lib(config, configs_per_lib_index)
 {
   config.collections.each { collection ->
-    // TODO(jrivero): limit to harmonic for testing proposes
-    if (collection.name != 'harmonic')
-      return
-
     collection.libs.each { lib ->
       def libName = lib.name
       def branch = lib.repo.current_branch
@@ -181,6 +177,10 @@ configs_per_lib_index.each { lib_name, lib_configs ->
 
     // CI branch jobs (-ci-$branch-) (pulling check every 5 minutes)
     branches_with_collections.each { branch_and_collection ->
+      // TODO: remove after testing
+      if (branch_and_collection.collection == 'harmonic')
+        return
+
       branch_name = branch_and_collection.branch
       def gz_ci_job = job("${gz_job_name_prefix}-ci-${branch_name}-${distro}-${arch}")
       generate_ci_job(gz_ci_job, lib_name, branch_name, ci_config)

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -178,7 +178,7 @@ configs_per_lib_index.each { lib_name, lib_configs ->
     // CI branch jobs (-ci-$branch-) (pulling check every 5 minutes)
     branches_with_collections.each { branch_and_collection ->
       // TODO: remove after testing
-      if (branch_and_collection.collection == 'harmonic')
+      if (branch_and_collection.collection != 'harmonic')
         return
 
       branch_name = branch_and_collection.branch

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -443,31 +443,13 @@ gz_software.each { gz_sw ->
     def gz_ci_job_name = "ignition_${software_name}-ci-pr_any-ubuntu_auto-${arch}"
     def gz_ci_any_job = job(gz_ci_job_name)
     def gz_checkout_dir = "ign-${software_name}"
-    OSRFLinuxCompilationAnyGitHub.create(gz_ci_any_job,
-                                        "gazebosim/${gz_checkout_dir}",
-                                         enable_testing(software_name))
-    include_gpu_label_if_needed(gz_ci_any_job, software_name)
+    GenericAnyJobGitHub.create(gz_ci_any_job,
+                              "gazebosim/${gz_checkout_dir}",
+                               [],
+                               true)
     gz_ci_any_job.with
     {
-      if (gz_sw == 'physics') {
-        label Globals.nontest_label("large-memory")
-        extra_str += '\nexport MAKE_JOBS=1'
-      }
-
-      steps
-      {
-         shell("""\
-              #!/bin/bash -xe
-
-              export DISTRO=${ci_distro_str}
-
-              ${GLOBAL_SHELL_CMD}
-
-              export ARCH=${arch}
-
-              /bin/bash -xe ./scripts/jenkins-scripts/docker/gz_${gz_sw.replaceAll('-','_')}-compilation.bash
-              """.stripIndent())
-      } // end of steps
+      description 'Automatic generated job by DSL jenkins. Stub job for migration, not doing any check'
     } // end of ci_any_job
 
     // add ci-pr_any to the list for CIWorkflow

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -87,24 +87,12 @@ ci_distro.each { distro ->
     }
 
     // --------------------------------------------------------------
-    // 2. Create the any job
+    // 2. Create a fake any job for migrating
+    // TODO: remove the job once the migration in https://github.com/gazebo-tooling/release-tools/issues/1010
+    // is done.
     String sdf_repo = "gazebosim/sdformat"
     def sdformat_ci_any_job = job(ci_build_any_job_name_linux)
-    OSRFLinuxCompilationAnyGitHub.create(sdformat_ci_any_job, sdf_repo)
-    sdformat_ci_any_job.with
-    {
-      steps
-      {
-         shell("""\
-         #!/bin/bash -xe
-
-         export DISTRO=${ci_distro_str}
-
-         export ARCH=${arch}
-         /bin/bash -xe ./scripts/jenkins-scripts/docker/sdformat-compilation.bash
-         """.stripIndent())
-       }
-     }
+    GenericAnyJobGitHub.create(sdformat_ci_any_job, sdf_repo)
   } // end of arch
 } // end of distro
 


### PR DESCRIPTION
The CI moves all CI done in our repositories to use the yaml documentation. After adding all distribution metadata to the yaml file in #1017, we are in the position of moving all the `-ci-pr_any-` generated jobs to use the yaml configuration. 

Until now the `-ci-pr_any-ubuntu-auto` jobs register all supported branches and dispatch the CI work. The new setup creates jobs based on the ubuntu distribution, so now the names are `-ci-pr_any-ubuntu-${distro}`. Each job register the supported branches (i.e: `-ci-pr_any-ubuntu-jammy` supports Garden and Harmonic branches).

Some details:
 * The current `-ci-pr_any-ubuntu-auto` jobs can not be renamed to the new `-ci-pr_any-ubuntu-${distro}`.  This PR set a transition step of returning always `true` from the old jobs before removing the completely. This should help people not to focus on the existing failing ones. After some weeks, the jobs will be removed. See 7473a18f44cb9c43b2e108f9ba2f41553db9cf56
 * We should cover new `main` branches jobs using the `__upcoming__` distribution defined in the yaml file.
 * The PR still does not generate the branches testing jobs `-ci-${branch}-` from the yaml file. This is for a new PR to reduce the scope of the testing. fbe24f3ccc74765e3d930e8d3188cbb70003c2ef
 * The -abichecker- jobs will follow after we check that ci-pr-any work as expected.

**Testing done:**

I have been using the XML diff to be sure that the configuration match the expectations from both, CI system and local checks. Here is what I have expected and results:

A) All the `ci-pr_any-ubuntu-auto` jobs should change to be just fake jobs that returns only true.

A1) Testing with the log file from the CI system in release-tools to see if all auto files differ:
```diff
/tmp ❯ grep auto log 
Files /tmp/current_xml_configuration/ignition_cmake-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_cmake-ci-pr_any-ubuntu_auto-amd64.xml differFiles /tmp/current_xml_configuration/ignition_common-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_common-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_fuel-tools-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_fuel-tools-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_gui-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_gui-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_launch-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_launch-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_math-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_math-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_msgs-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_msgs-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_physics-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_physics-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_plugin-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_plugin-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_rendering-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_rendering-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_sensors-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_sensors-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_tools-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_tools-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_transport-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_transport-ci-pr_any-ubuntu_auto-amd64.xml differ
Files /tmp/current_xml_configuration/ignition_utils-ci-pr_any-ubuntu_auto-amd64.xml and /tmp/pr_xml_configuration/ignition_utils-ci-pr_any-ubuntu_auto-amd64.xml differ
``` 

A2) Check a random job to see the returning true and a minimal configuration file:
```xml
<project>
    <actions></actions>
    <description>Automatic generated job by DSL jenkins. Stub job for migration, not doing any check</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.StringParameterDefinition>
                    <name>sha1</name>
                    <defaultValue>main</defaultValue>
                    <description>commit or refname to build. To manually use a branch: origin/$branch_name</description>
                </hudson.model.StringParameterDefinition>
            </parameterDefinitions>
        </hudson.model.ParametersDefinitionProperty>
        <com.coravy.hudson.plugins.github.GithubProjectProperty>
            <projectUrl>https://github.com/gazebosim/gz-cmake/</projectUrl>
        </com.coravy.hudson.plugins.github.GithubProjectProperty>
    </properties>
    <canRoam>true</canRoam>
    <disabled>false</disabled>
    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
    <triggers>
        <org.jenkinsci.plugins.ghprb.GhprbTrigger>
            <adminlist>osrf-jenkins j-rivero</adminlist>
            <orgslist>osrf gazebosim</orgslist>
            <allowMembersOfWhitelistedOrgsAsAdmin>true</allowMembersOfWhitelistedOrgsAsAdmin>
            <useGitHubHooks>true</useGitHubHooks>
            <onlyTriggerPhrase>false</onlyTriggerPhrase>
            <permitAll>true</permitAll>
            <spec></spec>
            <cron></cron>
            <whiteListTargetBranches></whiteListTargetBranches>
            <triggerPhrase>.*(re)?run test(s).*</triggerPhrase>
            <extensions>
                <org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
                    <commitStatusContext>${JOB_NAME}</commitStatusContext>
                    <triggeredStatus>starting deployment to build.osrfoundation.org</triggeredStatus>
                    <startedStatus>deploying to build.osrfoundation.org</startedStatus>
                    <addTestResults>true</addTestResults>
                </org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
                <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
                    <overrideGlobal>false</overrideGlobal>
                </org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
            </extensions>
        </org.jenkinsci.plugins.ghprb.GhprbTrigger>
    </triggers>
    <concurrentBuild>false</concurrentBuild>
    <builders></builders>
    <publishers></publishers>
    <buildWrappers></buildWrappers>
    <scm class='hudson.plugins.git.GitSCM'>
        <userRemoteConfigs>
            <hudson.plugins.git.UserRemoteConfig>
                <refspec>+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*</refspec>
                <url>https://github.com/gazebosim/gz-cmake.git</url>
            </hudson.plugins.git.UserRemoteConfig>
        </userRemoteConfigs>
        <branches>
            <hudson.plugins.git.BranchSpec>
                <name>${sha1}</name>
            </hudson.plugins.git.BranchSpec>
        </branches>
        <configVersion>2</configVersion>
        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
        <gitTool>Default</gitTool>
        <extensions>
            <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
                <relativeTargetDir>ign-cmake</relativeTargetDir>
            </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
        </extensions>
        <browser class='hudson.plugins.git.browser.GithubWeb'>
            <url>https://github.com/gazebosim/gz-cmake/</url>
        </browser>
    </scm>
</project>
```

A3) Test in Jenkins that new fake jobs works returning just true:
https://build.osrfoundation.org/job/_test_migration_ci_pr_any/2/

B) Existing `ci-pr_any-ubuntu-jammy` jobs created for Harmonic and in use would need to support the branches in upcoming:

B1) XML log diff should report only jammy jobs if we don't include the -auto jobs mentioned in A).
```diff
/tmp ❯ grep differ log  | grep -v auto
Files /tmp/current_xml_configuration/gz_cmake-ci-pr_any-jammy-amd64.xml and /tmp/pr_xml_configuration/gz_cmake-ci-pr_any-jammy-amd64.xml differ
Files /tmp/current_xml_configuration/gz_common-ci-pr_any-jammy-amd64.xml and /tmp/pr_xml_configuration/gz_common-ci-pr_any-jammy-amd64.xml differ
Files /tmp/current_xml_configuration/gz_math-ci-pr_any-jammy-amd64.xml and /tmp/pr_xml_configuration/gz_math-ci-pr_any-jammy-amd64.xml differ
Files /tmp/current_xml_configuration/gz_msgs-ci-pr_any-jammy-amd64.xml and /tmp/pr_xml_configuration/gz_msgs-ci-pr_any-jammy-amd64.xml differ
Files /tmp/current_xml_configuration/gz_physics-ci-pr_any-jammy-amd64.xml and /tmp/pr_xml_configuration/gz_physics-ci-pr_any-jammy-amd64.xml differ
Files /tmp/current_xml_configuration/gz_plugin-ci-pr_any-jammy-amd64.xml and /tmp/pr_xml_configuration/gz_plugin-ci-pr_any-jammy-amd64.xml differ
Files /tmp/current_xml_configuration/gz_tools-ci-pr_any-jammy-amd64.xml and /tmp/pr_xml_configuration/gz_tools-ci-pr_any-jammy-amd64.xml differ
Files /tmp/current_xml_configuration/gz_utils-ci-pr_any-jammy-amd64.xml and /tmp/pr_xml_configuration/gz_utils-ci-pr_any-jammy-amd64.xml differ
```
B2) Changes in the content of these files should show the `main` branch be added:
```diff
Test in content diff:diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration/gz_cmake-ci-pr_any-jammy-amd64.xml /tmp/pr_xml_configuration/gz_cmake-ci-pr_any-jammy-amd64.xml
--- /tmp/current_xml_configuration/gz_cmake-ci-pr_any-jammy-amd64.xml	2023-09-28 16:45:41.503147881 +0000
+++ /tmp/pr_xml_configuration/gz_cmake-ci-pr_any-jammy-amd64.xml	2023-09-28 16:43:59.801993781 +0000
@@ -55,6 +55,9 @@
                 <org.jenkinsci.plugins.ghprb.GhprbBranch>
                     <branch>gz-cmake3</branch>
                 </org.jenkinsci.plugins.ghprb.GhprbBranch>
+                <org.jenkinsci.plugins.ghprb.GhprbBranch>
+                    <branch>main</branch>
+                </org.jenkinsci.plugins.ghprb.GhprbBranch>
             </whiteListTargetBranches>
             <triggerPhrase>.*(re)?run test(s).*</triggerPhrase>
             <extensions>
Only in /tmp/pr_xml_configuration: gz_common-ci-pr_any-focal-amd64.xml
diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration/gz_common-ci-pr_any-jammy-amd64.xml /tmp/pr_xml_configuration/gz_common-ci-pr_any-jammy-amd64.xml
--- /tmp/current_xml_configuration/gz_common-ci-pr_any-jammy-amd64.xml	2023-09-28 16:45:42.715161014 +0000
+++ /tmp/pr_xml_configuration/gz_common-ci-pr_any-jammy-amd64.xml	2023-09-28 16:44:01.590022916 +0000
@@ -55,6 +55,9 @@
                 <org.jenkinsci.plugins.ghprb.GhprbBranch>
                     <branch>gz-common5</branch>
                 </org.jenkinsci.plugins.ghprb.GhprbBranch>
+                <org.jenkinsci.plugins.ghprb.GhprbBranch>
+                    <branch>main</branch>
+                </org.jenkinsci.plugins.ghprb.GhprbBranch>
             </whiteListTargetBranches>
             <triggerPhrase>.*(re)?run test(s).*</triggerPhrase>
             <extensions>
Only in /tmp/pr_xml_configuration: gz_fuel_tools-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_gui-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_launch-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_math-ci-pr_any-focal-amd64.xml
diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration/gz_math-ci-pr_any-jammy-amd64.xml /tmp/pr_xml_configuration/gz_math-ci-pr_any-jammy-amd64.xml
--- /tmp/current_xml_configuration/gz_math-ci-pr_any-jammy-amd64.xml	2023-09-28 16:45:42.235155759 +0000
+++ /tmp/pr_xml_configuration/gz_math-ci-pr_any-jammy-amd64.xml	2023-09-28 16:44:00.870011184 +0000
@@ -55,6 +55,9 @@
                 <org.jenkinsci.plugins.ghprb.GhprbBranch>
                     <branch>gz-math7</branch>
                 </org.jenkinsci.plugins.ghprb.GhprbBranch>
+                <org.jenkinsci.plugins.ghprb.GhprbBranch>
+                    <branch>main</branch>
+                </org.jenkinsci.plugins.ghprb.GhprbBranch>
             </whiteListTargetBranches>
             <triggerPhrase>.*(re)?run test(s).*</triggerPhrase>
             <extensions>
Only in /tmp/pr_xml_configuration: gz_msgs-ci-pr_any-focal-amd64.xml
diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration/gz_msgs-ci-pr_any-jammy-amd64.xml /tmp/pr_xml_configuration/gz_msgs-ci-pr_any-jammy-amd64.xml
--- /tmp/current_xml_configuration/gz_msgs-ci-pr_any-jammy-amd64.xml	2023-09-28 16:45:42.951163602 +0000
+++ /tmp/pr_xml_configuration/gz_msgs-ci-pr_any-jammy-amd64.xml	2023-09-28 16:44:01.954028847 +0000
@@ -55,6 +55,9 @@
                 <org.jenkinsci.plugins.ghprb.GhprbBranch>
                     <branch>gz-msgs10</branch>
                 </org.jenkinsci.plugins.ghprb.GhprbBranch>
+                <org.jenkinsci.plugins.ghprb.GhprbBranch>
+                    <branch>main</branch>
+                </org.jenkinsci.plugins.ghprb.GhprbBranch>
             </whiteListTargetBranches>
             <triggerPhrase>.*(re)?run test(s).*</triggerPhrase>
             <extensions>
```

B3) Check all new white listed branches to see if they have sense. We expect main and latest released branches:
```diff
Test in filesystem:release-tools2/jenkins-scripts/dsl on  jrivero/ci-pr_any-new [?] ❯ grep -10R '<white' gz_*jammy*.xml  | grep branch
gz_cmake-ci-pr_any-jammy-amd64.xml-                    <branch>gz-cmake3</branch>
gz_cmake-ci-pr_any-jammy-amd64.xml-                    <branch>main</branch>
gz_common-ci-pr_any-jammy-amd64.xml-                    <branch>gz-common5</branch>
gz_common-ci-pr_any-jammy-amd64.xml-                    <branch>main</branch>
gz_fuel_tools-ci-pr_any-jammy-amd64.xml-                    <branch>gz-fuel-tools9</branch>
gz_gui-ci-pr_any-jammy-amd64.xml-                    <branch>gz-gui8</branch>
gz_launch-ci-pr_any-jammy-amd64.xml-                    <branch>gz-launch7</branch>
gz_math-ci-pr_any-jammy-amd64.xml-                    <branch>gz-math7</branch>
gz_math-ci-pr_any-jammy-amd64.xml-                    <branch>main</branch>
gz_msgs-ci-pr_any-jammy-amd64.xml-                    <branch>gz-msgs10</branch>
gz_msgs-ci-pr_any-jammy-amd64.xml-                    <branch>main</branch>
gz_physics-ci-pr_any-jammy-amd64.xml-                    <branch>gz-physics7</branch>
gz_physics-ci-pr_any-jammy-amd64.xml-                    <branch>main</branch>
gz_plugin-ci-pr_any-jammy-amd64.xml-                    <branch>gz-plugin2</branch>
gz_plugin-ci-pr_any-jammy-amd64.xml-                    <branch>main</branch>
gz_rendering-ci-pr_any-jammy-amd64.xml-                    <branch>gz-rendering8</branch>
gz_sensors-ci-pr_any-jammy-amd64.xml-                    <branch>gz-sensors8</branch>
gz_sim-ci-pr_any-jammy-amd64.xml-                    <branch>gz-sim8</branch>
gz_tools-ci-pr_any-jammy-amd64.xml-                    <branch>gz-tools2</branch>
gz_tools-ci-pr_any-jammy-amd64.xml-                    <branch>main</branch>
gz_transport-ci-pr_any-jammy-amd64.xml-                    <branch>gz-transport13</branch>
gz_utils-ci-pr_any-jammy-amd64.xml-                    <branch>gz-utils2</branch>
```

C) New jobs added in this PR:

C1) There should be focal testing (for Fortress and Garden)
```difff
tmp ❯ grep -v differ log  | grep focal
Only in /tmp/pr_xml_configuration: gz_cmake-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_common-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_fuel_tools-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_gui-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_launch-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_math-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_msgs-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_physics-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_plugin-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_rendering-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_sensors-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_sim-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_tools-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_transport-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: gz_utils-ci-pr_any-focal-amd64.xml
Only in /tmp/pr_xml_configuration: sdformat-ci-pr_any-focal-amd64.xml
```

C2)  Check that branches are the expected. All focal jobs should have two since Garden bumped everything from Fortress:
```diff
release-tools2/jenkins-scripts/dsl on  jrivero/ci-pr_any-new [?] ❯ grep -10R '<white' gz_*focal*.xml  | grep branch
gz_cmake-ci-pr_any-focal-amd64.xml-                    <branch>gz-cmake2</branch>
gz_cmake-ci-pr_any-focal-amd64.xml-                    <branch>gz-cmake3</branch>
gz_common-ci-pr_any-focal-amd64.xml-                    <branch>gz-common4</branch>
gz_common-ci-pr_any-focal-amd64.xml-                    <branch>gz-common5</branch>
gz_fuel_tools-ci-pr_any-focal-amd64.xml-                    <branch>gz-fuel-tools7</branch>
gz_fuel_tools-ci-pr_any-focal-amd64.xml-                    <branch>gz-fuel-tools8</branch>
gz_gui-ci-pr_any-focal-amd64.xml-                    <branch>gz-gui6</branch>
gz_gui-ci-pr_any-focal-amd64.xml-                    <branch>gz-gui7</branch>
gz_launch-ci-pr_any-focal-amd64.xml-                    <branch>gz-launch5</branch>
gz_launch-ci-pr_any-focal-amd64.xml-                    <branch>gz-launch6</branch>
gz_math-ci-pr_any-focal-amd64.xml-                    <branch>gz-math6</branch>
gz_math-ci-pr_any-focal-amd64.xml-                    <branch>gz-math7</branch>
gz_msgs-ci-pr_any-focal-amd64.xml-                    <branch>gz-msgs8</branch>
gz_msgs-ci-pr_any-focal-amd64.xml-                    <branch>gz-msgs9</branch>
gz_physics-ci-pr_any-focal-amd64.xml-                    <branch>gz-physics6</branch>
gz_plugin-ci-pr_any-focal-amd64.xml-                    <branch>gz-plugin1</branch>
gz_plugin-ci-pr_any-focal-amd64.xml-                    <branch>gz-plugin2</branch>
gz_rendering-ci-pr_any-focal-amd64.xml-                    <branch>gz-rendering6</branch>
gz_rendering-ci-pr_any-focal-amd64.xml-                    <branch>gz-rendering7</branch>
gz_sensors-ci-pr_any-focal-amd64.xml-                    <branch>gz-sensors7</branch>
gz_sim-ci-pr_any-focal-amd64.xml-                    <branch>gz-sim6</branch>
gz_sim-ci-pr_any-focal-amd64.xml-                    <branch>gz-sim7</branch>
gz_tools-ci-pr_any-focal-amd64.xml-                    <branch>gz-tools1</branch>
gz_tools-ci-pr_any-focal-amd64.xml-                    <branch>gz-tools2</branch>
gz_transport-ci-pr_any-focal-amd64.xml-                    <branch>gz-transport11</branch>
gz_transport-ci-pr_any-focal-amd64.xml-                    <branch>gz-transport12</branch>
gz_utils-ci-pr_any-focal-amd64.xml-                    <branch>gz-utils1</branch>
gz_utils-ci-pr_any-focal-amd64.xml-                    <branch>gz-utils2</branch>
```

C3) Bionic testing (for Citadel) Still uses the ign name
```diff
Only in /tmp/pr_xml_configuration: ign_cmake-ci-pr_any-bionic-amd64.xml ---- branch2
Only in /tmp/pr_xml_configuration: ign_common-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_fuel_tools-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_gazebo-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_gui-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_launch-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_math-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_msgs-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_physics-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_plugin-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_rendering-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_sensors-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_tools-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: ign_transport-ci-pr_any-bionic-amd64.xml
Only in /tmp/pr_xml_configuration: sdformat-ci-pr_any-bionic-amd64.xml

release-tools2/jenkins-scripts/dsl on  jrivero/ci-pr_any-new [?] ❯ grep -3R '<white' ign_*.xml | grep branch
ign_cmake-ci-pr_any-bionic-amd64.xml-                    <branch>ign-cmake2</branch>
ign_common-ci-pr_any-bionic-amd64.xml-                    <branch>ign-common3</branch>
ign_fuel_tools-ci-pr_any-bionic-amd64.xml-                    <branch>ign-fuel-tools4</branch>
ign_gazebo-ci-pr_any-bionic-amd64.xml-                    <branch>ign-gazebo3</branch>
ign_gui-ci-pr_any-bionic-amd64.xml-                    <branch>ign-gui3</branch>
ign_launch-ci-pr_any-bionic-amd64.xml-                    <branch>ign-launch2</branch>
ign_math-ci-pr_any-bionic-amd64.xml-                    <branch>ign-math6</branch>
ign_msgs-ci-pr_any-bionic-amd64.xml-                    <branch>ign-msgs5</branch>
ign_physics-ci-pr_any-bionic-amd64.xml-                    <branch>ign-physics2</branch>
ign_plugin-ci-pr_any-bionic-amd64.xml-                    <branch>ign-plugin1</branch>
ign_rendering-ci-pr_any-bionic-amd64.xml-                    <branch>ign-rendering3</branch>
ign_sensors-ci-pr_any-bionic-amd64.xml-                    <branch>ign-sensors3</branch>
ign_tools-ci-pr_any-bionic-amd64.xml-                    <branch>ign-tools1</branch>
ign_transport-ci-pr_any-bionic-amd64.xml-                    <branch>ign-transport8</branch>
```