### PR TITLE
Fixes for OSRFSourceCreation and tests related

### DIFF
--- a/jenkins-scripts/docker/gz-source-generation.bash
+++ b/jenkins-scripts/docker/gz-source-generation.bash
@@ -18,7 +18,7 @@ BUILD_DIR=\$SOURCES_DIR/build
 
 cd \${WORKSPACE}
 rm -fr \$SOURCES_DIR && mkdir \$SOURCES_DIR
-git clone --depth 1 --branch ${PACKAGE}_${VERSION:~:-} ${SOURCE_REPO_URI} \${SOURCES_DIR}
+git clone --depth 1 --branch ${PACKAGE}_${VERSION/\~/-} ${SOURCE_REPO_URI} \${SOURCES_DIR}
 rm -fr \$BUILD_DIR && mkdir \$BUILD_DIR
 cd \${BUILD_DIR}
 cmake .. -DPACKAGE_SOURCE_ONLY:BOOL=ON

--- a/jenkins-scripts/docker/gz-source-generation.bash
+++ b/jenkins-scripts/docker/gz-source-generation.bash
@@ -18,7 +18,7 @@ BUILD_DIR=\$SOURCES_DIR/build
 
 cd \${WORKSPACE}
 rm -fr \$SOURCES_DIR && mkdir \$SOURCES_DIR
-git clone --depth 1 --branch ${PACKAGE}_${VERSION} ${SOURCE_REPO_URI} \${SOURCES_DIR}
+git clone --depth 1 --branch ${PACKAGE}_${VERSION:~:-} ${SOURCE_REPO_URI} \${SOURCES_DIR}
 rm -fr \$BUILD_DIR && mkdir \$BUILD_DIR
 cd \${BUILD_DIR}
 cmake .. -DPACKAGE_SOURCE_ONLY:BOOL=ON

--- a/jenkins-scripts/docker/gz-source-generation.bash
+++ b/jenkins-scripts/docker/gz-source-generation.bash
@@ -18,7 +18,7 @@ BUILD_DIR=\$SOURCES_DIR/build
 
 cd \${WORKSPACE}
 rm -fr \$SOURCES_DIR && mkdir \$SOURCES_DIR
-git clone --depth 1 --branch ${PACKAGE_NAME}_${VERSION} ${SOURCE_REPO_URI} \${SOURCES_DIR}
+git clone --depth 1 --branch ${PACKAGE}_${VERSION} ${SOURCE_REPO_URI} \${SOURCES_DIR}
 rm -fr \$BUILD_DIR && mkdir \$BUILD_DIR
 cd \${BUILD_DIR}
 cmake .. -DPACKAGE_SOURCE_ONLY:BOOL=ON

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -136,23 +136,18 @@ class Globals
     return package_name.replaceAll('\\d*$', '')
   }
 
-   static String _s3_releases_dir(String package_name) {
+   static String s3_releases_dir(String package_name) {
     return get_canonical_package_name(package_name) + '/releases'
    }
 
-   static String _s3_build_tarball_name(String package_name, String version) {
-    // canonical_name + version
-    return package_name.replaceAll('\\d*$', '') + '-' + version
-   }
-
    static String s3_upload_tarball_path(String package_name) {
-    return 's3://osrf-distributions/' + _s3_releases_dir(package_name)
+    return 's3://osrf-distributions/' + s3_releases_dir(package_name)
    }
 
-   // Not yet in use. Requires changing release.py
-   static String s3_download_uri(String package_name, String version) {
-    return 'https://osrf-distributions.s3.amazonaws.com/' + \
-            _s3_releases_dir(package_name) + \
-            _s3_build_tarball_name(package_name, version)
+   static String s3_download_url_basedir(String package_name) {
+    return 'https://osrf-distributions.s3.amazonaws.com/' + s3_releases_dir(package_name)
    }
+
+   /* rest of the s3 paths need to be cumputed during job running time since
+    * they depend on VERSION and it is not avialble at DSL time */
 }

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -57,6 +57,8 @@ class OSRFSourceCreation
 
       def canonical_package_name = Globals.get_canonical_package_name(
         default_params.find{ it.key == "PACKAGE"}.value)
+      def s3_download_url_basedir = Globals.s3_download_url_basedir(
+        default_params.find{ it.key == "PACKAGE"}?.value)
 
       steps {
         systemGroovyCommand("""\
@@ -94,7 +96,8 @@ class OSRFSourceCreation
             exit 1
           fi
 
-          echo "TARBALL_NAME=\${tarball}" >> ${properties_file}
+          echo "S3_FILES_TO_UPLOAD=\${tarball}" >> ${properties_file}
+          echo "SOURCE_TARBALL_URI=$s3_download_url_basedir/\${tarball}" >> ${properties_file}
           """.stripIndent()
         )
       }
@@ -124,8 +127,8 @@ class OSRFSourceCreation
                     parameters {
                       currentBuild()
                       predefinedProps([PROJECT_NAME_TO_COPY_ARTIFACTS: '${JOB_NAME}',
-                                       S3_UPLOAD_PATH: Globals.s3_upload_tarball_path(package_name)])
-                      propertiesFile(properties_file) // TARBALL_NAME
+                                       S3_UPLOAD_PATH: Globals.s3_releases_dir(package_name)])  // relative path
+                      propertiesFile(properties_file)  // S3_FILES_TO_UPLOAD
                     }
                   }
                 }
@@ -134,7 +137,7 @@ class OSRFSourceCreation
                     parameters {
                       currentBuild()
                       predefinedProps([PROJECT_NAME_TO_COPY_ARTIFACTS: "\${JOB_NAME}"])
-                      propertiesFile(properties_file) // TARBALL_NAME
+                      propertiesFile(properties_file) // SOURCE_TARBALL_URI
                     }
                   }
                 }

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -33,6 +33,9 @@ class OSRFSourceCreation
         stringParam("UPLOAD_TO_REPO",
                     default_params.find{ it.key == "UPLOAD_TO_REPO"}?.value,
                     "For downstream jobs: OSRF repo name to upload the package to: stable | prerelease | nightly | none (for testing proposes)")
+        stringParam("EXTRA_OSRF_REPO",
+                    default_params.find{ it.key == "EXTRA_OSRF_REPO"}?.value,
+                    "For downstream jobs: OSRF extra repositories to add")
       }
     }
   }

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -53,11 +53,14 @@ repo_uploader.with
     stringParam('S3_UPLOAD_PATH','', 'S3 path to upload')
     stringParam('S3_FILES_TO_UPLOAD','', 'S3 file names to upload')
     stringParam('UPLOAD_TO_REPO','none','repo to upload')
+    stringParam("PROJECT_NAME_TO_COPY_ARTIFACTS",
+                "",
+                "Internal use: parent job name passed by the job to be used in copy artifacts")
   }
 
   steps
   {
-    copyArtifacts('_test_gz_source')
+    copyArtifacts('${PROJECT_NAME_TO_COPY_ARTIFACTS}')
     {
       includePatterns("${pkg_sources_dir}/*")
       buildSelector {


### PR DESCRIPTION
Following up https://github.com/gazebo-tooling/release-tools/pull/989 and https://github.com/gazebo-tooling/release-tools/pull/1008, some fixes and improve of the testing. Each commit is self-contained:

- Fix PACKAGE_NAME replaced by PACKAGE in previous changes e5b2ebc948a3bd557e90fc644315f781bbeb2825
- Change TARBALL_NAME bY S3_FILES_TO_UPLOAD 3602f12acd42de1198037aa55e6419ae68576bdd
- Use PROJECT_NAME_TO_COPY_ARTIFACTS instead of hardcoding test job 05afb08d89185f8deb759af51ea0aea2ce407e8b
- Support EXTRA_OSRF_REPO to be passed to OSRFReleasepy 7122876b484d54c32e84363a5ad4cf153fd518c5
- Handle ~ symbols in git tags https://github.com/gazebo-tooling/release-tools/pull/1024/commits/0543b683376e2d3d0eb5414ef10ab5af0347babe
