### PR TITLE
Split CI: Move releasepy checks to its own workflow

### DIFF
--- a/.github/workflows/ci-releasepy.yaml
+++ b/.github/workflows/ci-releasepy.yaml
@@ -1,0 +1,18 @@
+name: Releasing tests
+
+on:
+  push:
+    paths:
+      - release.py
+
+jobs:
+  dsl_ci:
+    runs-on: ubuntu-latest
+    name: release.py checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run release.py script tests
+        run: ./check_releasepy.bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,8 +40,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Run release.py script tests
-        run: ./check_releasepy.bash
       - name: Download and setup job dsl jar
         if: steps.dsl_check.outputs.run_job == 'true'
         run: ./jenkins-scripts/dsl/tools/setup_local_generation.bash


### PR DESCRIPTION
Split the releasepy checks to its own file and trigger it only on changes to that file since it does not use any other file or resource in the repo.