### PR TITLE
homebrew_bottle_creation: fix ruby syntax

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -113,7 +113,7 @@ for j in $(ls *.bottle.json); do
   SRC_BOTTLE=$(brew ruby -e \
     "puts JSON.load(IO.read(\"${j}\")).values[0]['bottle']['tags'].values[0]['local_filename']")
   DEST_BOTTLE=$(brew ruby -e \
-    "puts URI.decode(JSON.load(IO.read(\"${j}\")).values[0]['bottle']['tags'].values[0]['filename'])")
+    "puts URI::DEFAULT_PARSER.unescape(JSON.load(IO.read(\"${j}\")).values[0]['bottle']['tags'].values[0]['filename'])")
   mv ${SRC_BOTTLE} ${DEST_BOTTLE}
 done
 mv *.bottle*.tar.gz ${PKG_DIR}


### PR DESCRIPTION
`URI.decode` has been obsolete for a while in Ruby, and with Homebrew's recent change to use Ruby 3.1 across the board, this call needs to be changed in our bottle creation script, which now causes bottle builds to fail. `URI::DEFAULT_PARSER.escape` appears to be equivalent for our purposes.

## Example failure

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder%2Flabel%3Dosx_monterey&build=1354)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_monterey/1354/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/1354/label=osx_monterey/console

~~~
++ brew ruby -e 'puts URI.decode(JSON.load(IO.read("gz-physics7--7.0.0_2.monterey.bottle.json")).values[0]['\''bottle'\'']['\''tags'\''].values[0]['\''filename'\''])'
-e:1:in `<main>': undefined method `decode' for URI:Module (NoMethodError)
~~~

## Test build with this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder&build=1356)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/1356/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/1356/