### PR TITLE
Fix broken script links generated in DSL code. Added CI test.

### DIFF
--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -13,10 +13,17 @@ if [[ -n ${not_null} ]]; then
   exit 1
 fi
 
-main=$(grep '<branch>main</branch>' -- *-abichecker-*.xml || true)
-if [[ -n ${main} ]]; then
+# Check for existing scripts
+for f in $(grep -Eh -o './scripts/.*.bash' -- *.xml | sort | uniq); do
+  if ! test -f "${f}"; then
+    echo "${f} script not found in the repository"
+  fi
+done
+
+abichecker_main=$(grep '<branch>main</branch>' -- *-abichecker-*.xml || true)
+if [[ -n ${abichecker_main} ]]; then
   echo "Found a main branch in an abichecker job:"
-  echo "${main}"
+  echo "${abichecker_main}"
   echo "Main branches are not target of abichecking. Fix the code."
   exit 1
 fi

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -614,15 +614,9 @@ gz_software.each { gz_sw ->
         shell("""\
               #!/bin/bash -xe
 
-              export HOMEBREW_SCRIPT="./scripts/jenkins-scripts/ign_${software_name}-default-devel-homebrew-amd64.bash"
-              if [ -s "\$HOMEBREW_SCRIPT" ]
-              then
-                /bin/bash -xe "\$HOMEBREW_SCRIPT"
-              else
-                software_name="gz-${software_name}"
-                [[ ${software_name} == 'gazebo' ]] && software_name="gz-sim"
-                /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
-              fi
+              software_name="gz-${software_name}"
+              [[ ${software_name} == 'gazebo' ]] && software_name="gz-sim"
+              /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
               """.stripIndent())
       }
   }
@@ -651,15 +645,9 @@ gz_software.each { gz_sw ->
           shell("""\
                 #!/bin/bash -xe
 
-                export HOMEBREW_SCRIPT="./scripts/jenkins-scripts/ign_${software_name}-default-devel-homebrew-amd64.bash"
-                if [ -s "\$HOMEBREW_SCRIPT" ]
-                then
-                  /bin/bash -xe "\$HOMEBREW_SCRIPT"
-                else
-                  software_name="gz-${software_name}"
-                  [[ ${software_name} == 'gazebo' ]] && software_name="gz-sim"
-                  /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
-                fi
+                software_name="gz-${software_name}"
+                [[ ${software_name} == 'gazebo' ]] && software_name="gz-sim"
+                /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "\${software_name}"
                 """.stripIndent())
         }
     }


### PR DESCRIPTION
Some problems raised with broken paths for release-tools scripts. The PR fixes them and introduce a CI to avoid the problem in the future:

 * [Fix compilation script path in -any- jobs](https://github.com/gazebo-tooling/release-tools/commit/0e9218e58ad18c92ce86b3280db1636640a7b870) . Broken -compilation.bash links in Citadel.
 * [Remove death code in brew jobs](https://github.com/gazebo-tooling/release-tools/commit/a245628b3c890b9c1e3c92cfc49a53d4cd9b8ee5). Death code pointing to non existing scripts in Brew.
 * [Add check for existing scripts](https://github.com/gazebo-tooling/release-tools/commit/ab9b95d44a37886c4d5708125c150c9da72e3c67). CI test to check for the links in the repo.