### PR TITLE
Fix ign-gazebo6 branch name

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -163,7 +163,7 @@ collections:
       - name: gz-sim
         major_version: 6
         repo:
-          current_branch: ign-sim6
+          current_branch: ign-gazebo6
       - name: gz-launch
         major_version: 5
         repo:


### PR DESCRIPTION
In gz-sim repository, the defined branch for gz-sim in fortress is named: `ign-gazebo6`.

This was changed in https://github.com/gazebo-tooling/release-tools/pull/1040