### PR TITLE
brew: use HOMEBREW_PREFIX in PYTHONPATH

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -24,7 +24,7 @@ export HOMEBREW_PREFIX=/usr/local
 export HOMEBREW_CELLAR=${HOMEBREW_PREFIX}/Cellar
 export PATH=${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:$PATH
 
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python
+export PYTHONPATH=$PYTHONPATH:${HOMEBREW_PREFIX}/lib/python
 
 # make verbose mode?
 MAKE_VERBOSE_STR=""


### PR DESCRIPTION
The `PYTHONPATH` currently references `/usr/local`, but it is cleaner to use the `HOMEBREW_PREFIX` variable to match how other variables are defined. This will be most relevant when we have mac CI machines with ARM CPUs.