### PR TITLE
Outdated job runner: Add condition to run job if it hasn't been run yet

### DIFF
--- a/jenkins-scripts/tools/outdated-job-runner.groovy
+++ b/jenkins-scripts/tools/outdated-job-runner.groovy
@@ -88,7 +88,7 @@ long fourDaysAgoMillis = System.currentTimeMillis() - 4 * 24 * 60 * 60 * 1000; /
 Date fourDaysAgoDate = new Date(fourDaysAgoMillis);
 
 jenkinsJobs.getItems(Project).each { project ->
-    // Filter jobs that have not been run in 4 days (or that don't have run yet)
+    // Filter jobs that have not been run in 4 days (or that have not yet run)
     if (!project.disabled && trackedJobs.contains(project.displayName) && (project.lastBuild == null || project.lastBuild.getTime().before(fourDaysAgoDate))) {
         if (project.displayName.contains('homebrew')) {
             jobsToRun.osx << project.displayName

--- a/jenkins-scripts/tools/outdated-job-runner.groovy
+++ b/jenkins-scripts/tools/outdated-job-runner.groovy
@@ -88,8 +88,8 @@ long fourDaysAgoMillis = System.currentTimeMillis() - 4 * 24 * 60 * 60 * 1000; /
 Date fourDaysAgoDate = new Date(fourDaysAgoMillis);
 
 jenkinsJobs.getItems(Project).each { project ->
-    // Filter jobs that have not been updated in the last 8 days
-    if (!project.disabled && trackedJobs.contains(project.displayName) && project.lastBuild.getTime().before(fourDaysAgoDate)) {
+    // Filter jobs that have not been run in 4 days (or that don't have run yet)
+    if (!project.disabled && trackedJobs.contains(project.displayName) && (project.lastBuild == null || project.lastBuild.getTime().before(fourDaysAgoDate))) {
         if (project.displayName.contains('homebrew')) {
             jobsToRun.osx << project.displayName
         } else if (project.displayName.contains('win')) {


### PR DESCRIPTION
Outdated job runner can fail if there is a job that doesn't contain any builds (`project.lastBuild.getTime()` raises a NullPointerException) such as: [gz_ionic-install_bottle-homebrew-amd64](https://build.osrfoundation.org/job/gz_ionic-install_bottle-homebrew-amd64/) (checked in May 23rd 2:15 UTC)

This PR adds the condition to run the job if `project.lastBuild` is null

Failed build: https://build.osrfoundation.org/job/_outdated_job_runner/7800/