### PR TITLE
Fix brew ign- formula names

### DIFF
--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -154,19 +154,23 @@ void generate_ci_job(gz_ci_job, lib_name, branch, ci_config,
 void generate_brew_ci_job(gz_brew_ci_job, lib_name, branch, ci_config)
 {
   def script_name_prefix = cleanup_library_name(lib_name)
+  def ws_checkout_dir = lib_name
+  def project_formula = lib_name.replaceAll(/^ign_/, 'ignition_')
   OSRFBrewCompilation.create(gz_brew_ci_job,
                              is_testing_enabled(lib_name, ci_config),
                              are_cmake_warnings_enabled(lib_name, ci_config))
   OSRFGitHub.create(gz_brew_ci_job,
                     "gazebosim/${lib_name}",
                     branch,
-                    lib_name)
+                    ws_checkout_dir)
   gz_brew_ci_job.with
   {
     steps {
       shell("""\
             #!/bin/bash -xe
 
+            export PROJECT_PATH="${ws_checkout_dir}"
+            export PROJECT_FORMULA="${project_formula}"
             /bin/bash -xe ./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash "${lib_name}"
             """.stripIndent())
       }
@@ -283,6 +287,8 @@ ciconf_per_lib_index.each { lib_name, lib_configs ->
       // --------------------------------------------------------------
       def gz_brew_ci_any_job_name = "${gz_job_name_prefix}-ci-pr_any-homebrew-amd64"
       def gz_brew_ci_any_job = job(gz_brew_ci_any_job_name)
+      def ws_checkout_dir = lib_name
+      def project_formula = lib_name.replaceAll(/^ign_/, 'ignition_')
       OSRFBrewCompilationAnyGitHub.create(gz_brew_ci_any_job,
                                           "gazebosim/${lib_name}",
                                           is_testing_enabled(lib_name, ci_config),
@@ -295,6 +301,8 @@ ciconf_per_lib_index.each { lib_name, lib_configs ->
           shell("""\
                 #!/bin/bash -xe
 
+                export PROJECT_PATH="${ws_checkout_dir}"
+                export PROJECT_FORMULA="${project_formula}"
                 /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "${lib_name}"
                 """.stripIndent())
         }

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -151,18 +151,10 @@ void generate_ci_job(gz_ci_job, lib_name, branch, ci_config,
   }
 }
 
-void generate_brew_ci_job(gz_brew_ci_job, lib_name, branch, ci_config)
+void add_brew_shell_build_step(gz_brew_ci_job, lib_name, ws_checkout_dir)
 {
-  def script_name_prefix = cleanup_library_name(lib_name)
-  def ws_checkout_dir = lib_name
-  def project_formula = lib_name.replaceAll(/^ign_/, 'ignition_')
-  OSRFBrewCompilation.create(gz_brew_ci_job,
-                             is_testing_enabled(lib_name, ci_config),
-                             are_cmake_warnings_enabled(lib_name, ci_config))
-  OSRFGitHub.create(gz_brew_ci_job,
-                    "gazebosim/${lib_name}",
-                    branch,
-                    ws_checkout_dir)
+  // ignition formulas does not match the lib name, expand the prefix
+  lib_name = lib_name.replaceAll(/^ign-/, 'ignition-')
   gz_brew_ci_job.with
   {
     steps {
@@ -170,11 +162,24 @@ void generate_brew_ci_job(gz_brew_ci_job, lib_name, branch, ci_config)
             #!/bin/bash -xe
 
             export PROJECT_PATH="${ws_checkout_dir}"
-            export PROJECT_FORMULA="${project_formula}"
             /bin/bash -xe ./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash "${lib_name}"
             """.stripIndent())
       }
   }
+}
+
+void generate_brew_ci_job(gz_brew_ci_job, lib_name, branch, ci_config)
+{
+  def script_name_prefix = cleanup_library_name(lib_name)
+  def ws_checkout_dir = lib_name
+  OSRFBrewCompilation.create(gz_brew_ci_job,
+                             is_testing_enabled(lib_name, ci_config),
+                             are_cmake_warnings_enabled(lib_name, ci_config))
+  OSRFGitHub.create(gz_brew_ci_job,
+                    "gazebosim/${lib_name}",
+                    branch,
+                    ws_checkout_dir)
+  add_brew_shell_build_step(gz_brew_ci_job, lib_name, ws_checkout_dir)
 }
 
 def ciconf_per_lib_index = [:].withDefault { [:] }
@@ -288,25 +293,13 @@ ciconf_per_lib_index.each { lib_name, lib_configs ->
       def gz_brew_ci_any_job_name = "${gz_job_name_prefix}-ci-pr_any-homebrew-amd64"
       def gz_brew_ci_any_job = job(gz_brew_ci_any_job_name)
       def ws_checkout_dir = lib_name
-      def project_formula = lib_name.replaceAll(/^ign_/, 'ignition_')
       OSRFBrewCompilationAnyGitHub.create(gz_brew_ci_any_job,
                                           "gazebosim/${lib_name}",
                                           is_testing_enabled(lib_name, ci_config),
                                           branch_names,
                                           ENABLE_GITHUB_PR_INTEGRATION,
                                           are_cmake_warnings_enabled(lib_name, ci_config))
-      gz_brew_ci_any_job.with
-      {
-        steps {
-          shell("""\
-                #!/bin/bash -xe
-
-                export PROJECT_PATH="${ws_checkout_dir}"
-                export PROJECT_FORMULA="${project_formula}"
-                /bin/bash -xe "./scripts/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash" "${lib_name}"
-                """.stripIndent())
-        }
-      }
+      add_brew_shell_build_step(gz_brew_ci_any_job, lib_name, ws_checkout_dir)
     }
   } //en of lib_configs
 } // end of lib

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -12,14 +12,17 @@ export HOMEBREW_MAKE_JOBS=${MAKE_JOBS}
 # Get project name as first argument to this script
 PROJECT=$1 # project will have the major version included (ex gazebo2)
 PROJECT_ARGS=${2}
-
-PROJECT_PATH=${PROJECT}
-
-# Check for major version number
-# the PROJECT_FORMULA variable is only used for dependency resolution
-PROJECT_FORMULA=${PROJECT//[0-9]}$(\
-  python3 ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
-  ${WORKSPACE}/${PROJECT_PATH}/CMakeLists.txt || true)
+# PROJECT_PATH can be passed as env variable or assume that is the same than project name
+PROJECT_PATH=${:-PROJECT}
+# PROJECT_FORMULA can be passed as env varible or assume that will be generated
+# from PROJECT and the major version in the CMakeLists.txt
+if [[ -z ${PROJECT_FORMULA} ]]; then
+  # Check for major version number
+  # the PROJECT_FORMULA variable is only used for dependency resolution
+  PROJECT_FORMULA=${PROJECT//[0-9]}$(\
+    python3 ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
+    ${WORKSPACE}/${PROJECT_PATH}/CMakeLists.txt || true)
+fi
 
 export HOMEBREW_PREFIX=/usr/local
 export HOMEBREW_CELLAR=${HOMEBREW_PREFIX}/Cellar

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -14,15 +14,11 @@ PROJECT=$1 # project will have the major version included (ex gazebo2)
 PROJECT_ARGS=${2}
 # PROJECT_PATH can be passed as env variable or assume that is the same than project name
 PROJECT_PATH=${:-PROJECT}
-# PROJECT_FORMULA can be passed as env varible or assume that will be generated
-# from PROJECT and the major version in the CMakeLists.txt
-if [[ -z ${PROJECT_FORMULA} ]]; then
-  # Check for major version number
-  # the PROJECT_FORMULA variable is only used for dependency resolution
-  PROJECT_FORMULA=${PROJECT//[0-9]}$(\
-    python3 ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
-    ${WORKSPACE}/${PROJECT_PATH}/CMakeLists.txt || true)
-fi
+# Check for major version number
+# the PROJECT_FORMULA variable is only used for dependency resolution
+PROJECT_FORMULA=${PROJECT//[0-9]}$(\
+  python3 ${SCRIPT_DIR}/tools/detect_cmake_major_version.py \
+  ${WORKSPACE}/${PROJECT_PATH}/CMakeLists.txt || true)
 
 export HOMEBREW_PREFIX=/usr/local
 export HOMEBREW_CELLAR=${HOMEBREW_PREFIX}/Cellar

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -13,7 +13,7 @@ export HOMEBREW_MAKE_JOBS=${MAKE_JOBS}
 PROJECT=$1 # project will have the major version included (ex gazebo2)
 PROJECT_ARGS=${2}
 # PROJECT_PATH can be passed as env variable or assume that is the same than project name
-PROJECT_PATH=${:-PROJECT}
+PROJECT_PATH=${PROJECT_PATH:-$PROJECT}
 # Check for major version number
 # the PROJECT_FORMULA variable is only used for dependency resolution
 PROJECT_FORMULA=${PROJECT//[0-9]}$(\


### PR DESCRIPTION
My approach in this PR has been trying to be explicit with the checkout directory for brew instead of trying to calculate it from PROJECT (lib name) and `PROJECT_FORMULA`. Accept to pass environment variables to the values and fallback to keep current behaviour, see 8c175f40dc42a593588a24712014f6c44462320f.

Change DSL to use that approach in 03cc3d0b5c09ebf86fa36b7753cb713df6b523d1

Refactoring code to use a single function to setup the bash call, I disliked the idea of having `PROJECT_FORMULA` from DSL since it really has no notion of "package-name" so I removed it and leaved as it was before (using `PROJECT + detect_cmake_major_version` and just fix the ign- value when going to the project to be ignition-, see def89176fa57182791e0928b6f642bfd3309e897