### PR TITLE
Use custom Garden/Focal ciconfig to avoid duplicate abi-checkers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,16 @@ jobs:
           WRITE_JOB_LOG=1 java -jar tools/jobdsl.jar *.dsl
           find logs/* -exec sort {} -o {} \;
           popd
+      - name: Checks for DSL Code
+        run: |
+          cd jenkins-scripts/dsl
+          ./dsl_checks.bash
+      - name: Export XML generated configuration for diff
+        run: |
+          cd jenkins-scripts/dsl
+          # export files for later diff
+          mkdir /tmp/pr_xml_configuration
+          mv *.xml /tmp/pr_xml_configuration/
       - name: Update and commit logs generated
         uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d  # v5 sha
         with:

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -256,7 +256,7 @@ collections:
           current_branch: main
     ci:
       configs:
-        - focal
+        - focal_garden
         - brew
         - win
     packaging:
@@ -459,10 +459,37 @@ ci_configs:
       all:
         - gz-citadel
         - gz-fortress
+      abichecker:
+        - gz-cmake
+        - gz-tools
+    pre_setup_script_hook:
+      gz-physics:
+        - "export MAKE_JOBS=1"
+    tests_disabled:
+  - name: focal_garden
+    system:
+      so: linux
+      distribution: ubuntu
+      version: focal
+      arch: amd64
+    requirements:
+      large_memory:
+        - gz-physics
+      nvidia_gpu:
+        - gz-sim
+        - gz-gui
+        - gz-rendering
+        - gz-sensors
+    exclude:
+      all:
         - gz-garden
       abichecker:
         - gz-cmake
         - gz-tools
+        - gz-common
+        - gz-math
+        - gz-plugin
+        - gz-utils
     pre_setup_script_hook:
       gz-physics:
         - "export MAKE_JOBS=1"


### PR DESCRIPTION
Fix #1095 

Declaring a separate Garden/Focal ciconfig allow us to:
  - Keep current abi-checkers on Focal (affecting Citadel and Fortress) to be generated normally
  - Skip the Focal abichecker jobs for the software units present on Garden and Harmonic (Jammy): common, math, plugin, utils. 