### PR TITLE
Rewrite DSL generation to remove the approach based on Indexes

### DIFF
--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -358,7 +358,7 @@ gz_collections_yaml.collections.each { collection ->
         branch_index[lib_name][platform]['pr'].contains(branch_name) ?:
           branch_index[lib_name][platform]['pr'] << [branch: branch_name, ci_name: config_name]
       }
-      if (categories_enabled.contains('pr_abichecker')
+      if (categories_enabled.contains('pr_abichecker'))
       {
         branch_index[lib_name][platform]['pr_abichecker'].contains(branch_name) ?:
           branch_index[lib_name][platform]['pr_abichecker'] << [branch: branch_name, ci_name: config_name]
@@ -436,6 +436,24 @@ branch_index.each { lib_name, distro_configs ->
                                              ENABLE_CPPCHECK,
                                              branch_names)
         generate_label_by_requirements(gz_ci_any_job, lib_name, ci_config.requirements)
+        gz_ci_any_job.with
+        {
+          steps
+          {
+             shell("""\
+                  #!/bin/bash -xe
+
+                  export DISTRO=${distro}
+
+                  ${GLOBAL_SHELL_CMD}
+                  ${extra_cmd}
+
+                  export BUILDING_SOFTWARE_DIRECTORY=${lib_name}
+                  export ARCH=${arch}
+                  /bin/bash -xe ./scripts/jenkins-scripts/docker/${script_name_prefix}-compilation.bash
+                  """.stripIndent())
+          } // end of steps
+        } // end of ci_any_job
       } else if (ci_config.system.so == 'darwin') {
         // --------------------------------------------------------------
         def gz_brew_ci_any_job_name = "${gz_job_name_prefix}-ci-pr_any-homebrew-amd64"

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -69,6 +69,9 @@ boolean are_cmake_warnings_enabled(lib_name, ci_config)
 }
 
 /*
+ * TODO: deprecated, migrate the pkgconf_per_src index to use new branch_index
+ * or generate a new one together with the branch_index
+ *
  * Generate an index that facilitates the operations with the yaml values,
  * avoiding to parse them several times.
  *

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -340,6 +340,8 @@ gz_collections_yaml.collections.each { collection ->
       def lib_name = lib.name
       def branch_name = lib.repo.current_branch
       def gz_job_name_prefix = lib_name.replaceAll('-','_')
+      if (ci_config.exclude.all?.contains(lib_name))
+        return
 
       // Build the branch_index while going through all the libraries to avoid
       // looping twice.
@@ -351,19 +353,15 @@ gz_collections_yaml.collections.each { collection ->
         platform = 'windows'
       }
       branch_index[lib_name][platform] = branch_index[lib_name][platform]?: ['pr':[], 'pr_abichecker':[]]
-      if (! ci_config.exclude.all?.contains(lib_name))
+      if (categories_enabled.contains('pr'))
       {
-        if (categories_enabled.contains('pr'))
-        {
-          branch_index[lib_name][platform]['pr'].contains(branch_name) ?:
-            branch_index[lib_name][platform]['pr'] << [branch: branch_name, ci_name: config_name]
-        }
-        if (categories_enabled.contains('pr_abichecker') &&
-         (! ci_config.exclude.abichecker?.contains(lib_name)))
-        {
-          branch_index[lib_name][platform]['pr_abichecker'].contains(branch_name) ?:
-            branch_index[lib_name][platform]['pr_abichecker'] << [branch: branch_name, ci_name: config_name]
-        }
+        branch_index[lib_name][platform]['pr'].contains(branch_name) ?:
+          branch_index[lib_name][platform]['pr'] << [branch: branch_name, ci_name: config_name]
+      }
+      if (categories_enabled.contains('pr_abichecker')
+      {
+        branch_index[lib_name][platform]['pr_abichecker'].contains(branch_name) ?:
+          branch_index[lib_name][platform]['pr_abichecker'] << [branch: branch_name, ci_name: config_name]
       }
 
       // Generate jobs for the library entry being parsed

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -358,7 +358,8 @@ gz_collections_yaml.collections.each { collection ->
         branch_index[lib_name][platform]['pr'].contains(branch_name) ?:
           branch_index[lib_name][platform]['pr'] << [branch: branch_name, ci_name: config_name]
       }
-      if (categories_enabled.contains('pr_abichecker'))
+      if (categories_enabled.contains('pr_abichecker') &&
+         (! ci_config.exclude.abichecker?.contains(lib_name)))
       {
         branch_index[lib_name][platform]['pr_abichecker'].contains(branch_name) ?:
           branch_index[lib_name][platform]['pr_abichecker'] << [branch: branch_name, ci_name: config_name]

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -379,6 +379,22 @@ gz_collections_yaml.collections.each { collection ->
            job_name: gz_ci_job.name])
       } // end of daily category enabled
     }
+
+    if (categories_enabled.contains('pr'))
+    {
+      if (ci_config.system.so == 'linux')
+      {
+        def pre_setup_script = ci_config.pre_setup_script_hook?.get(lib_name)?.join('\n')
+        def extra_cmd = pre_setup_script ?: ""
+        if (categories_enabled.contains('stable_branches') && \
+             (! ci_config.exclude.abichecker?.contains(lib_name)))
+        {
+          // generate_label_by_requirements(gz_ci_any_job, lib_name, ci_config.requirements)
+        }
+      } else if (ci_config.system.so == 'darwin') {
+      } else if (ci_config.system.so == 'windows') {
+      }
+
   }
 }
 

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -72,18 +72,6 @@ boolean are_cmake_warnings_enabled(lib_name, ci_config)
  * Generate an index that facilitates the operations with the yaml values,
  * avoiding to parse them several times.
  *
- * # ci_configs_by_lib index structure:
- *   lib_name : [ ci_config_name : [ .branch .collection ] ]
- *
- *   The index main keys are the lib names (i.e: gz-cmake) and associated them
- *   another map of CI configuration names supported as keys (i.e: jammy) with the
- *   list of associated items composed by a map: branch (and collection) that CI configuration
- *   (i.e [[branch:gz-cmake3, collection: harmonic], [branch: gz-cmake3, collection: garden])
- *   as values. In a graphic;
- *
- *   index[gz-cmake][jammy] -> [ branch: gz-cmake3, collection: garden ,
- *                               branch: gz-cmake3, collection: harmonic]
- *
  * # pkgconf_per_src index structure:
  *   pkg_src_name : [ packaging_config_name : [ .lib_name .collection ] ]
  *
@@ -94,16 +82,12 @@ boolean are_cmake_warnings_enabled(lib_name, ci_config)
  *
  *   index[gz-cmake3][jammy] -> [ lib_name: gz-cmake, collection: harmonic ]
  */
-void generate_ciconfigs_by_lib(config, ciconf_per_lib_index, pkgconf_per_src_index)
+void generate_ciconfigs_by_lib(config, pkgconf_per_src_index)
 {
   config.collections.each { collection ->
     collection.libs.each { lib ->
       def libName = lib.name
       def branch = lib.repo.current_branch
-      collection.ci.configs.each { config_name ->
-        ciconf_per_lib_index[libName][config_name] = ciconf_per_lib_index[libName][config_name]?: []
-        ciconf_per_lib_index[libName][config_name].contains(branch) ?: ciconf_per_lib_index[libName][config_name] << [branch: branch, collection: collection.name]
-      }
       def pkg_name = lib.name + lib.major_version
       if (collection.packaging.linux?.ignore_major_version?.contains(libName))
         pkg_name = lib.name
@@ -320,9 +304,8 @@ def generate_debbuilder_job(src_name, ArrayList pre_setup_script_hooks)
   }
 }
 
-def ciconf_per_lib_index = [:].withDefault { [:] }
 def pkgconf_per_src_index = [:].withDefault { [:] }
-generate_ciconfigs_by_lib(gz_collections_yaml, ciconf_per_lib_index, pkgconf_per_src_index)
+generate_ciconfigs_by_lib(gz_collections_yaml, pkgconf_per_src_index)
 /*
  *
  * Loop over each collection, inside each collection loop over the ci configurations assigned

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -1,5 +1,4 @@
 asan_ci __upcoming__ gz_tools-ci_asan-main-jammy-amd64
-asan_ci citadel gz_citadel-ci_asan-main-focal-amd64
 asan_ci citadel gz_cmake-ci_asan-ign-cmake2-focal-amd64
 asan_ci citadel gz_common-ci_asan-ign-common3-focal-amd64
 asan_ci citadel gz_fuel_tools-ci_asan-ign-fuel-tools4-focal-amd64
@@ -17,7 +16,6 @@ asan_ci citadel gz_transport-ci_asan-ign-transport8-focal-amd64
 asan_ci citadel sdformat-ci_asan-sdf9-focal-amd64
 asan_ci fortress gz_cmake-ci_asan-ign-cmake2-focal-amd64
 asan_ci fortress gz_common-ci_asan-ign-common4-focal-amd64
-asan_ci fortress gz_fortress-ci_asan-main-focal-amd64
 asan_ci fortress gz_fuel_tools-ci_asan-ign-fuel-tools7-focal-amd64
 asan_ci fortress gz_gui-ci_asan-ign-gui6-focal-amd64
 asan_ci fortress gz_launch-ci_asan-ign-launch5-focal-amd64
@@ -35,7 +33,6 @@ asan_ci fortress sdformat-ci_asan-sdf12-focal-amd64
 asan_ci garden gz_cmake-ci_asan-gz-cmake3-focal-amd64
 asan_ci garden gz_common-ci_asan-gz-common5-focal-amd64
 asan_ci garden gz_fuel_tools-ci_asan-gz-fuel-tools8-focal-amd64
-asan_ci garden gz_garden-ci_asan-main-focal-amd64
 asan_ci garden gz_gui-ci_asan-gz-gui7-focal-amd64
 asan_ci garden gz_launch-ci_asan-gz-launch6-focal-amd64
 asan_ci garden gz_math-ci_asan-gz-math7-focal-amd64
@@ -53,7 +50,6 @@ asan_ci harmonic gz_cmake-ci_asan-gz-cmake3-jammy-amd64
 asan_ci harmonic gz_common-ci_asan-gz-common5-jammy-amd64
 asan_ci harmonic gz_fuel_tools-ci_asan-gz-fuel-tools9-jammy-amd64
 asan_ci harmonic gz_gui-ci_asan-gz-gui8-jammy-amd64
-asan_ci harmonic gz_harmonic-ci_asan-main-jammy-amd64
 asan_ci harmonic gz_launch-ci_asan-gz-launch7-jammy-amd64
 asan_ci harmonic gz_math-ci_asan-gz-math7-jammy-amd64
 asan_ci harmonic gz_msgs-ci_asan-gz-msgs10-jammy-amd64
@@ -85,9 +81,6 @@ asan_ci ionic sdformat-ci_asan-main-jammy-amd64
 branch_ci __upcoming__ gz_tools-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_tools-ci-main-jammy-amd64
 branch_ci __upcoming__ gz_tools-main-win
-branch_ci citadel gz_citadel-ci-main-focal-amd64
-branch_ci citadel gz_citadel-ci-main-homebrew-amd64
-branch_ci citadel gz_citadel-main-win
 branch_ci citadel gz_cmake-ci-ign-cmake2-focal-amd64
 branch_ci citadel gz_cmake-ci-ign-cmake2-homebrew-amd64
 branch_ci citadel gz_cmake-ign-cmake2-win
@@ -102,7 +95,6 @@ branch_ci citadel gz_gui-ci-ign-gui3-homebrew-amd64
 branch_ci citadel gz_gui-ign-gui3-win
 branch_ci citadel gz_launch-ci-ign-launch2-focal-amd64
 branch_ci citadel gz_launch-ci-ign-launch2-homebrew-amd64
-branch_ci citadel gz_launch-ign-launch2-win
 branch_ci citadel gz_math-ci-ign-math6-focal-amd64
 branch_ci citadel gz_math-ci-ign-math6-homebrew-amd64
 branch_ci citadel gz_math-ign-math6-win
@@ -123,7 +115,6 @@ branch_ci citadel gz_sensors-ci-ign-sensors3-homebrew-amd64
 branch_ci citadel gz_sensors-ign-sensors3-win
 branch_ci citadel gz_sim-ci-ign-gazebo3-focal-amd64
 branch_ci citadel gz_sim-ci-ign-gazebo3-homebrew-amd64
-branch_ci citadel gz_sim-ign-gazebo3-win
 branch_ci citadel gz_tools-ci-ign-tools1-focal-amd64
 branch_ci citadel gz_tools-ci-ign-tools1-homebrew-amd64
 branch_ci citadel gz_tools-ign-tools1-win
@@ -139,9 +130,6 @@ branch_ci fortress gz_cmake-ign-cmake2-win
 branch_ci fortress gz_common-ci-ign-common4-focal-amd64
 branch_ci fortress gz_common-ci-ign-common4-homebrew-amd64
 branch_ci fortress gz_common-ign-common4-win
-branch_ci fortress gz_fortress-ci-main-focal-amd64
-branch_ci fortress gz_fortress-ci-main-homebrew-amd64
-branch_ci fortress gz_fortress-main-win
 branch_ci fortress gz_fuel_tools-ci-ign-fuel-tools7-focal-amd64
 branch_ci fortress gz_fuel_tools-ci-ign-fuel-tools7-homebrew-amd64
 branch_ci fortress gz_fuel_tools-ign-fuel-tools7-win
@@ -193,9 +181,6 @@ branch_ci garden gz_common-ci-gz-common5-homebrew-amd64
 branch_ci garden gz_fuel_tools-8-win
 branch_ci garden gz_fuel_tools-ci-gz-fuel-tools8-focal-amd64
 branch_ci garden gz_fuel_tools-ci-gz-fuel-tools8-homebrew-amd64
-branch_ci garden gz_garden-ci-main-focal-amd64
-branch_ci garden gz_garden-ci-main-homebrew-amd64
-branch_ci garden gz_garden-main-win
 branch_ci garden gz_gui-7-win
 branch_ci garden gz_gui-ci-gz-gui7-focal-amd64
 branch_ci garden gz_gui-ci-gz-gui7-homebrew-amd64
@@ -251,10 +236,6 @@ branch_ci harmonic gz_gui-8-win
 branch_ci harmonic gz_gui-ci-gz-gui8-homebrew-amd64
 branch_ci harmonic gz_gui-ci-gz-gui8-jammy-amd64
 branch_ci harmonic gz_gui-ci-gz-gui8-noble-amd64
-branch_ci harmonic gz_harmonic-ci-main-homebrew-amd64
-branch_ci harmonic gz_harmonic-ci-main-jammy-amd64
-branch_ci harmonic gz_harmonic-ci-main-noble-amd64
-branch_ci harmonic gz_harmonic-main-win
 branch_ci harmonic gz_launch-7-win
 branch_ci harmonic gz_launch-ci-gz-launch7-homebrew-amd64
 branch_ci harmonic gz_launch-ci-gz-launch7-jammy-amd64

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -1,4 +1,5 @@
 asan_ci __upcoming__ gz_tools-ci_asan-main-jammy-amd64
+asan_ci citadel gz_citadel-ci_asan-main-focal-amd64
 asan_ci citadel gz_cmake-ci_asan-ign-cmake2-focal-amd64
 asan_ci citadel gz_common-ci_asan-ign-common3-focal-amd64
 asan_ci citadel gz_fuel_tools-ci_asan-ign-fuel-tools4-focal-amd64
@@ -16,6 +17,7 @@ asan_ci citadel gz_transport-ci_asan-ign-transport8-focal-amd64
 asan_ci citadel sdformat-ci_asan-sdf9-focal-amd64
 asan_ci fortress gz_cmake-ci_asan-ign-cmake2-focal-amd64
 asan_ci fortress gz_common-ci_asan-ign-common4-focal-amd64
+asan_ci fortress gz_fortress-ci_asan-main-focal-amd64
 asan_ci fortress gz_fuel_tools-ci_asan-ign-fuel-tools7-focal-amd64
 asan_ci fortress gz_gui-ci_asan-ign-gui6-focal-amd64
 asan_ci fortress gz_launch-ci_asan-ign-launch5-focal-amd64
@@ -33,6 +35,7 @@ asan_ci fortress sdformat-ci_asan-sdf12-focal-amd64
 asan_ci garden gz_cmake-ci_asan-gz-cmake3-focal-amd64
 asan_ci garden gz_common-ci_asan-gz-common5-focal-amd64
 asan_ci garden gz_fuel_tools-ci_asan-gz-fuel-tools8-focal-amd64
+asan_ci garden gz_garden-ci_asan-main-focal-amd64
 asan_ci garden gz_gui-ci_asan-gz-gui7-focal-amd64
 asan_ci garden gz_launch-ci_asan-gz-launch6-focal-amd64
 asan_ci garden gz_math-ci_asan-gz-math7-focal-amd64
@@ -50,6 +53,7 @@ asan_ci harmonic gz_cmake-ci_asan-gz-cmake3-jammy-amd64
 asan_ci harmonic gz_common-ci_asan-gz-common5-jammy-amd64
 asan_ci harmonic gz_fuel_tools-ci_asan-gz-fuel-tools9-jammy-amd64
 asan_ci harmonic gz_gui-ci_asan-gz-gui8-jammy-amd64
+asan_ci harmonic gz_harmonic-ci_asan-main-jammy-amd64
 asan_ci harmonic gz_launch-ci_asan-gz-launch7-jammy-amd64
 asan_ci harmonic gz_math-ci_asan-gz-math7-jammy-amd64
 asan_ci harmonic gz_msgs-ci_asan-gz-msgs10-jammy-amd64
@@ -81,6 +85,9 @@ asan_ci ionic sdformat-ci_asan-main-jammy-amd64
 branch_ci __upcoming__ gz_tools-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_tools-ci-main-jammy-amd64
 branch_ci __upcoming__ gz_tools-main-win
+branch_ci citadel gz_citadel-ci-main-focal-amd64
+branch_ci citadel gz_citadel-ci-main-homebrew-amd64
+branch_ci citadel gz_citadel-main-win
 branch_ci citadel gz_cmake-ci-ign-cmake2-focal-amd64
 branch_ci citadel gz_cmake-ci-ign-cmake2-homebrew-amd64
 branch_ci citadel gz_cmake-ign-cmake2-win
@@ -95,6 +102,7 @@ branch_ci citadel gz_gui-ci-ign-gui3-homebrew-amd64
 branch_ci citadel gz_gui-ign-gui3-win
 branch_ci citadel gz_launch-ci-ign-launch2-focal-amd64
 branch_ci citadel gz_launch-ci-ign-launch2-homebrew-amd64
+branch_ci citadel gz_launch-ign-launch2-win
 branch_ci citadel gz_math-ci-ign-math6-focal-amd64
 branch_ci citadel gz_math-ci-ign-math6-homebrew-amd64
 branch_ci citadel gz_math-ign-math6-win
@@ -115,6 +123,7 @@ branch_ci citadel gz_sensors-ci-ign-sensors3-homebrew-amd64
 branch_ci citadel gz_sensors-ign-sensors3-win
 branch_ci citadel gz_sim-ci-ign-gazebo3-focal-amd64
 branch_ci citadel gz_sim-ci-ign-gazebo3-homebrew-amd64
+branch_ci citadel gz_sim-ign-gazebo3-win
 branch_ci citadel gz_tools-ci-ign-tools1-focal-amd64
 branch_ci citadel gz_tools-ci-ign-tools1-homebrew-amd64
 branch_ci citadel gz_tools-ign-tools1-win
@@ -130,6 +139,9 @@ branch_ci fortress gz_cmake-ign-cmake2-win
 branch_ci fortress gz_common-ci-ign-common4-focal-amd64
 branch_ci fortress gz_common-ci-ign-common4-homebrew-amd64
 branch_ci fortress gz_common-ign-common4-win
+branch_ci fortress gz_fortress-ci-main-focal-amd64
+branch_ci fortress gz_fortress-ci-main-homebrew-amd64
+branch_ci fortress gz_fortress-main-win
 branch_ci fortress gz_fuel_tools-ci-ign-fuel-tools7-focal-amd64
 branch_ci fortress gz_fuel_tools-ci-ign-fuel-tools7-homebrew-amd64
 branch_ci fortress gz_fuel_tools-ign-fuel-tools7-win
@@ -181,6 +193,9 @@ branch_ci garden gz_common-ci-gz-common5-homebrew-amd64
 branch_ci garden gz_fuel_tools-8-win
 branch_ci garden gz_fuel_tools-ci-gz-fuel-tools8-focal-amd64
 branch_ci garden gz_fuel_tools-ci-gz-fuel-tools8-homebrew-amd64
+branch_ci garden gz_garden-ci-main-focal-amd64
+branch_ci garden gz_garden-ci-main-homebrew-amd64
+branch_ci garden gz_garden-main-win
 branch_ci garden gz_gui-7-win
 branch_ci garden gz_gui-ci-gz-gui7-focal-amd64
 branch_ci garden gz_gui-ci-gz-gui7-homebrew-amd64
@@ -236,6 +251,10 @@ branch_ci harmonic gz_gui-8-win
 branch_ci harmonic gz_gui-ci-gz-gui8-homebrew-amd64
 branch_ci harmonic gz_gui-ci-gz-gui8-jammy-amd64
 branch_ci harmonic gz_gui-ci-gz-gui8-noble-amd64
+branch_ci harmonic gz_harmonic-ci-main-homebrew-amd64
+branch_ci harmonic gz_harmonic-ci-main-jammy-amd64
+branch_ci harmonic gz_harmonic-ci-main-noble-amd64
+branch_ci harmonic gz_harmonic-main-win
 branch_ci harmonic gz_launch-7-win
 branch_ci harmonic gz_launch-ci-gz-launch7-homebrew-amd64
 branch_ci harmonic gz_launch-ci-gz-launch7-jammy-amd64


### PR DESCRIPTION
The DSL generation in `gazebo_libs` is based on an approach of building two indexes before looping over the gz-collections.yaml file. That approach does not respect the fact of having different ci_config (CI confgurations) that use the same platform and will overwrite the first one found if that situation occurs. The index build process also did not load the exclusion clauses included in the ci_configuration which are useful to be parsed when building the index.

The changes in this PR modify it to mainly:
  * Loop over the gz-collections.yaml directly the first time to generate the jobs that are linked to lib branches `gz-fooX`. 
  * While looping it build a branch_index that will be used to build the pr jobs that are in the form `gz-foo-pr_any-` not based on the branch directly.
  * Loop over the branch_index created to create the pr jobs.

Note: the common jobs used for -pr- need the assumption of having the same metadata when ci_configs use the same platform. The restrictions needs to be coded or the design corrected with structural changes.

This should unblock the options to avoid duplicates of the abicheckers and create noble pr jobs that do not duplicate the existing jammy ones.