### PR TITLE
bump_dependency.bash: use - in version strings

### DIFF
--- a/source-repo-scripts/bump_dependency.bash
+++ b/source-repo-scripts/bump_dependency.bash
@@ -387,7 +387,7 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   # version
   PREV_VER_NONNEGATIVE=$([[ "${PREV_VER}" -lt 0 ]] && echo "0" || echo "${PREV_VER}")
   sed -i "/ version /d" $FORMULA
-  sed -i "/^  url.*/a\  version \"${PREV_VER_NONNEGATIVE}.999.999~0~`date +"%Y%m%d"`\"" $FORMULA
+  sed -i "/^  url.*/a\  version \"${PREV_VER_NONNEGATIVE}.999.999-0-`date +"%Y%m%d"`\"" $FORMULA
   # Remove extra blank lines
   cat -s $FORMULA | tee $FORMULA
 


### PR DESCRIPTION
Replace the `~` separator characters with `-` in homebrew formula version strings to satisfy osrf/homebrew-simulation#2390.

See https://github.com/osrf/homebrew-simulation/pull/2450#discussion_r1351219074.