### PR TITLE
Fix sensors and physics versions

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -152,13 +152,13 @@ collections:
         repo:
           current_branch: ign-gui6
       - name: gz-sensors
-        major_version: 7
-        repo:
-          current_branch: ign-sensors7
-      - name: gz-physics
         major_version: 6
         repo:
-          current_branch: ign-physics6
+          current_branch: ign-sensors6
+      - name: gz-physics
+        major_version: 5
+        repo:
+          current_branch: ign-physics5
       - name: gz-sim
         major_version: 6
         repo:


### PR DESCRIPTION
There is a discrepancy in [fortress gz-collections.yaml](https://github.com/gazebo-tooling/release-tools/blob/8c8880e00854bde1cbc4091e8e0c61759d1f03fe/jenkins-scripts/dsl/gz-collections.yaml#L154-L157) and [collection-fortress.yaml](https://github.com/gazebo-tooling/gazebodistro/blob/dfd98e79e17a146a25baaa72f7ef2ad07ff6f0ab/collection-fortress.yaml#L48-L50).

In the gz-collections it says ign-sensors7, but in collection-fortress it says ign-sensors6 (same happens for physics).