### PR TITLE
Change nightly labeler to run every 20min all day

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -13,10 +13,12 @@ class Globals
    static CRON_EVERY_THREE_DAYS = 'H H * * H/3'
    static CRON_HOURLY = 'H * * * *'
    static CRON_ON_WEEKEND = 'H H * * 6-7'
-   // Run nightly scheduler during the nightly creation to be sure
-   // that any possible node killed is replaced. Starting -15min
-   // before CRON_NIGHTLY_NODES and evert 20min for 3 hours
-   static CRON_NIGHTLY_NODES = '*/20 9-11 * * *'
+   // Run nightly scheduler every 20 minutes being sure to
+   // run it at 9 just before the nightly creation.
+   static CRON_NIGHTLY_NODES = [
+    '*/20 9-23 * * *',
+    '*/20 0-8 * * *']
+
    // Start the nightly generation 10 minutes after the nigthly node
    // initial generation
    static CRON_START_NIGHTLY = '10 9 * * *'

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -106,7 +106,9 @@ nightly_labeler.with
   label Globals.nontest_label("master")
 
   triggers {
-    cron(Globals.CRON_NIGHTLY_NODES)
+    Globals.CRON_NIGHTLY_NODES.each { cron_entry ->
+      cron(cron_entry)
+    }
   }
 
   steps


### PR DESCRIPTION
We want to be sure that there is a nightly node labeled always, not just during the nightly creation or generation. The PR uses a cron expression that tries to be sure that we still run it at 9:00, 10 minutes before the nightly creation but also add the rest of the day.
