### PR TITLE
homebrew_formula_pullrequest: unique branch name

### DIFF
--- a/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
@@ -108,6 +108,6 @@ if [ "$FORMULA_REVISION" -gt 0 ]; then
 fi
 
 # create branch with name and sanitized version string
-PULL_REQUEST_BRANCH="${PACKAGE_ALIAS}_`echo ${VERSION_SANITIZED} | tr ' ~:^?*[' '_'`"
+PULL_REQUEST_BRANCH="${PACKAGE_ALIAS}_$(echo ${VERSION_SANITIZED} | tr ' ~:^?*[' '_')_$(date +%s)"
 
 . ${SCRIPT_LIBDIR}/_homebrew_github_commit.bash


### PR DESCRIPTION
The homebrew formula pull requests sometimes are triggered twice, but the second pull request is not created due to overlapping branch names. This gives each pull request a unique branch name so that duplicate pull requests will be created, and the maintainer can figure out which has the correct tarball SHA.

Fixes #1020.