### PR TITLE
Update and fix gzdev jobs in Jenkins

### DIFF
--- a/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
+++ b/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
@@ -14,11 +14,8 @@ curl -s -L https://nvidia.github.io/nvidia-docker/\$distribution/nvidia-docker.l
   sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 sudo apt-get update
 sudo apt-get install -y nvidia-docker2
-# systemctl daemon-reload
-# systemctl restart docker
+sudo docker info
 echo '# END SECTION'
 """
-
-DOCKER2_CMD="sudo docker run --privileged -e DISPLAY=unix:0 -v /sys:/sys:ro -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/.X11-unix:/tmp/.X11-unix:rw --runtime=nvidia -e DOCKER_FIX= -v /dev/log:/dev/log:ro -v /run/log:/run/log:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro --device /dev/snd --tty --rm"
 
 DEPENDENCY_PKGS="${DEPENDENCY_PKGS} curl software-properties-common"

--- a/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
+++ b/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
@@ -1,18 +1,3 @@
-INSTALL_NVIDIA_DOCKER1="""
-echo '# BEGIN SECTION: install docker (in docker)'
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository -y \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
-sudo apt-get update
-sudo apt-get install -y docker-ce
-echo '# END SECTION'
-
-echo '# BEGIN SECTION: install nvidia-docker1 (in docker)'
-sudo apt-get install -y wget nvidia-340 nvidia-modprobe
-wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb
-sudo dpkg -i /tmp/nvidia-docker*.deb && rm /tmp/nvidia-docker*.deb
-echo '# END SECTION'
-"""
-
 INSTALL_NVIDIA_DOCKER2="""
 echo '# BEGIN SECTION: install docker (in docker)'
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -

--- a/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
+++ b/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
@@ -1,7 +1,7 @@
 INSTALL_NVIDIA_DOCKER1="""
 echo '# BEGIN SECTION: install docker (in docker)'
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
+sudo add-apt-repository -y \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
 sudo apt-get update
 sudo apt-get install -y docker-ce
 echo '# END SECTION'
@@ -16,7 +16,7 @@ echo '# END SECTION'
 INSTALL_NVIDIA_DOCKER2="""
 echo '# BEGIN SECTION: install docker (in docker)'
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
+sudo add-apt-repository -y \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
 sudo apt-get update
 # sudo apt-get install -y docker-ce
 echo '# END SECTION'

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -413,6 +413,13 @@ DELIM_DISPLAY
   fi
 fi
 
+if ${USE_DOCKER_IN_DOCKER}; then
+cat >> Dockerfile << DELIM_WORKAROUND_DOCKER_IN_DOCKER_HOOK
+# Avoid ERROR: invoke-rc.d: policy-rc.d denied execution of start.
+RUN sed -i "s/^exit 101$/exit 0/" /usr/sbin/policy-rc.d
+DELIM_WORKAROUND_DOCKER_IN_DOCKER_HOOK
+fi
+
 if [ `expr length "${DOCKER_POSTINSTALL_HOOK}"` -gt 1 ]; then
 cat >> Dockerfile << DELIM_WORKAROUND_POST_HOOK
 RUN ${DOCKER_POSTINSTALL_HOOK}

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -475,11 +475,16 @@ RUN adduser --uid \$USERID --gid \$GID --gecos "Developer" --disabled-password \
 RUN adduser \$USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R \$USER:\$USER /home/\$USER
+# Needed if USE_DOCKER_IN_DOCKER is active. Harmless to be here
+RUN groupadd docker
+RUN gpasswd -a \$USER docker
+RUN newgrp docker
 
 # permit access to USER variable inside docker
 ENV USER \$USER
 USER \$USER
 # Must use sudo where necessary from this point on
+
 DELIM_DOCKER_USER
 
 if [[ -n ${SOFTWARE_DIR} ]]; then

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -13,9 +13,6 @@ set -ex
 export MAKE_JOBS=${MAKE_JOBS}
 export DISPLAY=${DISPLAY}
 
-# workaround problems for docker in docker sin policy-rc.d
-printf '#!/bin/sh\nexit 0' > /usr/sbin/policy-rc.d
-
 ${INSTALL_NVIDIA_DOCKER2}
 
 echo '# BEGIN SECTION: install pip requirements'

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -24,9 +24,18 @@ echo '# BEGIN SECTION: smoke tests for ign-docker-env'
 pip3 install wheel
 pip3 install rocker
 pip3 install git+https://github.com/adlarkin/ign-rocker.git
-./gzdev.py ign-docker-env dome --linux-distro ubuntu:bionic
-echo '# END SECTION'
 
+TEST_TIMEOUT=300
+TEST_START=\`date +%s\`
+timeout --preserve-status \$TEST_TIMEOUT ./gzdev.py ign-docker-env dome --linux-distro ubuntu:bionic
+TEST_END=\`date +%s\`
+DIFF=\$(expr \$TEST_END - \$TEST_START)
+
+if [ \$DIFF -lt \$TEST_TIMEOUT ]; then
+   echo 'The test took less than \$TEST_TIMEOUT. Something bad happened'
+   exit 1
+fi
+echo '# END SECTION'
 DELIM
 
 export USE_DOCKER_IN_DOCKER=true

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -24,7 +24,7 @@ echo '# BEGIN SECTION: smoke tests for ign-docker-env'
 pip3 install wheel
 pip3 install rocker
 pip3 install git+https://github.com/adlarkin/ign-rocker.git
-./gzdev ign-docker-env dome --linux-distro ubuntu:bionic
+./gzdev.py ign-docker-env dome --linux-distro ubuntu:bionic
 echo '# END SECTION'
 
 DELIM

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -37,6 +37,7 @@ export DEPENDENCY_PKGS="python3-pip \
                  ca-certificates \
                  curl \
                  software-properties-common \
+                 python3-rocker \
                  psmisc" # killall
 
 . "${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash"

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -27,6 +27,8 @@ pip3 install git+https://github.com/adlarkin/ign-rocker.git
 ./gzdev ign-docker-env dome --linux-distro ubuntu:bionic
 echo '# END SECTION'
 
+DELIM
+
 export USE_DOCKER_IN_DOCKER=true
 export OSRF_REPOS_TO_USE="stable"
 export DEPENDENCY_PKGS="python3-pip \
@@ -35,8 +37,7 @@ export DEPENDENCY_PKGS="python3-pip \
                  ca-certificates \
                  curl \
                  software-properties-common \
-		 psmisc" # killall
-DELIM
+                 psmisc" # killall
 
 . "${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash"
 . "${SCRIPT_DIR}/lib/docker_run.bash"

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -41,6 +41,7 @@ DELIM
 export USE_DOCKER_IN_DOCKER=true
 export OSRF_REPOS_TO_USE="stable"
 export USE_ROS_REPO=true
+export ROS2=true
 export DEPENDENCY_PKGS="python3-pip \
                  bash \
                  apt-transport-https \

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -20,32 +20,12 @@ cd ${WORKSPACE}/gzdev
 pip3 install -r requirements.txt
 echo '# END SECTION'
 
-echo '# BEGIN SECTION: run gzdev for gazebo8 with nvidia'
-cd ${WORKSPACE}/gzdev
-./gzdev.py spawn --gzv=8 --nvidia
+echo '# BEGIN SECTION: smoke tests for ign-docker-env'
+pip3 install wheel
+pip3 install rocker
+pip3 install git+https://github.com/adlarkin/ign-rocker.git
+./gzdev ign-docker-env dome --linux-distro ubuntu:bionic
 echo '# END SECTION'
-
-echo '# BEGIN SECTION: Disply log file.'
-cat ./gz8.log
-echo '# END SECTION'
-
-echo '# BEGIN SECTION: check that gazebo is running'
-gazebo_detection=false
-seconds_waiting=0
-cat gz8.log | grep "Connected to gazebo master" && gazebo_detection=true
-while (! \$gazebo_detection); do
-   sleep 1
-   docker top gz8 | grep gazebo && gazebo_detection=true
-   docker top gz8 | grep gzserver && gazebo_detection=true
-   seconds_waiting=\$((seconds_waiting+1))
-   [ \$seconds_waiting -gt 30 ] && break
-done
-# clean up gazebo instances
-docker rm -f gz8 || true
-killall -9 gazebo gzserver gzclient || true
-! \${gazebo_detection} && exit 1
-echo '# END SECTION'
-DELIM
 
 export USE_DOCKER_IN_DOCKER=true
 export OSRF_REPOS_TO_USE="stable"
@@ -56,6 +36,7 @@ export DEPENDENCY_PKGS="python3-pip \
                  curl \
                  software-properties-common \
 		 psmisc" # killall
+DELIM
 
 . "${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash"
 . "${SCRIPT_DIR}/lib/docker_run.bash"

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -40,6 +40,7 @@ DELIM
 
 export USE_DOCKER_IN_DOCKER=true
 export OSRF_REPOS_TO_USE="stable"
+export USE_ROS_REPO=true
 export DEPENDENCY_PKGS="python3-pip \
                  bash \
                  apt-transport-https \

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -13,7 +13,7 @@ set -ex
 export MAKE_JOBS=${MAKE_JOBS}
 export DISPLAY=${DISPLAY}
 
-${INSTALL_NVIDIA_DOCKER1}
+${INSTALL_NVIDIA_DOCKER2}
 
 echo '# BEGIN SECTION: install pip requirements'
 cd ${WORKSPACE}/gzdev

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -17,22 +17,29 @@ ${INSTALL_NVIDIA_DOCKER2}
 
 echo '# BEGIN SECTION: install pip requirements'
 cd ${WORKSPACE}/gzdev
-pip3 install -r requirements.txt
+# pip3 install -r requirements.txt
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: smoke tests for ign-docker-env'
-pip3 install git+https://github.com/adlarkin/ign-rocker.git
+sudo pip3 install git+https://github.com/adlarkin/ign-rocker.git
 
-TEST_TIMEOUT=300
-TEST_START=\`date +%s\`
-timeout --preserve-status \$TEST_TIMEOUT ./gzdev.py ign-docker-env dome --linux-distro ubuntu:bionic
-TEST_END=\`date +%s\`
-DIFF=\$(expr \$TEST_END - \$TEST_START)
+# TODO: rocker can not play well docker-in-docker installations
+# out of the box. Needs more work.
 
-if [ \$DIFF -lt \$TEST_TIMEOUT ]; then
-   echo 'The test took less than \$TEST_TIMEOUT. Something bad happened'
-   exit 1
-fi
+# xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 &
+# export display=:1.0
+# export mesa_gl_version_override=3.3
+
+# test_timeout=300
+# test_start=\`date +%s\`
+# sudo bash -c "timeout --preserve-status \$test_timeout ./gzdev.py ign-docker-env dome --linux-distro ubuntu:bionic"
+# test_end=\`date +%s\`
+# diff=\$(expr \$test_end - \$test_start)
+
+# if [ \$diff -lt \$test_timeout ]; then
+#    echo 'the test took less than \$test_timeout. something bad happened'
+#    exit 1
+# fi
 echo '# END SECTION'
 DELIM
 
@@ -47,7 +54,8 @@ export DEPENDENCY_PKGS="python3-pip \
                  curl \
                  software-properties-common \
                  python3-rocker \
-                 psmisc" # killall
+                 psmisc \
+                 xvfb"
 
 . "${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash"
 . "${SCRIPT_DIR}/lib/docker_run.bash"

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -13,6 +13,9 @@ set -ex
 export MAKE_JOBS=${MAKE_JOBS}
 export DISPLAY=${DISPLAY}
 
+# workaround problems for docker in docker sin policy-rc.d
+printf '#!/bin/sh\nexit 0' > /usr/sbin/policy-rc.d
+
 ${INSTALL_NVIDIA_DOCKER2}
 
 echo '# BEGIN SECTION: install pip requirements'
@@ -21,8 +24,6 @@ pip3 install -r requirements.txt
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: smoke tests for ign-docker-env'
-pip3 install wheel
-pip3 install rocker
 pip3 install git+https://github.com/adlarkin/ign-rocker.git
 
 TEST_TIMEOUT=300

--- a/jenkins-scripts/dsl/gzdev.dsl
+++ b/jenkins-scripts/dsl/gzdev.dsl
@@ -1,7 +1,7 @@
 import _configs_.*
 import javaposse.jobdsl.dsl.Job
 
-def supported_distros = [ 'bionic' ]
+def supported_distros = [ 'jammy' ]
 def supported_arches = [ 'amd64' ]
 
 
@@ -17,6 +17,8 @@ supported_distros.each { distro ->
 
     gzdev_ci_job.with
     {
+    
+      label Globals.nontest_label("large-memory")
 
       scm {
         git {
@@ -54,7 +56,6 @@ supported_distros.each { distro ->
 
     gzdev_any_job.with
     {
-      // use only the most powerful nodes
       label Globals.nontest_label("large-memory")
 
       steps {


### PR DESCRIPTION
Current gzdev jobs are hanging on the buildfarm. The PR updates a good bunch of the CI code in different aspects:

 * Modernize DSL distributions
 * Update and fix the docker-in-docker support until the point of being able to run rocker
 * Remove old docker install code

Still a work in progress is to fix the real CI done on gzdev docker module, it will probably require upstream code changes. I've commented out the support by now. Anyway, the changes in docker-in-docker and the fix for the handing code should worth the pull request.