### PR TITLE
brew CI: temporarily disable pip install

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -84,12 +84,14 @@ if [[ "${RERUN_FAILED_TESTS}" -gt 0 ]]; then
 fi
 
 if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
-  brew install python
+  brew install python3
   PIP=pip3
   if ! which ${PIP}; then
     PIP=/usr/local/opt/python/bin/pip3
   fi
-  ${PIP} install ${PIP_PACKAGES_NEEDED}
+  echo Skipping ${PIP} install ${PIP_PACKAGES_NEEDED}
+  echo since it is currently broken
+  # ${PIP} install ${PIP_PACKAGES_NEEDED}
 fi
 
 if [[ -z "${DISABLE_CCACHE}" ]]; then


### PR DESCRIPTION
This is currently broken, so disable for now to un-break CI.

Testing with `ign-math6`:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-ign-math6-homebrew-amd64&build=24)](https://build.osrfoundation.org/job/gz_math-ci-ign-math6-homebrew-amd64/24/) https://build.osrfoundation.org/job/gz_math-ci-ign-math6-homebrew-amd64/24/