### PR TITLE
brew CI: pip install with --break-system-packages

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -89,9 +89,8 @@ if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   if ! which ${PIP}; then
     PIP=/usr/local/opt/python/bin/pip3
   fi
-  echo Skipping ${PIP} install ${PIP_PACKAGES_NEEDED}
-  echo since it is currently broken
-  # ${PIP} install ${PIP_PACKAGES_NEEDED}
+  # TODO use a python3 venv instead.
+  ${PIP} install --break-system-packages ${PIP_PACKAGES_NEEDED}
 fi
 
 if [[ -z "${DISABLE_CCACHE}" ]]; then


### PR DESCRIPTION
Try this until we switch to a venv.

This should allow `pytest` to be installed, which provides better feedback to jenkins about python test results.

Testing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-ign-math6-homebrew-amd64&build=25)](https://build.osrfoundation.org/job/gz_math-ci-ign-math6-homebrew-amd64/25/) https://build.osrfoundation.org/job/gz_math-ci-ign-math6-homebrew-amd64/25/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdf14-homebrew-amd64&build=25)](https://build.osrfoundation.org/job/sdformat-ci-sdf14-homebrew-amd64/25/) https://build.osrfoundation.org/job/sdformat-ci-sdf14-homebrew-amd64/25/