### PR TITLE
Exclude sdformat CMake warnings on brew in gz-collections.yaml

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -546,6 +546,7 @@ ci_configs:
       - gz-tools
       - gz-transport
       - gz-utils
+      - sdformat
 packaging_configs:
   - name: bionic
     system:


### PR DESCRIPTION
The list of CMake warning exclusion did not include sdformat before.