### PR TITLE
Make Citadel to use custom ciconfig to exclude gz-sim/gz-launch

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -96,7 +96,7 @@ collections:
       configs:
         - focal
         - brew
-        - win
+        - win_citadel
     packaging:
       configs:
         - focal
@@ -532,7 +532,6 @@ ci_configs:
     requirements:
     exclude:
       all:
-        - gz-citadel
         - gz-fortress
         - gz-garden
         - gz-harmonic
@@ -545,6 +544,33 @@ ci_configs:
       - gz-sim
       - gz-gui
       - gz-launch
+      - gz-math
+      - gz-msgs
+      - gz-physics
+      - gz-rendering
+      - gz-sensors
+      - gz-tools
+      - gz-transport
+      - gz-utils
+      - sdformat
+  # No gz-sim and gz-launch on Citadel
+  - name: win_citadel
+    system:
+      so: windows
+      distribution: windows
+      version: "10"
+      arch: amd64
+    requirements:
+    exclude:
+      all:
+        - gz-citadel
+        - gz-sim
+        - gz-launch
+    cmake_warnings_disabled:
+      - gz-cmake
+      - gz-common
+      - gz-fuel-tools
+      - gz-gui
       - gz-math
       - gz-msgs
       - gz-physics

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -95,7 +95,6 @@ branch_ci citadel gz_gui-ci-ign-gui3-homebrew-amd64
 branch_ci citadel gz_gui-ign-gui3-win
 branch_ci citadel gz_launch-ci-ign-launch2-focal-amd64
 branch_ci citadel gz_launch-ci-ign-launch2-homebrew-amd64
-branch_ci citadel gz_launch-ign-launch2-win
 branch_ci citadel gz_math-ci-ign-math6-focal-amd64
 branch_ci citadel gz_math-ci-ign-math6-homebrew-amd64
 branch_ci citadel gz_math-ign-math6-win
@@ -116,7 +115,6 @@ branch_ci citadel gz_sensors-ci-ign-sensors3-homebrew-amd64
 branch_ci citadel gz_sensors-ign-sensors3-win
 branch_ci citadel gz_sim-ci-ign-gazebo3-focal-amd64
 branch_ci citadel gz_sim-ci-ign-gazebo3-homebrew-amd64
-branch_ci citadel gz_sim-ign-gazebo3-win
 branch_ci citadel gz_tools-ci-ign-tools1-focal-amd64
 branch_ci citadel gz_tools-ci-ign-tools1-homebrew-amd64
 branch_ci citadel gz_tools-ign-tools1-win


### PR DESCRIPTION
Need to exclude gz-sim and gz-launch from Citadel. To avoid adding harcoded values in the DSL, the declarative approach is to create a new ciconfig for Citadel, just by duplicating the win configuration and make the exclusions for the libraries.