### PR TITLE
Retry brew update to fix errors about another active Homebrew process being active

### DIFF
--- a/jenkins-scripts/lib/_homebrew_base_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_base_setup.bash
@@ -16,7 +16,15 @@ fi
 
 git -C $(${BREW_BINARY} --repo) fsck
 export HOMEBREW_UPDATE_TO_TAG=1
-${BREW_BINARY} update
+
+# There might be a background process that blocks `brew update`, so we try to
+# run it several times until it succeeds.
+# See https://github.com/Homebrew/brew/issues/1155
+brew_update_retry_count=0
+until ${BREW_BINARY} update || (( brew_update_retry_count++ > 6 ))
+do
+  sleep 10
+done
 # manually exclude a ruby warning that jenkins thinks is from clang
 # https://github.com/osrf/homebrew-simulation/issues/1343
 ${BREW_BINARY} install ${BREW_BASE_DEPENDCIES} \

--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -39,16 +39,6 @@ git stash && git clean -d -f
 ${BREW_BINARY} audit cmake || restore_brew
 popd 2> /dev/null
 
-# There might be a background process that blocks `brew update`, so we try to
-# run it several times until it succeeds.
-# See https://github.com/Homebrew/brew/issues/1155
-brew_update_retry_count=0
-until brew update || (( brew_update_retry_count++ > 6 ))
-do
-  brew update
-  sleep 10
-done
-
 # test-bot needs variables and does not work just with config not sure why
 export GIT_AUTHOR_NAME="OSRF Build Bot"
 export GIT_COMMITTER_NAME=${GIT_AUTHOR_NAME}

--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -39,8 +39,15 @@ git stash && git clean -d -f
 ${BREW_BINARY} audit cmake || restore_brew
 popd 2> /dev/null
 
-# Remove any locks to avoid any errors about another active Homebrew process being active.
-rm -rf $(${BREW_BINARY} --prefix)/var/homebrew/locks
+# There might be a background process that blocks `brew update`, so we try to
+# run it several times until it succeeds.
+# See https://github.com/Homebrew/brew/issues/1155
+brew_update_retry_count=0
+until brew update || (( brew_update_retry_count++ > 6 ))
+do
+  brew update
+  sleep 10
+done
 
 # test-bot needs variables and does not work just with config not sure why
 export GIT_AUTHOR_NAME="OSRF Build Bot"

--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -39,6 +39,9 @@ git stash && git clean -d -f
 ${BREW_BINARY} audit cmake || restore_brew
 popd 2> /dev/null
 
+# Remove any locks to avoid any errors about another active Homebrew process being active.
+rm -rf $(${BREW_BINARY} --prefix)/var/homebrew/locks
+
 # test-bot needs variables and does not work just with config not sure why
 export GIT_AUTHOR_NAME="OSRF Build Bot"
 export GIT_COMMITTER_NAME=${GIT_AUTHOR_NAME}


### PR DESCRIPTION
We're getting the "Another active Homebrew update process is already in progress" error very frequently now, so this is an attempt to fix it. ~It doesn't seem like a great approach since homebrew should be cleaning things up itself, but might be worth a try. At least, this is something others have [recommended](https://stackoverflow.com/a/40473139/283225). From the [logs](https://build.osrfoundation.org/job/ignition_transport-ci-pr_any-homebrew-amd64/1656/console), `brew` is able to install things before `_homebrew_cleanup.bash` is called, so I figured removing the locks when that script is done might fix the issue.~ The fix retries running `brew update` several times until it succeeds.