### PR TITLE
Fix brew -ci-pr_any-: remove workarounds in project-default bash file

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -13,16 +13,7 @@ export HOMEBREW_MAKE_JOBS=${MAKE_JOBS}
 PROJECT=$1 # project will have the major version included (ex gazebo2)
 PROJECT_ARGS=${2}
 
-# TODO(chapulina) Use gz path instead of legacy ign
 PROJECT_PATH=${PROJECT}
-if [[ ${PROJECT/gz} != ${PROJECT} ]]; then
-    PROJECT_PATH="ign${PROJECT/gz}"
-    PROJECT_PATH="${PROJECT_PATH/[0-9]*}"
-fi
-
-# Temporary fix for gz-sim
-PROJECT=${PROJECT/gz-gazebo/gz-sim}
-PROJECT_PATH=${PROJECT_PATH/ign-sim/ign-gazebo}
 
 # Check for major version number
 # the PROJECT_FORMULA variable is only used for dependency resolution


### PR DESCRIPTION
After #1054 the brew builds are broken with problem to execute the detection of the major versions. Problem seems to be in the bash code of `jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash` that was modifying the value passed as the relative path for workaround to force the `ign-` prefix injection. We should not need that anymore.

Failing:
gz-cmake [![Build Status](https://build.osrfoundation.org/job/gz_cmake-ci-pr_any-homebrew-amd64/1/badge/icon)](https://build.osrfoundation.org/job/gz_cmake-ci-pr_any-homebrew-amd64/1/)

This PR:
gz-cmake [![Build Status](https://build.osrfoundation.org/job/gz_cmake-ci-pr_any-homebrew-amd64/2/badge/icon)](https://build.osrfoundation.org/job/gz_cmake-ci-pr_any-homebrew-amd64/2/)