### PR TITLE
OSRFSourceCreation: use git refs directly instead of rebuild it

### DIFF
--- a/jenkins-scripts/docker/gz-source-generation.bash
+++ b/jenkins-scripts/docker/gz-source-generation.bash
@@ -22,7 +22,7 @@ BUILD_DIR=\$SOURCES_DIR/build
 
 cd \${WORKSPACE}
 rm -fr \$SOURCES_DIR && mkdir \$SOURCES_DIR
-git clone --depth 1 --branch ${PACKAGE}_${VERSION/\~/-} ${SOURCE_REPO_URI} \${SOURCES_DIR}
+git clone --depth 1 --branch ${SOURCE_REPO_REF} ${SOURCE_REPO_URI} \${SOURCES_DIR}
 rm -fr \$BUILD_DIR && mkdir \$BUILD_DIR
 cd \${BUILD_DIR}
 cmake .. -DPACKAGE_SOURCE_ONLY:BOOL=ON

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -18,8 +18,8 @@ class OSRFSourceCreation
         choiceParam('SOURCE_REPO_URI',
                     [default_params.find{ it.key == "SOURCE_REPO_URI"}?.value],
                     "Software repository URL (can not be modified)")
-        choiceParam('SOURCE_REPO_REF',
-                    [default_params.find{ it.key == "SOURCE_REPO_REF"}?.value],
+        stringParam('SOURCE_REPO_REF',
+                    default_params.find{ it.key == "SOURCE_REPO_REF"}?.value,
                     "Git branch or tag to build sources from")
         stringParam("VERSION",
                     default_params.find{ it.key == "VERSION"}?.value,

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -15,12 +15,12 @@ class OSRFSourceCreation
     job.with
     {
       parameters {
-        choiceParam('PACKAGE',
-                    [default_params.find{ it.key == "PACKAGE"}?.value],
-                    "Package name (can not be modified)")
         choiceParam('SOURCE_REPO_URI',
                     [default_params.find{ it.key == "SOURCE_REPO_URI"}?.value],
                     "Software repository URL (can not be modified)")
+        choiceParam('SOURCE_REPO_REF',
+                    [default_params.find{ it.key == "SOURCE_REPO_REF"}?.value],
+                    "Git branch or tag to build sources from")
         stringParam("VERSION",
                     default_params.find{ it.key == "VERSION"}?.value,
                     "Packages version to be built or nightly (enable nightly build mode)")
@@ -33,6 +33,9 @@ class OSRFSourceCreation
         stringParam("DISTRO",
                     default_params.find{ it.key == "DISTRO"}?.value,
                     "Linux release inside LINUX_DISTRO to generate sources on")
+        choiceParam('PACKAGE',
+                    [default_params.find{ it.key == "PACKAGE"}?.value],
+                    "For downstream use: Package name (can not be modified)")
         stringParam("RELEASE_VERSION",
                     default_params.find{ it.key == "RELEASE_VERSION"}?.value,
                     "For downstream jobs: Packages release version")

--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -5,7 +5,7 @@ if [[ -z $(ls -- *.xml) ]]; then
   echo "https://github.com/gazebo-tooling/release-tools/blob/master/jenkins-scripts/README.md#L11"
 fi
 
-not_null=$(grep 'null' -- *.xml || true)
+not_null=$(grep -3 'null' -- *.xml || true)
 if [[ -n ${not_null} ]]; then
   echo "Found a null value in a configuration file:"
   echo "${not_null}"

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -261,7 +261,7 @@ pkgconf_per_src_index.each { pkg_src, pkg_src_configs ->
 
     def gz_source_job = job("${pkg_src}-source")
     OSRFSourceCreation.create(gz_source_job, [
-      PACKAGE: pkg_src ,
+      PACKAGE: pkg_src,
       SOURCE_REPO_URI: "https://github.com/gazebosim/${canonical_lib_name}.git"])
     OSRFSourceCreation.call_uploader_and_releasepy(gz_source_job,
       'repository_uploader_packages',

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -29,8 +29,9 @@ releasepy_job.with {
 // gz source testing job
 def gz_source_job = job("_test_gz_source")
 OSRFSourceCreation.create(gz_source_job, [
-  PACKAGE: "gz-plugin2" ,
-  SOURCE_REPO_URI: "https://github.com/gazebosim/gz-plugin.git"])
+  PACKAGE: "gz-plugin2",
+  SOURCE_REPO_URI: "https://github.com/gazebosim/gz-plugin.git",
+  SOURCE_REPO_REF: "gz-plugin2"])
 OSRFSourceCreation.call_uploader_and_releasepy(gz_source_job,
   '_test_repository_uploader',
   '_test_releasepy')


### PR DESCRIPTION
This has the benefit of not to have the same logic duplicated in different places, the one that builds the labels for tagging when releasing. It goes directly from release.py to the OSRFSourceCreation jobs.