### PR TITLE
Change release.py to use the new centralized tarball approach

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+      - name: Run release.py script tests
+        run: ./check_relasepy.bash
       - name: Download and setup job dsl jar
         if: steps.dsl_check.outputs.run_job == 'true'
         run: ./jenkins-scripts/dsl/tools/setup_local_generation.bash
-
       - name: Generate all DSL files
         if: steps.dsl_check.outputs.run_job == 'true'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Run release.py script tests
-        run: ./check_relasepy.bash
+        run: ./check_releasepy.bash
       - name: Download and setup job dsl jar
         if: steps.dsl_check.outputs.run_job == 'true'
         run: ./jenkins-scripts/dsl/tools/setup_local_generation.bash

--- a/check_releasepy.bash
+++ b/check_releasepy.bash
@@ -11,14 +11,14 @@ exec_releasepy_test()
     ./release.py \
       --dry-run \
       --no-sanity-checks \
-    gz-foo 1.2.3 token ${test_params}
+    gz-foo 1.2.3 token ${test_params}""
 }
 
 expect_job_run()
 {
   output="${1}" job="${2}"
 
-  if ! $(grep -q "job/${job}/buildWith" <<< "${output}"); then
+  if ! grep -q "job/${job}/buildWith" <<< "${output}"; then
     echo "${job} not found in test output"
     exit 1
   fi
@@ -28,7 +28,7 @@ expect_job_not_run()
 {
   output="${1}" job="${2}"
 
-  if $(grep -q "job/${job}/buildWith" <<< "${output}"); then
+  if grep -q "job/${job}/buildWith" <<< "${output}"; then
     echo "${job} found in test output. Should not appear."
     exit 1
   fi
@@ -38,7 +38,7 @@ expect_number_of_jobs()
 {
   output=${1} njobs=${2}
 
-  if [[ `grep  "job/.*/buildWithParameters" <<< "${output}" | wc -l` != "${njobs}" ]]; then
+  if [[ $(grep  -c "job/.*/buildWithParameters" <<< "${output}") != "${njobs}" ]]; then
     echo "Number of jobs caled is not the expected ${njobs}"
     exit 1
   fi
@@ -48,7 +48,7 @@ expect_param()
 {
   output="${1}" param="${2}"
 
-  if ! $(grep -q "[&\?]${param}" <<< "${output}"); then
+  if ! grep -q "[&\?]${param}" <<< "${output}"; then
     echo "${param} not found in test output"
     exit 1
   fi

--- a/check_releasepy.bash
+++ b/check_releasepy.bash
@@ -1,0 +1,76 @@
+#!/bin/bash -xe
+
+test_dir=$(mktemp -d)
+mkdir -p ${test_dir}/{focal,jammy,ubuntu}/debian
+export _RELEASEPY_TEST_RELEASE_REPO=${test_dir}
+
+exec_releasepy_test()
+{
+  test_params=${1}
+
+    ./release.py \
+      --dry-run \
+      --no-sanity-checks \
+    gz-foo 1.2.3 token ${test_params}
+}
+
+expect_job_run()
+{
+  output="${1}" job="${2}"
+
+  if ! $(grep -q "job/${job}/buildWith" <<< "${output}"); then
+    echo "${job} not found in test output"
+    exit 1
+  fi
+}
+
+expect_job_not_run()
+{
+  output="${1}" job="${2}"
+
+  if $(grep -q "job/${job}/buildWith" <<< "${output}"); then
+    echo "${job} found in test output. Should not appear."
+    exit 1
+  fi
+}
+
+expect_number_of_jobs()
+{
+  output=${1} njobs=${2}
+
+  if [[ `grep  "job/.*/buildWithParameters" <<< "${output}" | wc -l` != "${njobs}" ]]; then
+    echo "Number of jobs caled is not the expected ${njobs}"
+    exit 1
+  fi
+}
+
+expect_param()
+{
+  output="${1}" param="${2}"
+
+  if ! $(grep -q "[&\?]${param}" <<< "${output}"); then
+    echo "${param} not found in test output"
+    exit 1
+  fi
+
+}
+
+source_repo_uri_test=$(exec_releasepy_test "--source-repo-uri https://github.org/gazebosim/gz-foo")
+expect_job_run "${source_repo_uri_test}" "gz-foo-source"
+expect_job_not_run "${source_repo_uri_test}" "gz-foo-debbuilder"
+expect_number_of_jobs "${source_repo_uri_test}" "1"
+
+source_tarball_uri_test=$(exec_releasepy_test "--source-tarball-uri https://gazebosim/gz-foo-1.2.3.tar.gz")
+expect_job_run "${source_tarball_uri_test}" "gz-foo-debbuilder"
+expect_job_run "${source_tarball_uri_test}" "generic-release-homebrew_pull_request_updater"
+expect_job_not_run "${source_tarball_uri_test}" "gz-foo-source"
+expect_number_of_jobs "${source_tarball_uri_test}" "7"
+expect_param "${source_tarball_uri_test}" "SOURCE_TARBALL_URI=https%3A%2F%2Fgazebosim%2Fgz-foo-1.2.3.tar.gz"
+
+nightly_test=$(exec_releasepy_test "--nightly-src-branch my-nightly-branch3 --upload-to-repo nightly")
+expect_job_run "${nightly_test}" "gz-foo-debbuilder"
+expect_job_not_run "${nightly_test}" "generic-release-homebrew_pull_request_updater"
+expect_job_not_run "${nightly_test}" "gz-foo-source"
+expect_number_of_jobs "${nightly_test}" "2"
+expect_param "${nightly_test}" "SOURCE_TARBALL_URI=my-nightly-branch3"
+

--- a/check_releasepy.bash
+++ b/check_releasepy.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 
 test_dir=$(mktemp -d)
 mkdir -p ${test_dir}/{focal,jammy,ubuntu}/debian
@@ -74,3 +74,9 @@ expect_job_not_run "${nightly_test}" "gz-foo-source"
 expect_number_of_jobs "${nightly_test}" "2"
 expect_param "${nightly_test}" "SOURCE_TARBALL_URI=my-nightly-branch3"
 
+bump_linux_test=$(exec_releasepy_test "--source-tarball-uri https://gazebosim/gz-foo-1.2.3.tar.gz --only-bump-revision-linux -r 2")
+expect_job_run "${bump_linux_test}" "gz-foo-debbuilder"
+expect_job_not_run "${bump_linux_test}" "generic-release-homebrew_pull_request_updater"
+expect_job_not_run "${bump_linux_test}" "gz-foo-source"
+expect_number_of_jobs "${bump_linux_test}" "6"
+expect_param "${bump_linux_test}" "RELEASE_VERSION=2"

--- a/check_releasepy.bash
+++ b/check_releasepy.bash
@@ -39,7 +39,7 @@ expect_number_of_jobs()
   output=${1} njobs=${2}
 
   if [[ $(grep  -c "job/.*/buildWithParameters" <<< "${output}") != "${njobs}" ]]; then
-    echo "Number of jobs caled is not the expected ${njobs}"
+    echo "Number of jobs called is not the expected ${njobs}"
     exit 1
   fi
 }

--- a/release.py
+++ b/release.py
@@ -24,7 +24,7 @@ LINUX_DISTROS = ['ubuntu', 'debian']
 SUPPORTED_ARCHS = ['amd64', 'armhf', 'arm64']
 RELEASEPY_NO_ARCH_PREFIX = '.releasepy_NO_ARCH_'
 
-OSRF_REPOS_SUPPORTED = "stable prerelease nightly testing"
+OSRF_REPOS_SUPPORTED = "stable prerelease nightly testing none"
 
 DRY_RUN = False
 NIGHTLY = False
@@ -277,7 +277,8 @@ def sanity_check_repo_name(repo_name):
     if repo_name in OSRF_REPOS_SUPPORTED:
         return
 
-    error("Upload repo value: " + repo_name + " is not valid. stable | prerelease | nightly")
+    error(f"Upload repo value: {repo_name} is not valid. \
+            Supported values are: {OSRF_REPOS_SUPPORTED}")
 
 
 def sanity_project_package_in_stable(version, repo_name):

--- a/release.py
+++ b/release.py
@@ -142,7 +142,7 @@ C) Nightly builds (linux)
     parser.add_argument('--source-repo-existing-ref',
                         dest='source_repo_ref',
                         default=None,
-                        help='Optionally, when using --source-repo-urr, indicate the Git reference (branch|tag) to grab the release sources from.\
+                        help='Optionally, when using --source-repo-uri, indicate the Git reference (branch|tag) to grab the release sources from.\
                               If used: avoid to tag the local repository. If not used: tag the local repository with <version> and use it as ref')  # NOQA
     parser.add_argument('--source-tarball-uri',
                         dest='source_tarball_uri', default=None,

--- a/release.py
+++ b/release.py
@@ -297,11 +297,22 @@ def sanity_project_package_in_stable(version, repo_name):
     return
 
 
+def sanity_check_source_repo_uri(source_repo_uri):
+    # Check if the scheme is "https" and the path ends with ".git"
+    parsed_uri = urllib.parse.urlparse(source_repo_uri)
+    if not parsed_uri.scheme == "https" or \
+       not parsed_uri.path.endswith(".git"):
+        error("--source-repo-uri parameter should start with https:// and end with .git")
+
+
 def sanity_checks(args, repo_dir):
     print("Safety checks:")
     sanity_package_name_underscore(args.package, args.package_alias)
     sanity_package_name(repo_dir, args.package, args.package_alias)
     sanity_check_repo_name(args.upload_to_repository)
+
+    if args.source_repo_uri:
+        sanity_check_source_repo_uri(args.source_repo_uri)
 
     if not NIGHTLY:
         sanity_package_version(repo_dir, args.version, str(args.release_version))

--- a/release.py
+++ b/release.py
@@ -121,8 +121,6 @@ def parse_args(argv):
                         help='Release version suffix; usually 1 (e.g., 1')
     parser.add_argument('--no-sanity-checks', dest='no_sanity_checks', action='store_true', default=False,
                         help='no-sanity-checks; i.e. skip sanity checks commands')
-    parser.add_argument('--no-generate-source-file', dest='no_source_file', action='store_true', default=False,
-                        help='Do not generate source file when building')
     parser.add_argument('--upload-to-repo', dest='upload_to_repository', default="stable",
                         help='OSRF repo to upload: stable | prerelease | nightly')
     parser.add_argument('--extra-osrf-repo', dest='extra_repo', default="",
@@ -146,9 +144,6 @@ def parse_args(argv):
         NIGHTLY = True
     if args.upload_to_repository == 'prerelease':
         PRERELEASE = True
-    # Nightly do not generate a tar.bz2 file
-    if NIGHTLY:
-        args.no_source_file = True
 
     return args
 
@@ -324,7 +319,7 @@ def discover_distros(repo_dir):
         arches_supported = [x for x in SUPPORTED_ARCHS if x not in excluded_arches]
         distro_arch_list[d] = arches_supported
 
-    print('Releasing for distributions: ')
+    print('Distributions in release-repo:')
     for k in distro_arch_list:
         print("- " + k + " (" + ', '.join(distro_arch_list[k]) + ")")
 
@@ -411,7 +406,7 @@ def go(argv):
     params = {}
     params['token'] = args.jenkins_token
     params['PACKAGE'] = args.package
-    params['VERSION'] = args.version
+    params['VERSION'] = args.version if not NIGHTLY else 'nightly'
     params['RELEASE_REPO_BRANCH'] = args.release_repo_branch
     params['PACKAGE_ALIAS'] = args.package_alias
     params['RELEASE_VERSION'] = args.release_version

--- a/release.py
+++ b/release.py
@@ -181,21 +181,25 @@ def get_release_repository_info(package):
 
     error("release repository not found in github.com/gazebo-release")
 
+
 def download_release_repository(package, release_branch):
-    vcs, url = get_release_repository_info(package)
-    release_tmp_dir = tempfile.mkdtemp()
+    try:
+        return os.environ['_RELEASEPY_TEST_RELEASE_REPO'], 'main'
+    except KeyError:
+        vcs, url = get_release_repository_info(package)
+        release_tmp_dir = tempfile.mkdtemp()
 
-    if vcs == "git" and release_branch == "default":
-        release_branch = "master"
+        if vcs == "git" and release_branch == "default":
+            release_branch = "master"
 
-    # If main branch exists, prefer it over master
-    if release_branch == "master":
-        if exists_main_branch(url):
-            release_branch = 'main'
+        # If main branch exists, prefer it over master
+        if release_branch == "master":
+            if exists_main_branch(url):
+                release_branch = 'main'
 
-    cmd = [vcs, "clone", "-b", release_branch, url, release_tmp_dir]
-    check_call(cmd, IGNORE_DRY_RUN)
-    return release_tmp_dir, release_branch
+        cmd = [vcs, "clone", "-b", release_branch, url, release_tmp_dir]
+        check_call(cmd, IGNORE_DRY_RUN)
+        return release_tmp_dir, release_branch
 
 
 def sanity_package_name_underscore(package, package_alias):

--- a/release.py
+++ b/release.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from __future__ import print_function
+from argparse import RawTextHelpFormatter
 import subprocess
 import sys
 import tempfile
@@ -104,7 +105,21 @@ def parse_args(argv):
     global NIGHTLY
     global PRERELEASE
 
-    parser = argparse.ArgumentParser(description='Make releases.')
+    parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter,
+    description="""
+Script to handle the release process for the Gazebo devs.
+Examples:
+A) Generate source: local repository tag + call source job:
+   $ release.py <package> <version> <jenkins_token>
+   (auto calculate source-repo-uri from local directory)
+
+B) Call builders: reuse existing tarball version + call build jobs:
+   $ release.py --source-tarball-uri <URL> <package> <version> <jenkins_token>
+   (no call to source job, directly build jobs with tarball URL)
+
+C) Nightly builds (linux)
+   $ release.py --source-repo-existing-ref <git_branch> --upload-to-repo nightly <URL> <package> <version> <jenkins_token>
+ """)
     parser.add_argument('package', help='which package to release')
     parser.add_argument('version', help='which version to release')
     parser.add_argument('jenkins_token', help='secret token to allow access to Jenkins to start builds')

--- a/release.py
+++ b/release.py
@@ -377,6 +377,25 @@ def tag_repo(args):
     return tag
 
 
+def generate_source_repository_uri(args):
+    org_repo = f"gazebosim/{get_canonical_package_name(args.package_alias)}"
+    out, err = check_call(['git', 'ls-remote', '--get-url', 'origin'],
+                          IGNORE_DRY_RUN)
+    if err:
+        print(f"An error happened running git ls-remote: ${err}")
+        sys.exit(1)
+
+    git_remote = out.decode().split('\n')[0]
+    if org_repo not in git_remote:
+        print(f""" !! Automatic calculation of source_repo_uri failed.\
+              \n   * git remote origin is: {git_remote}\
+              \n   * Package name generated org/repo: {org_repo}\
+              \n >> Please use --source-repo-uri parameter""")
+        sys.exit(1)
+
+    return f"https://github.com/{org_repo}.git"  # NOQA
+
+
 def call_jenkins_build(job_name, params, output_string):
     params_query = urllib.parse.urlencode(params)
     url = '%s/job/%s/buildWithParameters?%s' % (JENKINS_URL,

--- a/release.py
+++ b/release.py
@@ -305,11 +305,20 @@ def sanity_check_source_repo_uri(source_repo_uri):
         error("--source-repo-uri parameter should start with https:// and end with .git")
 
 
+def sanity_check_bump_linux(source_tarball_uri):
+    if (not source_tarball_uri):
+        error('--only-bump-revision-linux needs --source-tarball-uri argument'
+              'to call builders and not source generation')
+
+
 def sanity_checks(args, repo_dir):
     print("Safety checks:")
     sanity_package_name_underscore(args.package, args.package_alias)
     sanity_package_name(repo_dir, args.package, args.package_alias)
     sanity_check_repo_name(args.upload_to_repository)
+
+    if (args.bump_rev_linux_only):
+        sanity_check_bump_linux(args.source_tarball_uri)
 
     if args.source_repo_uri:
         sanity_check_source_repo_uri(args.source_repo_uri)

--- a/release.py
+++ b/release.py
@@ -425,18 +425,18 @@ def generate_source_repository_uri(args):
 
 def generate_source_params(args):
     params = {}
-    # 1. Launch source jobs (SOURCE_REPO_URI)
+    # 1. NIGHTLY (launch builders):
+    #     Pass the nightly branch if NIGHTLY enabled
+    # 2. Launch builders
+    #     Using args.source_tarball_uri if present
+    # 3. Launch source jobs (SOURCE_REPO_URI)
     #     1.1 using args.source_repo_uri (if it was passed)
     #     1.2 autogenerating it
-    #
-    # 2. Launch builders (SOURCE_TARBALL_URI)
-    #     2.1 using args.source_tarball_uri
-    #     2.2 pass the nightly branch if NIGHTLY enabled
-    #
-    if args.source_tarball_uri:
-        params['SOURCE_TARBALL_URI'] = \
-            args.source_tarball_uri if not NIGHTLY else \
-            args.nightly_branch
+
+    if NIGHTLY:
+        params['SOURCE_TARBALL_URI'] = args.nightly_branch
+    elif args.source_tarball_uri:
+        params['SOURCE_TARBALL_URI'] = args.source_tarball_uri
     else:
         params['SOURCE_REPO_URI'] = \
             args.source_repo_uri if args.source_repo_uri else \


### PR DESCRIPTION
The PR changes the release.py logic to be able to use the new generation of tarball that happens on Jenkins instead of using the dev local machines. See the linked docs update for a general usage and data flow overview https://github.com/gazebosim/docs/pull/403

**No changes in releasing workflow and the release.py call:** Note that the tag of the project code to be built still happens in the local dev system so the workflow is the same than now: go to the source code you want to build and run `release.py` with the same arguments than now. Instead of calling `-debbuilders` there will a chain of actions composed 

PR is quite long, probably easier to read change by change to understand the logic:
 1. Remove all current code related to tarball generation  5f18737cdd47d918c30ecfec5dd569f2c71d7ffc
 1. Remove current `--no-generate-source-file` and clean up nightly generation 7887be0975ab0b100335d1ed9f76604b1c284c89
  1. Helper function to get the github repository uri from current directory:
     1. Originally implemented in  6a712ff36af9d6f480af3f0ba7a0876a8436d1d0 but patched afterwards in https://github.com/gazebo-tooling/release-tools/commit/a870d8c87abe56f6eb4c3dc63637ad8e6290f54a#diff-9f016d3777d731463c2969cd7d16bb014363bee6bf98af9fe7ca66c4392949ad
     2. Sanity check for right format added in dc06b9724615607672f98077112b1402fdb08d92
 1. Introduce new release.py parameters `--source-repo-existing-ref` and  `--source-tarball-uri`. If `--source-tarball-uri`:
     1. Implement the transport of the parameters in the release call e786626b3c52eb88475b302c7420e6864c007cae
     1. Explain in `--help` what the new parameters do 8aca8acd5655fcb7a9f52dc386976ffb91100fee
 1. Change logic to make the two modes of calling to work:  db39135071fea103f092ebccd592bb5b69bab6ac
     1. Standard new workflow calls to `gz-foo-source` directory as entry point
     3. Nightly and `--source-tarball-uri` calls will trigger `gz-foo-debbuilders` directly since no source code needs to be generated.
        1. Make the `--bump-only-revision-linux` parameter to need `--source-tarball-uri` [cbb83e2](https://github.com/gazebo-tooling/release-tools/pull/1048/commits/cbb83e242bd9a470bf85184acb20995d2a521841)

CI Testing:
  1. Implemented an smoke test job to be added to CI
    1. Change release.py to be use `_RELEASEPY_TEST_RELEASE_REPO` https://github.com/gazebo-tooling/release-tools/commit/479139235e9b7218960a1d35c91130049a75f0d8#diff-9f016d3777d731463c2969cd7d16bb014363bee6bf98af9fe7ca66c4392949ad
    2.  See the bash testing in https://github.com/gazebo-tooling/release-tools/commit/a870d8c87abe56f6eb4c3dc63637ad8e6290f54a#diff-9074386702f4ff2677975dcd91d17dd99887e1e2a886f8234056e4a8ebefbf9b

Manual testing:
Run the whole generation pipeline with the real example of `gz-utils2` version `2.2.0~pre3`. Steps were as follow:
  1. Usual previous steps to prepare the -release repository and the source code modifying `CMakeLists.txt`
  1. `cd code/gz-utils`
  1. Dry run `~/code/release-tools/release.py gz-utils2 2.2.0~pre1 <token> --dry-run --upload-to-repo prerelease` to see the gz-source
  1. Run release `~/code/release-tools/release.py gz-utils2 2.2.0~pre1 <token> --upload-to-repo prerelease`
    1. The release.py call triggers **gz-utils2-source** [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-utils2-source&build=9)](https://build.osrfoundation.org/job/gz-utils2-source/9/). Which after success, called:
      1. **repository_uploader_packages** to upload the tarball. In the parameters can be found the new tarball name and upload target. [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=repository_uploader_packages&build=44229)](https://build.osrfoundation.org/job/repository_uploader_packages/44229/) 
      2. **_releasepy** (that will wait until all jobs of `repository_uploader_packages` finish) to call the debbuilders using `--source-tarball-uri` that points to the new tarball. The call and output is hidden in the a workspace log for security reasons.  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_releasepy&build=13)](https://build.osrfoundation.org/job/_releasepy/13/). This job will call `--debuilders` and the brew bottle builder as it is done until now.