### PR TITLE
Use platform in docker call for amrhf builds on Noble

### DIFF
--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -26,7 +26,9 @@ USER=$(whoami)
 # platform support starts on versions greater than 17.07
 PLAFTORM_PARAM=
 DOCKER_CLI_PLUGIN=
-if [[ ${DISTRO} == 'jammy' && ${ARCH} == 'armhf' ]]; then
+if [[ ${LINUX_DISTRO} == 'ubuntu' && \
+      ${DISTRO} != 'focal' && \
+      ${ARCH} == 'armhf' ]]; then
   PLAFTORM_PARAM="--platform=linux/armhf"
   DOCKER_CLI_PLUGIN="buildx"
 fi


### PR DESCRIPTION
Follow up of #1135. Needs platform command for ubuntu different 