### PR TITLE
Fixes for gazebo-install-one_liner-homebrew-amd64

### DIFF
--- a/jenkins-scripts/gazebo-one_liner-homebrew.bash
+++ b/jenkins-scripts/gazebo-one_liner-homebrew.bash
@@ -10,5 +10,5 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: run the one-liner installation'
 # curl -ssL https://get.gazebosim.org | sh -x
-sh -x ${SCRIPT_DIR}/one-line-installations/gazebo.sh
+sh -x ${SCRIPT_DIR}/../one-line-installations/gazebo.sh
 echo '# END SECTION'

--- a/jenkins-scripts/gazebo-one_liner-homebrew.bash
+++ b/jenkins-scripts/gazebo-one_liner-homebrew.bash
@@ -9,6 +9,8 @@ echo '# BEGIN SECTION: cleanup brew installation'
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run the one-liner installation'
-# curl -ssL https://get.gazebosim.org | sh -x
-sh -x ${SCRIPT_DIR}/../one-line-installations/gazebo.sh
+curl -ssL https://get.gazebosim.org | sh -x
+# to test undeployed changes to gazebo.sh, comment out the
+# curl invocation and uncomment the line below
+# sh -x ${SCRIPT_DIR}/../one-line-installations/gazebo.sh
 echo '# END SECTION'

--- a/jenkins-scripts/gazebo-one_liner-homebrew.bash
+++ b/jenkins-scripts/gazebo-one_liner-homebrew.bash
@@ -9,6 +9,6 @@ echo '# BEGIN SECTION: cleanup brew installation'
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run the one-liner installation'
-# TODO: change this to 'curl -ssL https://get.gazebosim.org' once that supports https
-curl -ssL https://github.com/gazebo-tooling/release-tools/raw/master/one-line-installations/gazebo.sh | sh -x
+# curl -ssL https://get.gazebosim.org | sh -x
+sh -x ${SCRIPT_DIR}/one-line-installations/gazebo.sh
 echo '# END SECTION'

--- a/jenkins-scripts/gazebo-one_liner-homebrew.bash
+++ b/jenkins-scripts/gazebo-one_liner-homebrew.bash
@@ -9,7 +9,7 @@ echo '# BEGIN SECTION: cleanup brew installation'
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run the one-liner installation'
-curl -ssL https://get.gazebosim.org | sh -x
+curl -sSL https://get.gazebosim.org | sh -x
 # to test undeployed changes to gazebo.sh, comment out the
 # curl invocation and uncomment the line below
 # sh -x ${SCRIPT_DIR}/../one-line-installations/gazebo.sh

--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -31,7 +31,7 @@ for t in $(HOMEBREW_NO_AUTO_UPDATE=1 \
           | grep -v '^homebrew/core$'); do
   ${BREW_BINARY} untap $t
 done
-brew cleanup --prune-prefix
+${BREW_BINARY} cleanup --prune-prefix
 
 pushd $(${BREW_BINARY} --prefix)/Homebrew/Library 2> /dev/null
 git stash && git clean -d -f

--- a/one-line-installations/gazebo.sh
+++ b/one-line-installations/gazebo.sh
@@ -287,7 +287,7 @@ do_install() {
 				exit 1
 			  fi
 
-			  export PATH=/usr/local/bin:${PATH}
+			  export PATH=/usr/local/bin:/usr/local/sbin:${PATH}
 			  if ! command_exists brew; then
 				echo "Installing Homebrew:"
 				ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"


### PR DESCRIPTION
I noticed the following failed CI job and made a few fixes after some debugging:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-one_liner-homebrew-amd64&build=2959)](https://build.osrfoundation.org/view/ign-citadel/job/gazebo-install-one_liner-homebrew-amd64/2959/) https://build.osrfoundation.org/view/ign-citadel/job/gazebo-install-one_liner-homebrew-amd64/2959/

That first failure has the following error:

~~~
++ brew cleanup --prune-prefix
./scripts/jenkins-scripts/lib/_homebrew_cleanup.bash: line 34: brew: command not found
~~~

The fix in https://github.com/gazebo-tooling/release-tools/commit/8e852017192e5f4c93f07a3107f60f72bcc981bc is to use `${BREW_BINARY}` to match the rest of the script.

After that I saw a `brew doctor` complaint about `sbin` not being in the `PATH`:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-one_liner-homebrew-amd64&build=2960)](https://build.osrfoundation.org/view/ign-citadel/job/gazebo-install-one_liner-homebrew-amd64/2960/) https://build.osrfoundation.org/view/ign-citadel/job/gazebo-install-one_liner-homebrew-amd64/2960/

~~~
Warning: Homebrew's "sbin" was not found in your PATH but you have installed
formulae that put executables in /usr/local/sbin.
Consider setting your PATH for example like so:
  echo 'export PATH="/usr/local/sbin:$PATH"' >> ~/.zshrc
~~~

The fix is in https://github.com/gazebo-tooling/release-tools/commit/115c708f346ec373b38eadc96f525b57bb2645ee, copied from https://github.com/gazebo-tooling/release-tools/pull/931.

I then made a change in https://github.com/gazebo-tooling/release-tools/commit/70c04c491bf3d86fcb413273f50501074d6fee5d and https://github.com/gazebo-tooling/release-tools/commit/46f55b9b046c5a524d702fdc004d8039b5c53226 to use a local copy of the script in CI, and after it passed, I reverted to `curl`ing the script and followed the recommendation to get it from https://get.gazebosim.org

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-one_liner-homebrew-amd64&build=2963)](https://build.osrfoundation.org/view/ign-citadel/job/gazebo-install-one_liner-homebrew-amd64/2963/) https://build.osrfoundation.org/view/ign-citadel/job/gazebo-install-one_liner-homebrew-amd64/2963/

The CI job should be fixed once this is merged.