### PR TITLE
Improvements in the releasing pipeline

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -137,7 +137,7 @@ class Globals
   }
 
    static String s3_releases_dir(String package_name) {
-    return get_canonical_package_name(package_name) + '/releases/'
+    return get_canonical_package_name(package_name) + '/releases'
    }
 
    static String s3_upload_tarball_path(String package_name) {

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -137,7 +137,7 @@ class Globals
   }
 
    static String s3_releases_dir(String package_name) {
-    return get_canonical_package_name(package_name) + '/releases'
+    return get_canonical_package_name(package_name) + '/releases/'
    }
 
    static String s3_upload_tarball_path(String package_name) {

--- a/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
@@ -75,7 +75,7 @@ class OSRFReleasepy
               python3 ./scripts/release.py \${dry_run_str} "\${PACKAGE}" "\${VERSION}" "\${PASS}" \${extra_osrf_repo} \
                       --source-tarball-uri \${SOURCE_TARBALL_URI} \
                       --release-repo-branch \${RELEASE_REPO_BRANCH} \
-                      --upload-to-repo \${UPLOAD_TO_REPO} > log || echo "MARK_AS_UNSTABLE"
+                      --upload-to-repo \${UPLOAD_TO_REPO} > log
             echo " - done"
             """.stripIndent())
       }

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -136,7 +136,7 @@ class OSRFSourceCreation
                     parameters {
                       currentBuild()
                       predefinedProps([PROJECT_NAME_TO_COPY_ARTIFACTS: '${JOB_NAME}',
-                                       S3_UPLOAD_PATH: Globals.s3_releases_dir(package_name)])  // relative path
+                                       S3_UPLOAD_PATH: "${Globals.s3_releases_dir(package_name)}/"])  // relative path with a final /
                       propertiesFile(properties_file)  // S3_FILES_TO_UPLOAD
                     }
                   }

--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -144,7 +144,7 @@ for pkg in ${S3_FILES_TO_UPLOAD}; do
   fi
 
   # Seems important to upload the path with a final slash
-  S3_upload "${pkgs_path}/${pkg}" "${S3_UPLOAD_PATH}"
+  S3_upload "${pkgs_path}/${pkg}" "${S3_UPLOAD_PATH%%*(/)}/"
 done
 
 # .bottle | brew binaries


### PR DESCRIPTION
A couple of small improvements in the releasing pipeline:
 * [Be sure that we use a final / in S3_UPLOAD_PATH](https://github.com/gazebo-tooling/release-tools/commit/171ab976b2dc4e6a72a801e183ea83f0bc237cc9).
 * [Make OSRFRelease to fail if release.py fails](https://github.com/gazebo-tooling/release-tools/commit/a04482e1b7dd2bd975a4ac7b8b9d0eee76462c59)