### PR TITLE
Removes apt-get installed packages from Dockerfile

### DIFF
--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -144,7 +144,7 @@ output_dir=$WORKSPACE/output
 work_dir=$WORKSPACE/work
 
 # TODO: Check for docker package
-NEEDED_HOST_PACKAGES="git python-setuptools python-psutil qemu-user-static gpgv squid-deb-proxy bc"
+NEEDED_HOST_PACKAGES="git python-setuptools python-psutil gpgv squid-deb-proxy bc"
 # python-argparse is integrated in libpython2.7-stdlib since raring
 # Check for precise in the HOST system (not valid DISTRO variable)
 if [[ $(lsb_release -sr | cut -c 1-5) == '12.04' ]]; then

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -143,8 +143,6 @@ fi
 output_dir=$WORKSPACE/output
 work_dir=$WORKSPACE/work
 
-# TODO: Check for docker package
-NEEDED_HOST_PACKAGES="git python-setuptools python-psutil gpgv squid-deb-proxy bc"
 # python-argparse is integrated in libpython2.7-stdlib since raring
 # Check for precise in the HOST system (not valid DISTRO variable)
 if [[ $(lsb_release -sr | cut -c 1-5) == '12.04' ]]; then


### PR DESCRIPTION
### Description
There were some issues with unattended upgrades making builds fail ([See](https://build.osrfoundation.org/job/gz_sim-abichecker-any_to_any-ubuntu-jammy-amd64/120)). After some research it seems this is due to release-tools installing packages that are already provisioned when the image for the agents is built. This PR removes all dependencies that are installed through this mechanism. 