### PR TITLE
Use `--merge-install` for colcon so that `gz` can be found during build

### DIFF
--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -194,7 +194,7 @@ echo "COLCON_EXTRA_ARGS: %COLCON_EXTRA_ARGS% %COLCON_PACKAGE%"
 echo "COLCON_EXTRA_CMAKE_ARGS: %COLCON_EXTRA_CMAKE_ARGS%"
 echo "COLCON_EXTRA_CMAKE_ARGS2: %COLCON_EXTRA_CMAKE_ARGS2%"
 
-colcon build --build-base "build"^
+colcon build --merge-install --build-base "build"^
 	     --install-base "install"^
 	     --parallel-workers %MAKE_JOBS%^
 	     %COLCON_EXTRA_ARGS% %COLCON_PACKAGE%^
@@ -243,7 +243,7 @@ goto :EOF
 set COLCON_PACKAGE=%1
 
 echo # BEGIN SECTION: colcon test for !COLCON_PACKAGE!
-colcon test --install-base "install"^
+colcon test --merge-install --install-base "install"^
             --packages-select !COLCON_PACKAGE!^
             --executor sequential^
             --event-handler console_direct+


### PR DESCRIPTION
Our windows builds are not running `UNIT_gz_TEST` or similar tests because  `gz` is not found at build time. This is because we are using isolated builds and `colcon` doesn't seem to expose the `bin` directories of each of the dependencies at build time. Using `--merge-install` fixes this and this is also what we've been recommending for our users (see https://gazebosim.org/docs/harmonic/install_windows_src#building-the-gazebo-libraries)