### PR TITLE
INVALIDATE_DOCKER_CACHE in Bionic and Focal for the next two months

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -29,6 +29,14 @@ fi
 
 [[ -z ${INSTALL_C17_COMPILER} ]] && INSTALL_C17_COMPILER=false
 
+# Bionic builds were affected by a "gpg: keyserver receive failed" in apt-key execution
+# that poisoned a lot of docker cache in different builds and nodes. Force invalidation
+# during a couple of month to rotate images
+if [[ "${DISTRO}" == 'bionic' ]] && \
+   [[ "$(date '+%s')" -lt "$(date -d '+60 days' '+%s')" ]]; then
+  export INVALIDATE_DOCKER_CACHE=true
+fi
+
 export APT_PARAMS=
 
 GZDEV_DIR=${WORKSPACE}/gzdev

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -32,8 +32,9 @@ fi
 # Bionic|Focal builds were affected by a "gpg: keyserver receive failed" in apt-key execution
 # that poisoned a lot of docker cache in different builds and nodes. Force invalidation
 # during a couple of month to rotate images
+ref_date='2023-11-13'
 if [[ "${DISTRO}" == 'bionic' || "${DISTRO}" == 'focal' ]] && \
-   [[ "$(date '+%s')" -lt "$(date -d '+60 days' '+%s')" ]]; then
+   [[ "$(date '+%s')" -lt "$(date -d "${ref_date}+60 days" '+%s')" ]]; then
   export INVALIDATE_DOCKER_CACHE=true
 fi
 

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -29,10 +29,10 @@ fi
 
 [[ -z ${INSTALL_C17_COMPILER} ]] && INSTALL_C17_COMPILER=false
 
-# Bionic builds were affected by a "gpg: keyserver receive failed" in apt-key execution
+# Bionic|Focal builds were affected by a "gpg: keyserver receive failed" in apt-key execution
 # that poisoned a lot of docker cache in different builds and nodes. Force invalidation
 # during a couple of month to rotate images
-if [[ "${DISTRO}" == 'bionic' ]] && \
+if [[ "${DISTRO}" == 'bionic' || "${DISTRO}" == 'focal' ]] && \
    [[ "$(date '+%s')" -lt "$(date -d '+60 days' '+%s')" ]]; then
   export INVALIDATE_DOCKER_CACHE=true
 fi


### PR DESCRIPTION
After many problems related to an apt-key failure that has poisoned many of our docker cache, this PR should invalidate docker cache. This PR will help to keep the cache clean for a couple of months to facilitate image rotation.

See #1069 