### PR TITLE
Clean up DSL CI by using GitHub actions paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,9 @@
-name: CI
+name: DSL logs and checks
 
-# base_ref / head_reaf are only available in PRs
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'jenkins-scripts/dsl/**'
 
 jobs:
   dsl_ci:
@@ -12,39 +14,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Idenfify files changed in this PR
-        id: files
-        run: |
-            git fetch origin ${{ github.ref }}
-            git diff --name-only origin/${{ github.base_ref }}...FETCH_HEAD
-            echo "changed-files=$(git diff --name-only origin/${{ github.base_ref }}...FETCH_HEAD| tr '\n' ' ')"  >> $GITHUB_OUTPUT
-      - name: Run testing on changed config files
-        id: dsl_check
-        run: |
-          for changed_file in ${{ steps.files.outputs.changed-files }}; do
-            if [[ ${changed_file} != ${changed_file/dsl\/*} ]]; then
-              echo "+ Detected at leat one config file: ${changed_file}."
-              echo "run_job=true" >> $GITHUB_OUTPUT
-              break
-            else
-              echo "run_job=false" >> $GITHUB_OUTPUT
-            fi
-          done
       - name: Checkout
-        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/setup-java@v3
-        if: steps.dsl_check.outputs.run_job == 'true'
         with:
           distribution: 'temurin'
           java-version: '11'
       - name: Download and setup job dsl jar
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: ./jenkins-scripts/dsl/tools/setup_local_generation.bash
       - name: Generate all DSL files
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           # simulate token for brew_release
           sudo mkdir -p /var/lib/jenkins/ && sudo touch /var/lib/jenkins/remote_token
@@ -52,12 +32,10 @@ jobs:
           cd jenkins-scripts/dsl
           WRITE_JOB_LOG=1 java -jar tools/jobdsl.jar *.dsl
       - name: Checks for DSL Code
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           cd jenkins-scripts/dsl
           ./dsl_checks.bash
       - name: Export XML generated configuration for diff
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           cd jenkins-scripts/dsl
           # export files for later diff
@@ -67,7 +45,6 @@ jobs:
           mv *.xml /tmp/pr_xml_configuration/
           mv *.txt /tmp/pr_log_generated/
       - name: Generate master DSL files
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           git clean -f -e jobdsl.jar
           git checkout master
@@ -79,26 +56,22 @@ jobs:
           mv *.xml /tmp/current_xml_configuration/
           mv *.txt /tmp/current_log_generated/ || true
       - name: Generating diffs
-        if: steps.dsl_check.outputs.run_job == 'true'
         run: |
           # somehow the Jenkins views changed the portlet_ id on every run.
           diff -qr -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration | sort > /tmp/xml_config_files_changed.diff || true
           diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration > /tmp/xml_config_content_changed.diff || true
           diff -ur /tmp/current_log_generated /tmp/pr_log_generated > /tmp/log_content_changed.diff || true
       - name: Archive files changes
-        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: xml_config_files_changed
           path: /tmp/xml_config_files_changed.diff
       - name: Archive content changes
-        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: xml_config_content_changed
           path: /tmp/xml_config_content_changed.diff
       - name: Archive log changes
-        if: steps.dsl_check.outputs.run_job == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: log_content_changed


### PR DESCRIPTION
Modify the GitHub actions workflow to rely on `paths:` for triggering the CI instead of having a custom logic of detecting changes on dsl directory.