### PR TITLE
brew: pip install protobuf in CI

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -78,6 +78,9 @@ brew install $(brew deps --1 --include-build ${PROJECT_FORMULA})
 # pytest is needed to run python tests with junit xml output
 PIP_PACKAGES_NEEDED="${PIP_PACKAGES_NEEDED} pytest"
 
+# Add protobuf since the homebrew protobuf bottle dropped support for python bindings
+PIP_PACKAGES_NEEDED="${PIP_PACKAGES_NEEDED} protobuf"
+
 if [[ "${RERUN_FAILED_TESTS}" -gt 0 ]]; then
   # Install lxml for flaky_junit_merge.py
   PIP_PACKAGES_NEEDED="${PIP_PACKAGES_NEEDED} lxml"


### PR DESCRIPTION
gz-transport Python tests are failing because Python bindings were removed in the latest update of protobuf homebrew bottle. It seems like the [recommended](https://github.com/protocolbuffers/protobuf/tree/main/python#installation) way to install the Python bindings is through `pip`. Since this will be needed for anything above gz-transport, I thought we should just add it here to `PIP_PACKAGES_NEEDED` as a global dependency.