### PR TITLE
Fix null check in CI

### DIFF
--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -6,7 +6,9 @@ if [[ -z $(ls -- *.xml) ]]; then
   exit 1
 fi
 
-not_null=$(grep -3 'null' -- *.xml || true)
+# Some XML generated files include valid Groovy code using null
+# like the _outdated_jobs job. Do not search for null unconditionally
+not_null=$(grep -3 '>.*null.*<' -- *.xml || true)
 if [[ -n ${not_null} ]]; then
   echo "Found a null value in a configuration file:"
   echo "${not_null}"


### PR DESCRIPTION
The null check in dsl_checks looks for the 'null' string in all the XML config generated. There are some jobs generated that include Groovy code that actually use null values. The PR modifies it to restrict the check to be the value under XML tags.