### PR TITLE
Remove nightly generation for Harmonic

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -334,9 +334,6 @@ collections:
         package_name:
           ignore_major_version:
             - gz-harmonic
-        nightly:
-            distros:
-              - jammy
   - name: 'ionic'
     libs:
       - name: gz-cmake


### PR DESCRIPTION
Harmonic release is stable and Ionic is being setup. We probably don't need nightlies anymore for Harmonic, @azeey ?