### PR TITLE
gz-rendering9+: build without -DSKIP_optix

### DIFF
--- a/jenkins-scripts/docker/gz_rendering-compilation.bash
+++ b/jenkins-scripts/docker/gz_rendering-compilation.bash
@@ -35,4 +35,10 @@ fi
 export GPU_SUPPORT_NEEDED=true
 export GZDEV_PROJECT_NAME="gz-rendering${GZ_RENDERING_MAJOR_VERSION}"
 
+# set SKIP_optix=true for Harmonic and earlier
+# not needed for ionic since https://github.com/gazebosim/gz-rendering/pull/1032
+if [[ ${GZ_RENDERING_MAJOR_VERSION} -le 8 ]]; then
+  export BUILDING_EXTRA_CMAKE_PARAMS+=" -DSKIP_optix=true"
+fi
+
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/gz_rendering-compilation.bash
+++ b/jenkins-scripts/docker/gz_rendering-compilation.bash
@@ -35,6 +35,4 @@ fi
 export GPU_SUPPORT_NEEDED=true
 export GZDEV_PROJECT_NAME="gz-rendering${GZ_RENDERING_MAJOR_VERSION}"
 
-export BUILDING_EXTRA_CMAKE_PARAMS+=" -DSKIP_optix=true"
-
 . ${SCRIPT_DIR}/lib/generic-building-base.bash


### PR DESCRIPTION
This was added in #456, but now it seems to be causing a cmake warning for an unused manually specified variable:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering-ci-main-noble-amd64&build=24)](https://build.osrfoundation.org/job/gz_rendering-ci-main-noble-amd64/24/) https://build.osrfoundation.org/job/gz_rendering-ci-main-noble-amd64/24/cmake/

~~~
CMake Warning:
  Manually-specified variables were not used by the project:

    SKIP_optix
~~~

testing with this branch:

* 1 test failure expected, but no cmake warnings [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering-ci-main-noble-amd64&build=25)](https://build.osrfoundation.org/job/gz_rendering-ci-main-noble-amd64/25/) https://build.osrfoundation.org/job/gz_rendering-ci-main-noble-amd64/25/cmake/