### PR TITLE
II part of clean up and refactoring release.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -299,13 +299,6 @@ def sanity_project_package_in_stable(version, repo_name):
     return
 
 
-def sanity_use_prerelease_branch(release_branch):
-    if release_branch == 'prerelease':
-        error("The use of prerelease branch is now deprecated. Please check internal wiki instructions")
-
-    return
-
-
 def check_s3cmd_configuration():
     # Need to check if s3cmd is installed
     try:
@@ -325,7 +318,6 @@ def sanity_checks(args, repo_dir):
     sanity_package_name_underscore(args.package, args.package_alias)
     sanity_package_name(repo_dir, args.package, args.package_alias)
     sanity_check_repo_name(args.upload_to_repository)
-    sanity_use_prerelease_branch(args.release_repo_branch)
 
     if not NIGHTLY:
         check_s3cmd_configuration()

--- a/release.py
+++ b/release.py
@@ -29,7 +29,7 @@ RELEASEPY_NO_ARCH_PREFIX = '.releasepy_NO_ARCH_'
 # the release repositories, when needed.
 UBUNTU_DISTROS = []
 
-OSRF_REPOS_SUPPORTED = "stable prerelease nightly"
+OSRF_REPOS_SUPPORTED = "stable prerelease nightly testing"
 OSRF_REPOS_SELF_CONTAINED = ""
 
 DRY_RUN = False

--- a/release.py
+++ b/release.py
@@ -30,7 +30,6 @@ RELEASEPY_NO_ARCH_PREFIX = '.releasepy_NO_ARCH_'
 UBUNTU_DISTROS = []
 
 OSRF_REPOS_SUPPORTED = "stable prerelease nightly testing"
-OSRF_REPOS_SELF_CONTAINED = ""
 
 DRY_RUN = False
 NIGHTLY = False
@@ -566,9 +565,6 @@ def go(argv):
     params['OSRF_REPOS_TO_USE'] = "stable " + args.upload_to_repository
     if args.extra_repo:
         params['OSRF_REPOS_TO_USE'] += " " + args.extra_repo
-
-    if args.upload_to_repository in OSRF_REPOS_SELF_CONTAINED:
-        params['OSRF_REPOS_TO_USE'] = args.upload_to_repository
 
     if NIGHTLY:
         params['VERSION'] = 'nightly'

--- a/release.py
+++ b/release.py
@@ -34,7 +34,6 @@ OSRF_REPOS_SUPPORTED = "stable prerelease nightly testing"
 DRY_RUN = False
 NIGHTLY = False
 PRERELEASE = False
-NO_SRC_FILE = False
 
 IGNORE_DRY_RUN = True
 
@@ -127,7 +126,6 @@ def parse_args(argv):
     global DRY_RUN
     global NIGHTLY
     global PRERELEASE
-    global NO_SRC_FILE
 
     parser = argparse.ArgumentParser(description='Make releases.')
     parser.add_argument('package', help='which package to release')
@@ -167,14 +165,12 @@ def parse_args(argv):
     args.package_alias = args.package
 
     DRY_RUN = args.dry_run
-    NO_SRC_FILE = args.no_source_file
     if args.upload_to_repository == 'nightly':
         NIGHTLY = True
     if args.upload_to_repository == 'prerelease':
         PRERELEASE = True
     # Nightly do not generate a tar.bz2 file
     if NIGHTLY:
-        NO_SRC_FILE = True
         args.no_source_file = True
 
     return args

--- a/release.py
+++ b/release.py
@@ -170,6 +170,7 @@ def get_release_repository_info(package):
     if (github_repo_exists(github_url)):
         return 'git', github_url
 
+    error("release repository not found in github.com/gazebo-release")
 
 def download_release_repository(package, release_branch):
     vcs, url = get_release_repository_info(package)

--- a/release.py
+++ b/release.py
@@ -554,8 +554,6 @@ def go(argv):
         # name must be modified in the future
         params['SOURCE_TARBALL_URI'] = args.nightly_branch
 
-    job_name = JOB_NAME_PATTERN % (args.package)
-
     # RELEASING FOR BREW
     if not NIGHTLY and not args.bump_rev_linux_only:
         call_jenkins_build(GENERIC_BREW_PULLREQUEST_JOB,
@@ -607,7 +605,8 @@ def go(argv):
                     assert a == 'amd64', f'Nightly tag assumed amd64 but arch is {a}'
                     linux_platform_params['JENKINS_NODE_TAG'] = 'linux-nightly-' + d
 
-                call_jenkins_build(job_name, linux_platform_params, 'Linux')
+                call_jenkins_build(f"{args.package}-debbuilder",
+                                   linux_platform_params, f"{l} {d}/{a}")
 
 
 if __name__ == '__main__':

--- a/release.py
+++ b/release.py
@@ -25,10 +25,6 @@ LINUX_DISTROS = ['ubuntu', 'debian']
 SUPPORTED_ARCHS = ['amd64', 'armhf', 'arm64']
 RELEASEPY_NO_ARCH_PREFIX = '.releasepy_NO_ARCH_'
 
-# Ubuntu distributions are automatically taken from the top directory of
-# the release repositories, when needed.
-UBUNTU_DISTROS = []
-
 OSRF_REPOS_SUPPORTED = "stable prerelease nightly testing"
 
 DRY_RUN = False

--- a/release.py
+++ b/release.py
@@ -370,12 +370,8 @@ def discover_distros(repo_dir):
 
 
 def check_call(cmd, ignore_dry_run=False):
-    if ignore_dry_run:
-        # Commands that do not change anything in repo level
-        print('Dry-run running:\n  %s\n' % (' '.join(cmd)))
-    else:
-        print('Running:\n  %s' % (' '.join(cmd)))
     if DRY_RUN and not ignore_dry_run:
+        print('Dry-run running:\n  %s\n' % (' '.join(cmd)))
         return b'', b''
     else:
         po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/release.py
+++ b/release.py
@@ -76,7 +76,7 @@ def error(msg):
 
 
 def print_success(msg):
-    print("     + OK " + msg)
+    print(" + OK " + msg)
 
 
 # Remove the last character if it is a number.
@@ -185,7 +185,6 @@ def download_release_repository(package, release_branch):
     # If main branch exists, prefer it over master
     if release_branch == "master":
         if exists_main_branch(url):
-            print_success('Found main branch in repo, use it instead master')
             release_branch = 'main'
 
     cmd = [vcs, "clone", "-b", release_branch, url, release_tmp_dir]
@@ -303,6 +302,7 @@ def check_s3cmd_configuration():
 
 
 def sanity_checks(args, repo_dir):
+    print("Safety checks:")
     sanity_package_name_underscore(args.package, args.package_alias)
     sanity_package_name(repo_dir, args.package, args.package_alias)
     sanity_check_repo_name(args.upload_to_repository)
@@ -367,6 +367,7 @@ def check_call(cmd, ignore_dry_run=False):
         print('Dry-run running:\n  %s\n' % (' '.join(cmd)))
         return b'', b''
     else:
+        print('Running:\n  %s' % (' '.join(cmd)))
         po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = po.communicate()
         if po.returncode != 0:

--- a/release.py
+++ b/release.py
@@ -282,21 +282,6 @@ def sanity_project_package_in_stable(version, repo_name):
     return
 
 
-def check_s3cmd_configuration():
-    # Need to check if s3cmd is installed
-    try:
-        subprocess.call(["s3cmd", "--version"])
-    except OSError:
-        error("s3cmd command for uploading is not available. Install it using: apt-get install s3cmd")
-
-    # Need to check if configuration for s3 exists
-    s3_config = os.path.expanduser('~') + "/.s3cfg"
-    if not os.path.isfile(s3_config):
-        error(s3_config + " does not exists. Please configure s3: s3cmd --configure")
-
-    return True
-
-
 def sanity_checks(args, repo_dir):
     print("Safety checks:")
     sanity_package_name_underscore(args.package, args.package_alias)
@@ -304,7 +289,6 @@ def sanity_checks(args, repo_dir):
     sanity_check_repo_name(args.upload_to_repository)
 
     if not NIGHTLY:
-        check_s3cmd_configuration()
         sanity_package_version(repo_dir, args.version, str(args.release_version))
         sanity_check_sdformat_versions(args.package, args.version)
         sanity_project_package_in_stable(args.version, args.upload_to_repository)

--- a/release.py
+++ b/release.py
@@ -86,10 +86,6 @@ def get_canonical_package_name(pkg_name):
     return pkg_name.rstrip('1234567890')
 
 
-def is_catkin_package():
-    return os.path.isfile("package.xml")
-
-
 def github_repo_exists(url):
     try:
         check_call(['git', 'ls-remote', '-q', '--exit-code', url], IGNORE_DRY_RUN)
@@ -102,9 +98,6 @@ def github_repo_exists(url):
 
 def generate_package_source(srcdir, builddir):
     cmake_cmd = ["cmake"]
-
-    if is_catkin_package():
-        cmake_cmd = cmake_cmd + ['-DCATKIN_BUILD_BINARY_PACKAGE="1"']
 
     # configure and make package_source
     os.mkdir(builddir)


### PR DESCRIPTION
Following  up #1014 part of https://github.com/gazebo-tooling/release-tools/issues/990

Easy to read commit by commit, changes done:

- Add support for testing repo releases 
- Remove sanity_use_prerelease_branch, obsolete
- Remove the use of obsolete OSRF_REPOS_SELF_CONTAINED
- Refactor: move tag repo to a method
- Remove obsolte NO_SRC_FILE
- Fix dry-run to output real actions
- Remove is_catking_package. Obsolete
- Improve output format
- Refactor: move Jenkins call to a method
- Remove UBUNTU_DISTROS: not in use
- Remove s3cmd check to facilitate changes
- Added error on non existing release repo 