### PR TITLE
Do not exclude gz-common from focal ci_configs

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -466,7 +466,6 @@ ci_configs:
         - gz-cmake
         - gz-tools
         # These have a Jammy counterpart in Harmonic
-        - gz-common
         - gz-math
         - gz-plugin
         - gz-utils

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -465,10 +465,6 @@ ci_configs:
       abichecker:
         - gz-cmake
         - gz-tools
-        # These have a Jammy counterpart in Harmonic
-        - gz-math
-        - gz-plugin
-        - gz-utils
     pre_setup_script_hook:
       gz-physics:
         - "export MAKE_JOBS=1"


### PR DESCRIPTION
ign-common4 (Fortress) is configured to run on `focal`, but we were excluding the abichecker from the `focal` ci_configs.

https://build.osrfoundation.org/job/gz_common-abichecker-any_to_any-ubuntu-jammy-amd64/ only triggers on `gz-common5`.