### PR TITLE
Generate source jobs using an index of source packages

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -96,8 +96,9 @@ collections:
       configs:
         - bionic
     packaging:
+      configs:
+        - bionic
       linux:
-        package_name:
           ignore_major_version:
             - ign-citadel
   - name: 'fortress'
@@ -174,10 +175,11 @@ collections:
       configs:
         - focal
     packaging:
+      configs:
+        - focal
       linux:
-        package_name:
-          ignore_major_version:
-            - gz-fortress
+        ignore_major_version:
+          - gz-fortress
   - name: 'garden'
     libs:
       - name: gz-cmake
@@ -252,10 +254,11 @@ collections:
       configs:
         - focal
     packaging:
+      configs:
+        - focal
       linux:
-        package_name:
-          ignore_major_version:
-            - gz-garden
+        ignore_major_version:
+          - gz-garden
   - name: 'harmonic'
     libs:
       - name: gz-cmake
@@ -330,13 +333,14 @@ collections:
       configs:
         - jammy
     packaging:
+      configs:
+        - jammy
       linux:
-        package_name:
-          ignore_major_version:
-            - gz-harmonic
-        nightly:
-            distros:
-              - jammy
+        ignore_major_version:
+          - gz-harmonic
+      nightly:
+        distros:
+          - jammy
   - name: '__upcoming__'
     libs:
       - name: gz-cmake
@@ -407,6 +411,8 @@ collections:
       configs:
         - jammy
     packaging:
+      configs:
+        - jammy
       exclude:
         - __upcoming__
 ci_configs:
@@ -472,3 +478,30 @@ ci_configs:
       gz-physics:
         - "export MAKE_JOBS=1"
     tests_disabled:
+packaging_configs:
+  - name: bionic
+    system:
+      so: linux
+      distribution: ubuntu
+      version: bionic
+      arch:
+        - i386
+        - amd64
+        - arm64
+  - name: focal
+    system:
+      so: linux
+      distribution: ubuntu
+      version: focal
+      arch:
+        - amd64
+        - arm64
+  - name: jammy
+    system:
+      so: linux
+      distribution: ubuntu
+      version: jammy
+      arch:
+        - amd64
+        - arm64
+        - armhf

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -17,7 +17,7 @@ String get_debbuilder_name(parsed_yaml_lib, parsed_yaml_packaging)
 {
   major_version = parsed_yaml_lib.major_version
 
-  ignore_major_version = parsed_yaml_packaging.linux?.package_name?.ignore_major_version
+  ignore_major_version = parsed_yaml_packaging.linux?.ignore_major_version
   if (ignore_major_version && ignore_major_version.contains(parsed_yaml_lib.name))
     major_version = ""
 


### PR DESCRIPTION
Part of #990 .

Create an index for packaging configuration composed by entries of source packages. Use it to generate the new source jobs that generates the tarballs. 