### PR TITLE
Alternative keyserver for Bionic

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -206,6 +206,11 @@ DELIM_DOCKER_DIRMNGR
 # Install necessary repositories using gzdev
 dockerfile_install_gzdev_repos
 
+KEYSERVER="keyserver.ubuntu.com"
+if [ "${DISTRO}" == 'bionic' ]; then
+  KEYSERVER="keys.openpgp.org"
+fi
+
 if ${USE_ROS_REPO}; then
   if ${ROS2}; then
 cat >> Dockerfile << DELIM_ROS_REPO
@@ -224,14 +229,14 @@ DELIM_ROS_REPO
 cat >> Dockerfile << DELIM_ROS_REPO
 RUN echo "deb http://repos.ros.org/repos/ros_bootstrap/ ${DISTRO} main" > \\
                                                 /etc/apt/sources.list.d/ros_bootstrap.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8EDB2EF661FC880E
+RUN apt-key adv --keyserver ${KEYSERVER} --recv-keys 8EDB2EF661FC880E
 DELIM_ROS_REPO
   else
 cat >> Dockerfile << DELIM_ROS_REPO
 # Note that ROS uses ubuntu hardcoded in the paths of repositories
 RUN echo "deb http://packages.ros.org/${ROS_REPO_NAME}/ubuntu ${DISTRO} main" > \\
                                                 /etc/apt/sources.list.d/ros.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654
+RUN apt-key adv --keyserver ${KEYSERVER} --recv-keys F42ED6FBAB17C654
 DELIM_ROS_REPO
 # Need ros stable for the cases of ros-testing
 if [[ ${ROS_REPO_NAME} != "ros" ]]; then


### PR DESCRIPTION
@Crola1702 reported that Bionic builds were failing continuously something that I tried to debug in other occasions and could not reproduce the error locally, so flakiness is involved in the issue. Error on Bionic build is:
```
#14 0.607 Warning: apt-key output should not be parsed (stdout is not a terminal)
#14 0.625 Executing: /tmp/apt-key-gpghome.pDPnL9osSh/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
#14 0.883 gpg: keyserver receive failed: Cannot assign requested address
```
gpg is unable to get packages.osrfoundation,org key under some circumstances.

My hypothesis has to do with the: gpg/ssl/apt-key libraries/apps versions on Bionic that might not implement new/modern aspect of a protocol that has been updated in [keyserver.ubuntu.com](http://keyserver.ubuntu.com/). Once Bionic was EOL, ubuntu dropped the support for these old versions of the protocol. All this is pure speculative and could be plain fantasy.

Anyway, changing the keyserver worked in previous failing examples:
* ign-gazebo3  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gazebo-ci-ign-gazebo3-bionic-amd64&build=6)](https://build.osrfoundation.org/job/ign_gazebo-ci-ign-gazebo3-bionic-amd64/6/)
* ign-gui3 [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gui-ci-ign-gui3-bionic-amd64)](https://build.osrfoundation.org/job/ign_gui-ci-ign-gui3-bionic-amd64/)