### PR TITLE
Include a script to obtain gazebo releases for a given library

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gazebo software.
 
   * [release.py](release.py): Triggers new debian and homebrew releases (major, minor, patch, pre-release...).
   * For scripts working on -release repositories, please see [release-repo-scripts/README.md](release-repo-scripts/README.md)
-  * For scripts working on library source repository, please see [source-repo-scripts/README.md](source-repo-scripts/README.md)
+  * For scripts working on library source repositories, please see [source-repo-scripts/README.md](source-repo-scripts/README.md)
   * For scripts related to unofficial ROS packages, please see [bloom scripts](bloom/ros_gazebo_pkgs/README.md)
   * For scripts working on DSL Jenkins code and/or gz-collections.yaml, please see [dsl/tools](jenkins-scripts/dsl/tools/README.md)
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Gazebo software.
 ## Scripts
 
   * [release.py](release.py): Triggers new debian and homebrew releases (major, minor, patch, pre-release...).
-  * For -release repository scripts, please see [release-repo-scripts/README.md](release-repo-scripts/README.md)
-  * For source repository scripts, please see [source-repo-scripts/README.md](source-repo-scripts/README.md)
+  * For scripts working on -release repositories, please see [release-repo-scripts/README.md](release-repo-scripts/README.md)
+  * For scripts working on library source repository, please see [source-repo-scripts/README.md](source-repo-scripts/README.md)
   * For scripts related to unofficial ROS packages, please see [bloom scripts](bloom/ros_gazebo_pkgs/README.md)
+  * For scripts working on DSL Jenkins code and/or gz-collections.yaml, please see [dsl/tools](jenkins-scripts/dsl/tools/README.md)
 
 ### Making releases
 

--- a/jenkins-scripts/dsl/tools/README.md
+++ b/jenkins-scripts/dsl/tools/README.md
@@ -1,0 +1,50 @@
+# Scripts for working with Jenkins DSL and gz-collections.yaml
+
+## DSL 
+
+## setup_local_generation.bash (jobdsl.jar)
+
+Script use to generate job configuration locally for Jenkins. See
+[Jenkins script README](../README.md) 
+
+## gz-collections.yaml
+
+The `gz-collections.yaml` file stores all the metadata corresponding
+to the different collections of Gazebo, the libraries that compose
+each release and the metadata for creating the buildfarm jobs that
+implement the CI and packaging.
+
+The file is useful for scripts that use global information about the
+Gazebo libraries.
+
+### get_collections_from_package_and_version.py
+
+The script return the Gazebo releases (also known as collections) that
+contains a given library and major version that are provided as input
+parameters.
+
+The output is provid
+
+The output is provided as a space separated list in a single line.
+Nothing if not found.ed as a space separated list in a single line.
+Nothing if not found.
+
+#### Usage
+
+```
+./get_collections_from_package_and_version.py <lib_name> <major_version> <path-to-gz-collections.yaml>
+```
+
+Be sure of not including the major version number in the `<lib_name>`
+
+#### Example
+
+```
+$./get_collections_from_package_and_version.py gz-cmake 3 ../gz-collections.yaml
+```
+
+That generates the result of:
+
+```
+garden harmonic
+```

--- a/jenkins-scripts/dsl/tools/README.md
+++ b/jenkins-scripts/dsl/tools/README.md
@@ -26,11 +26,8 @@ The script return the Gazebo releases (also known as collections) that
 contains a given library and major version that are provided as input
 parameters.
 
-The output is provid
-
-The output is provided as a space separated list in a single line.
-Nothing if not found.ed as a space separated list in a single line.
-Nothing if not found.
+The output is provided as a space separated list in a single line. If
+no match is found, the result is an empty string.
 
 #### Usage
 

--- a/jenkins-scripts/dsl/tools/README.md
+++ b/jenkins-scripts/dsl/tools/README.md
@@ -2,7 +2,10 @@
 
 ## DSL 
 
-## setup_local_generation.bash (jobdsl.jar)
+DSL is the Jenkins plugins that allows to use code for creating
+the different Jenkins jobs and configurations.
+
+### setup_local_generation.bash (jobdsl.jar)
 
 Script use to generate job configuration locally for Jenkins. See
 [Jenkins script README](../README.md) 

--- a/jenkins-scripts/dsl/tools/get_collections_from_package_and_version.py
+++ b/jenkins-scripts/dsl/tools/get_collections_from_package_and_version.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
-
 import sys
 import yaml
 
 
 # Function to find the collection name based on lib name and major version
-def find_collection(data, lib_name, major_version):
+def find_collection(data, lib_name, major_version) -> list:
   instances = []
 
   for collection in data['collections']:
@@ -15,21 +14,29 @@ def find_collection(data, lib_name, major_version):
   return instances
 
 
-def get_major_version(version):
+def get_major_version(version) -> int:
   elements = version.split('.')
   return int(elements[0])
 
 
-if len(sys.argv) < 3:
-  print(f"Usage: {sys.argv[0]} <lib_name> <major_version> <collection-yaml-file>")
-  sys.exit(1)
+def main() -> int:
+  if len(sys.argv) < 3:
+    print(f"Usage: {sys.argv[0]} <lib_name> <major_version> <collection-yaml-file>")
+    return 2
 
-lib_name = sys.argv[1]
-version = sys.argv[2]
-yaml_file = sys.argv[3]
+  lib_name = sys.argv[1]
+  version = sys.argv[2]
+  yaml_file = sys.argv[3]
 
-with open(yaml_file, 'r') as file:
-  data = yaml.safe_load(file)
+  with open(yaml_file, 'r') as file:
+    data = yaml.safe_load(file)
 
-collection_names = find_collection(data, lib_name, get_major_version(version))
-print(f"{' '.join(collection_names)}")
+  collection_names = find_collection(data, lib_name, get_major_version(version))
+  if not collection_names:
+    return 1
+  print(f"{' '.join(collection_names)}")
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/jenkins-scripts/dsl/tools/get_collections_from_package_and_version.py
+++ b/jenkins-scripts/dsl/tools/get_collections_from_package_and_version.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+import sys
+import yaml
+
+
+# Function to find the collection name based on lib name and major version
+def find_collection(data, lib_name, major_version):
+  instances = []
+
+  for collection in data['collections']:
+    for lib in collection['libs']:
+      if lib['name'] == lib_name and lib['major_version'] == major_version:
+        instances.append(collection['name'])
+  return instances
+
+
+def get_major_version(version):
+  elements = version.split('.')
+  return int(elements[0])
+
+
+if len(sys.argv) < 3:
+  print(f"Usage: {sys.argv[0]} <lib_name> <major_version> <collection-yaml-file>")
+  sys.exit(1)
+
+lib_name = sys.argv[1]
+version = sys.argv[2]
+yaml_file = sys.argv[3]
+
+with open(yaml_file, 'r') as file:
+  data = yaml.safe_load(file)
+
+collection_names = find_collection(data, lib_name, get_major_version(version))
+print(f"{' '.join(collection_names)}")


### PR DESCRIPTION
A helper script to obtain the Gazebo collection/releases given a library and a major version. It uses the gz-collections.yaml as the database to search for the metadata.