### PR TITLE
Add _releasepy job to be a wrapper of releasepy calls in Jenkins

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
@@ -37,7 +37,6 @@ class OSRFReleasepy
         stringParam("EXTRA_OSRF_REPO",
                     default_params.find{ it.key == "OSRF_REPOS_TO_USE"}?.value,
                     "OSRF repos name to use when building the package")
-  
         booleanParam('DRY_RUN',
                     default_params.find{ it.key == "DRY_RUN"}?.value,
                     'run a testing run with no effects')

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -146,7 +146,7 @@ outdated_job_runner.with
 
 // -------------------------------------------------------------------
 def releasepy_job = job("_releasepy")
-OSRFReleasepy.create(releasepy_job)
+OSRFReleasepy.create(releasepy_job, [DRY_RUN: false])
 releasepy_job.with {
       blockOn("repository_uploader_packages") {
         blockLevel('GLOBAL')

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -143,3 +143,13 @@ outdated_job_runner.with
     systemGroovyCommand(readFileFromWorkspace('scripts/jenkins-scripts/tools/outdated-job-runner.groovy'))
   }
 }
+
+// -------------------------------------------------------------------
+def releasepy_job = job("_releasepy")
+OSRFReleasepy.create(releasepy_job)
+releasepy_job.with {
+      blockOn("repository_uploader_packages") {
+        blockLevel('GLOBAL')
+        scanQueueFor('ALL')
+      }
+}


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/990. Add a real job to be a wrapper of releasepy calls inside the own Jenkins. Most of the work was already done for the test job so just a matter of creating the real job in core.dsl.
