### PR TITLE
For armhf use docker ubuntu images instead of osrf/ for Jammy onwards

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -116,12 +116,10 @@ case ${ARCH} in
      fi
      ;;
    'armhf')
-     # There is no osrf/jammy_armhf image. Trying new
-     # platform support in docker
-     if [[ ${DISTRO} == 'jammy' ]]; then
-      FROM_VALUE=${LINUX_DISTRO}:${DISTRO}
-     else
+     if [[ ${DISTRO} == 'focal' ]]; then
       FROM_VALUE=osrf/${LINUX_DISTRO}_${ARCH}:${DISTRO}
+     else
+      FROM_VALUE=${LINUX_DISTRO}:${DISTRO}
      fi
      ;;
   'arm64')


### PR DESCRIPTION
Starting from jammy the official docker images to generate armhf can be used through the dockerx platform command. To support jammy, I'm reverting the logic here to restric the use of osrf/ images to focal.

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-cmake3-debbuilder&build=1282)](https://build.osrfoundation.org/job/gz-cmake3-debbuilder/1282/)