### PR TITLE
 Avoid duplicate abichecker in Fortress/Harmonic 

### DIFF
--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -50,16 +50,14 @@ if [[ -n ${non_github_orgs} ]]; then
   exit 1
 fi
 
-# re-enable after https://github.com/gazebo-tooling/release-tools/issues/1095
-
 # Filter out the previous auto jobs
-# filtered_dir=$(mktemp -d)
-# cp -- *-abichecker-*.xml "${filtered_dir}"
-# rm -f "${filtered_dir}"/*-ubuntu_auto*.xml
-# repeated=$(grep '\<branch>' "${filtered_dir}"/*-abichecker-*.xml | awk '{ print $2 }' | sort | uniq -d)
-# if [[ -n ${repeated} ]]; then
-#   echo "Found a duplicate in an abichecker branch:"
-#   echo "${repeated}"
-#   echo "please exclude one of the versions in the yaml file to reduce the server workload"
-#   exit 1
-# fi
+filtered_dir=$(mktemp -d)
+cp -- *-abichecker-*.xml "${filtered_dir}"
+rm -f "${filtered_dir}"/*-ubuntu_auto*.xml
+repeated=$(grep '\<branch>' "${filtered_dir}"/*-abichecker-*.xml | awk '{ print $2 }' | sort | uniq -d)
+if [[ -n ${repeated} ]]; then
+  echo "Found a duplicate in an abichecker branch:"
+  echo "${repeated}"
+  echo "please exclude one of the versions in the yaml file to reduce the server workload"
+  exit 1
+fi

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -256,7 +256,7 @@ collections:
           current_branch: main
     ci:
       configs:
-        - focal
+        - focal_exclude_harmonic_abi_dups
         - brew
         - win
     packaging:
@@ -345,7 +345,7 @@ collections:
         - jammy
       linux:
         ignore_major_version:
-          - gz-harmonic     
+          - gz-harmonic
   - name: 'ionic'
     libs:
       - name: gz-cmake
@@ -463,6 +463,43 @@ ci_configs:
       abichecker:
         - gz-cmake
         - gz-tools
+    pre_setup_script_hook:
+      gz-physics:
+        - "export MAKE_JOBS=1"
+    tests_disabled:
+    ci_categories_enabled:
+      - pr
+      - pr_abichecker
+      - stable_branches
+      - stable_branches_asan
+  - name: focal_exclude_harmonic_abi_dups
+    system:
+      so: linux
+      distribution: ubuntu
+      version: focal
+      arch: amd64
+    requirements:
+      large_memory:
+        - gz-physics
+      nvidia_gpu:
+        - gz-sim
+        - gz-gui
+        - gz-rendering
+        - gz-sensors
+    exclude:
+      all:
+        - gz-citadel
+        - gz-fortress
+        - gz-garden
+      abichecker:
+        - gz-cmake
+        - gz-tools
+        # Exclude the abichecker that are duplicate with Harmonic
+        # The ones on Harmonic run on jammy
+        - gz-common
+        - gz-math
+        - gz-plugin
+        - gz-utils
     pre_setup_script_hook:
       gz-physics:
         - "export MAKE_JOBS=1"


### PR DESCRIPTION
Fixes: #1095

The fact of having two abichecker in the PRs can be workaround by defining a new ci_configuration (`focal_exclude_harmonic_abi_dups`) which clones focal for Garden but exclude the libraries also present in Harmonic from having an abichecker.

The PR also reverts : "Disable DSL check for duplicate abicheckers (#1099)" so the dsl_check is in place again.
