### PR TITLE
ros_gz wrappers: include ROS package in conflicts when adding a second conflict

### DIFF
--- a/bloom/ros_gz/rename-ros_gz-pkgs.bash
+++ b/bloom/ros_gz/rename-ros_gz-pkgs.bash
@@ -48,7 +48,7 @@ for pkg in ${PKGS}; do
     # Include conflict with initial package name in ROS
     sed -i -e '/^Depends/a\Conflicts: \@(Package)' debian/control.em
     if [[ -n ${GZ_RELEASE_TO_CONFLICT} ]]; then
-      sed -i -e "s/Conflicts: @(Package)/Conflicts: @(Package.replace('-gz','-gz${GZ_RELEASE_TO_CONFLICT}'))/" debian/control.em
+      sed -i -e "s/Conflicts: @(Package)/Conflicts: @(Package), @(Package.replace('-gz','-gz${GZ_RELEASE_TO_CONFLICT}'))/" debian/control.em
     fi
     git commit debian/control.em -m "Set up a conflict with official ROS packages"
     git push origin "debian/$distro/$pkg"


### PR DESCRIPTION
When creating the ros_gz unofficial packages, if `GZ_RELEASE_TO_CONFLICT` is set the conflict on the original ROS package is lost. For example: releasing Harmonic packages for Humble that conflict with the unofficial Garden packages make the packages not to conflict with `ros-humble-ros-gz`.

The PR preserves the original conflict and add a new one when using `GZ_RELEASE_TO_CONFLICT`