### PR TITLE
Fix cron DSL entries for the _nightly_node_labeler

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -15,9 +15,7 @@ class Globals
    static CRON_ON_WEEKEND = 'H H * * 6-7'
    // Run nightly scheduler every 20 minutes being sure to
    // run it at 9 just before the nightly creation.
-   static CRON_NIGHTLY_NODES = [
-    '*/20 9-23 * * *',
-    '*/20 0-8 * * *']
+   static CRON_NIGHTLY_NODES = '*/20 9-23 * * * \n20 0-8 * * *'
 
    // Start the nightly generation 10 minutes after the nigthly node
    // initial generation

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -106,9 +106,7 @@ nightly_labeler.with
   label Globals.nontest_label("master")
 
   triggers {
-    Globals.CRON_NIGHTLY_NODES.each { cron_entry ->
-      cron(cron_entry)
-    }
+    cron(Globals.CRON_NIGHTLY_NODES)
   }
 
   steps


### PR DESCRIPTION
Although the XML generated by using several cron invocations seemed to be fine the reality is that the generated code did not work and the last entry was overwriting the first one. After modifying the config manually the XML seems to be using several lines for different entries. The PR modifies the code to use this approach.

Patching #1113 