### PR TITLE
OSRFSourceCreation needs to install gz-cmake to generate sources

### DIFF
--- a/jenkins-scripts/docker/gz-source-generation.bash
+++ b/jenkins-scripts/docker/gz-source-generation.bash
@@ -16,6 +16,10 @@ PKG_DIR=\$WORKSPACE/pkgs
 SOURCES_DIR=\$WORKSPACE/sources
 BUILD_DIR=\$SOURCES_DIR/build
 
+# Need to intall all supported gz-cmake* packages in the platform
+(sudo apt-get install -y *gz-cmake* || sudo apt-get install -y *ign-cmake*) || \
+  (echo "Can not find any ign-cmake/gz-cmake package" && exit 1)
+
 cd \${WORKSPACE}
 rm -fr \$SOURCES_DIR && mkdir \$SOURCES_DIR
 git clone --depth 1 --branch ${PACKAGE}_${VERSION/\~/-} ${SOURCE_REPO_URI} \${SOURCES_DIR}

--- a/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
@@ -74,6 +74,7 @@ class OSRFReleasepy
 
             echo "releasing \${n} (from branch \${src_branch})"
               python3 ./scripts/release.py \${dry_run_str} "\${PACKAGE}" "\${VERSION}" "\${PASS}" \${extra_osrf_repo} \
+                      --source-tarball-uri \${SOURCE_TARBALL_URI} \
                       --release-repo-branch \${RELEASE_REPO_BRANCH} \
                       --upload-to-repo \${UPLOAD_TO_REPO} > log || echo "MARK_AS_UNSTABLE"
             echo " - done"

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -36,6 +36,12 @@ class OSRFSourceCreation
         stringParam("EXTRA_OSRF_REPO",
                     default_params.find{ it.key == "EXTRA_OSRF_REPO"}?.value,
                     "For downstream jobs: OSRF extra repositories to add")
+        stringParam("LINUX_DISTRO",
+                    default_params.find{ it.key == "LINUX_DISTRO"}?.value,
+                    "Linux distribution to use to generate sources")
+        stringParam("DISTRO",
+                    default_params.find{ it.key == "DISTRO"}?.value,
+                    "Linux release inside LINUX_DISTRO to generate sources on")
       }
     }
   }
@@ -78,10 +84,7 @@ class OSRFSourceCreation
         shell("""\
           #!/bin/bash -xe
 
-          # Use Jammy/amd64 as base image to generate sources
-          export DISTRO=jammy
           export ARCH=amd64
-
           /bin/bash -x ./scripts/jenkins-scripts/docker/gz-source-generation.bash
           """.stripIndent()
         )

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -24,6 +24,15 @@ class OSRFSourceCreation
         stringParam("VERSION",
                     default_params.find{ it.key == "VERSION"}?.value,
                     "Packages version to be built or nightly (enable nightly build mode)")
+        stringParam("OSRF_REPOS_TO_USE",
+                    default_params.find{ it.key == "OSRF_REPOS_TO_USE"}?.value,
+                    "OSRF repos name to use when building the package")
+        stringParam("LINUX_DISTRO",
+                    default_params.find{ it.key == "LINUX_DISTRO"}?.value,
+                    "Linux distribution to use to generate sources")
+        stringParam("DISTRO",
+                    default_params.find{ it.key == "DISTRO"}?.value,
+                    "Linux release inside LINUX_DISTRO to generate sources on")
         stringParam("RELEASE_VERSION",
                     default_params.find{ it.key == "RELEASE_VERSION"}?.value,
                     "For downstream jobs: Packages release version")
@@ -36,12 +45,6 @@ class OSRFSourceCreation
         stringParam("EXTRA_OSRF_REPO",
                     default_params.find{ it.key == "EXTRA_OSRF_REPO"}?.value,
                     "For downstream jobs: OSRF extra repositories to add")
-        stringParam("LINUX_DISTRO",
-                    default_params.find{ it.key == "LINUX_DISTRO"}?.value,
-                    "Linux distribution to use to generate sources")
-        stringParam("DISTRO",
-                    default_params.find{ it.key == "DISTRO"}?.value,
-                    "Linux release inside LINUX_DISTRO to generate sources on")
       }
     }
   }

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -29,8 +29,8 @@ releasepy_job.with {
 // gz source testing job
 def gz_source_job = job("_test_gz_source")
 OSRFSourceCreation.create(gz_source_job, [
-  PACKAGE: "gz-cmake3" ,
-  SOURCE_REPO_URI: "https://github.com/gazebosim/gz-cmake.git"])
+  PACKAGE: "gz-plugin2" ,
+  SOURCE_REPO_URI: "https://github.com/gazebosim/gz-plugin.git"])
 OSRFSourceCreation.call_uploader_and_releasepy(gz_source_job,
   '_test_repository_uploader',
   '_test_releasepy')


### PR DESCRIPTION
The source generation jobs needs to use a given Ubuntu distribution since the `make package_source` coming from gz-cmake needs, indeed, to have gz-cmake installed b2e821565418cdef7162972a261d724a30d6b2e4. Not detected until now since the test case was gz-cmake which does not need a gz-cmake to be in place. Obviously. Changed to plugin in: 6866030dd31743c9ea84e8594ce7454d254bd1e0.

The installation of all gz-cmake available in the platform needs that plaform values reach the gz-source job from release.py. Done in 01cceab09ea52f1246e72f38567a3b3e188d38a1.

Not related but also in the PR a small change for OSRFReleasePy to use the new release.py script: 24cfea2feb72b5b873088758b38769affe3242ad