### PR TITLE
homebrew_cleanup: don't fail on git fsck

### DIFF
--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -10,7 +10,9 @@ restore_brew()
 
 BREW_BINARY_DIR=/usr/local/bin
 BREW_BINARY=${BREW_BINARY_DIR}/brew
-git -C $(${BREW_BINARY} --repo) fsck
+# Try running `git fsck` before `brew update` in case `git gc` broke something
+# but don't fail
+git -C $(${BREW_BINARY} --repo) fsck || true
 export HOMEBREW_UPDATE_TO_TAG=1
 ${BREW_BINARY} up || { restore_brew && ${BREW_BINARY} up ; }
 


### PR DESCRIPTION
The `git fsck` call added to `_homebrew_cleanup.bash` in f5e9ef9ad6bef555ca4e30d04d4c10f3ff59bc4e is trying to improve reliability, but it can fail if git from brew is broken. Since this script is removing all installed formulae,
just continue if `git fsck` fails, and it should remove the broken `git` for us.

Testing on Mac-four:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake3-install_bottle-homebrew-amd64&build=244)](https://build.osrfoundation.org/job/gz_cmake3-install_bottle-homebrew-amd64/244/) https://build.osrfoundation.org/job/gz_cmake3-install_bottle-homebrew-amd64/244/