### PR TITLE
Fix -source jobs to deal with packages with underscores (i.e gz-fuel_tools)

### DIFF
--- a/jenkins-scripts/docker/gz-source-generation.bash
+++ b/jenkins-scripts/docker/gz-source-generation.bash
@@ -29,7 +29,7 @@ cmake .. -DPACKAGE_SOURCE_ONLY:BOOL=ON
 make package_source
 
 rm -fr \$PKG_DIR && mkdir \$PKG_DIR
-find \${BUILD_DIR} -maxdepth 1 -name '*${VERSION}.tar.*' -exec mv {} \${PKG_DIR} \\;
+find \${BUILD_DIR} -maxdepth 1 -name '*-${VERSION}.tar.*' -exec mv {} \${PKG_DIR} \\;
 
 if [ $(ls 2>/dev/null -Ubad1 -- "\${PKG_DIR}" | wc -l) -gt 1 ]; then
   echo "Found more than one file inside pkgs directory:"

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -109,7 +109,7 @@ class OSRFSourceCreation
             # is to just search for the VERSION (not so safety but should work)
             tarball=\$(find \${WORKSPACE}/${pkg_sources_dir} \
                          -type f \
-                         -name .*-\${VERSION}.tar.* \
+                         -name *-\${VERSION}.tar.* \
                          -printf "%f\\n")
             if [[ -z \${tarball} ]] || [[ \$(wc -w <<< \${tarball}) != 1 ]]; then
               echo "Tarball name extraction returned \${tarball} which is not a one word string"

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -104,8 +104,17 @@ class OSRFSourceCreation
                        -name ${canonical_package_name}-\${VERSION}.tar.* \
                        -printf "%f\\n")
           if [[ -z \${tarball} ]] || [[ \$(wc -w <<< \${tarball}) != 1 ]]; then
-            echo "Tarball name extraction returned \${tarball} which is not a one word string"
-            exit 1
+            # There is one use case that can be valid but failed to find canonical_package_name
+            # which are package using _ (underscores) in their name like gz-fuel_tools. Workaround
+            # is to just search for the VERSION (not so safety but should work)
+            tarball=\$(find \${WORKSPACE}/${pkg_sources_dir} \
+                         -type f \
+                         -name .*-\${VERSION}.tar.* \
+                         -printf "%f\\n")
+            if [[ -z \${tarball} ]] || [[ \$(wc -w <<< \${tarball}) != 1 ]]; then
+              echo "Tarball name extraction returned \${tarball} which is not a one word string"
+              exit 1
+            fi
           fi
 
           echo "S3_FILES_TO_UPLOAD=\${tarball}" >> ${properties_file}


### PR DESCRIPTION
The `PACKAGE` parameter in -source jobs is being populated by the args of `release.py` using always hyphens even if the `project` name in CMakeLists.txt of the package (and thus the tarball generated) is using underscores. Some other parts of the infrastructure also applies this same naming.

This is making the gz-fuel-tools -source package to fail since the -source jobs check for existence of `{canonical_package_name}-\${VERSION}.tar.*` tarball. This PR relax that restriction and make a second pass to just `*-\${VERSION}.tar.*` to grab this exception.

Tested: 
 * _test_gz_source [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_gz_source&build=90)](https://build.osrfoundation.org/job/_test_gz_source/90/)
 * Cloned _test_gz-fuel-tools9-source [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_gz-fuel-tools9-source&build=4)](https://build.osrfoundation.org/job/_test_gz-fuel-tools9-source/4/)