### PR TITLE
detect_cmake_version.py: use raw regex strings

### DIFF
--- a/jenkins-scripts/tools/detect_cmake_major_version.py
+++ b/jenkins-scripts/tools/detect_cmake_major_version.py
@@ -12,11 +12,11 @@ f = open(fileName, 'r')
 txt = f.read()
 f.close()
 
-old_version = re.search('set *\( *PROJECT_MAJOR_VERSION +(\d+)', txt)
-gazebo_version = re.search('set *\( *GAZEBO_MAJOR_VERSION +(\d+)', txt)
-sdformat_version = re.search('set *\( *SDF_MAJOR_VERSION +(\d+)', txt)
-ign_cmake_version = re.search('project *\( *ignition-[a-z\-_]+(\d+)', txt)
-cmake_project_version = re.search('project *\(.*VERSION +(\d+)', txt)
+old_version = re.search(r'set *\( *PROJECT_MAJOR_VERSION +(\d+)', txt)
+gazebo_version = re.search(r'set *\( *GAZEBO_MAJOR_VERSION +(\d+)', txt)
+sdformat_version = re.search(r'set *\( *SDF_MAJOR_VERSION +(\d+)', txt)
+ign_cmake_version = re.search(r'project *\( *ignition-[a-z\-_]+(\d+)', txt)
+cmake_project_version = re.search(r'project *\(.*VERSION +(\d+)', txt)
 if old_version:
     print(old_version.group(1) )
 elif gazebo_version:


### PR DESCRIPTION
Some of the sequences in the regex patterns are not valid in python string literals (such as `\(`, so use raw strings instead (see [related stack overflow answer](https://stackoverflow.com/a/52335971)). This fixes some `SyntaxWarning`s when running the script with `python@3.12`:

~~~
# without this script:
 ++ python3 detect_cmake_major_version.py /github/workspace/CMakeLists.txt
  /github/workspace/detect_cmake_major_version.py:15: SyntaxWarning: invalid escape sequence '\('
    old_version = re.search('set *\( *PROJECT_MAJOR_VERSION +(\d+)', txt)
  /github/workspace/detect_cmake_major_version.py:16: SyntaxWarning: invalid escape sequence '\('
    gazebo_version = re.search('set *\( *GAZEBO_MAJOR_VERSION +(\d+)', txt)
  /github/workspace/detect_cmake_major_version.py:17: SyntaxWarning: invalid escape sequence '\('
    sdformat_version = re.search('set *\( *SDF_MAJOR_VERSION +(\d+)', txt)
  /github/workspace/detect_cmake_major_version.py:18: SyntaxWarning: invalid escape sequence '\('
    ign_cmake_version = re.search('project *\( *ignition-[a-z\-_]+(\d+)', txt)
  /github/workspace/detect_cmake_major_version.py:19: SyntaxWarning: invalid escape sequence '\('
    cmake_project_version = re.search('project *\(.*VERSION +(\d+)', txt)
  + PACKAGE_MAJOR_VERSION=8
~~~