### PR TITLE
Use stable branch for gz-cmake4

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -359,7 +359,7 @@ collections:
       - name: gz-cmake
         major_version: 4
         repo:
-          current_branch: main
+          current_branch: gz-cmake4
       - name: gz-tools
         major_version: 2
         repo:
@@ -443,6 +443,10 @@ collections:
     libs:
       - name: gz-tools
         major_version: 3
+        repo:
+          current_branch: main
+      - name: gz-cmake
+        major_version: 4
         repo:
           current_branch: main
     ci:

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -1,3 +1,4 @@
+asan_ci __upcoming__ gz_cmake-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_tools-ci_asan-main-noble-amd64
 asan_ci citadel gz_cmake-ci_asan-ign-cmake2-focal-amd64
 asan_ci citadel gz_common-ci_asan-ign-common3-focal-amd64
@@ -62,7 +63,7 @@ asan_ci harmonic gz_tools-ci_asan-gz-tools2-jammy-amd64
 asan_ci harmonic gz_transport-ci_asan-gz-transport13-jammy-amd64
 asan_ci harmonic gz_utils-ci_asan-gz-utils2-jammy-amd64
 asan_ci harmonic sdformat-ci_asan-sdf14-jammy-amd64
-asan_ci ionic gz_cmake-ci_asan-main-noble-amd64
+asan_ci ionic gz_cmake-ci_asan-gz-cmake4-noble-amd64
 asan_ci ionic gz_common-ci_asan-main-noble-amd64
 asan_ci ionic gz_fuel_tools-ci_asan-main-noble-amd64
 asan_ci ionic gz_gui-ci_asan-main-noble-amd64
@@ -78,6 +79,9 @@ asan_ci ionic gz_tools-ci_asan-gz-tools2-noble-amd64
 asan_ci ionic gz_transport-ci_asan-main-noble-amd64
 asan_ci ionic gz_utils-ci_asan-main-noble-amd64
 asan_ci ionic sdformat-ci_asan-main-noble-amd64
+branch_ci __upcoming__ gz_cmake-ci-main-homebrew-amd64
+branch_ci __upcoming__ gz_cmake-ci-main-noble-amd64
+branch_ci __upcoming__ gz_cmake-main-win
 branch_ci __upcoming__ gz_tools-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_tools-ci-main-noble-amd64
 branch_ci __upcoming__ gz_tools-main-win
@@ -284,9 +288,9 @@ branch_ci harmonic sdformat-ci-sdf14-homebrew-amd64
 branch_ci harmonic sdformat-ci-sdf14-jammy-amd64
 branch_ci harmonic sdformat-ci-sdf14-noble-amd64
 branch_ci harmonic sdformat-sdf14-win
-branch_ci ionic gz_cmake-ci-main-homebrew-amd64
-branch_ci ionic gz_cmake-ci-main-noble-amd64
-branch_ci ionic gz_cmake-main-win
+branch_ci ionic gz_cmake-4-win
+branch_ci ionic gz_cmake-ci-gz-cmake4-homebrew-amd64
+branch_ci ionic gz_cmake-ci-gz-cmake4-noble-amd64
 branch_ci ionic gz_common-ci-main-homebrew-amd64
 branch_ci ionic gz_common-ci-main-noble-amd64
 branch_ci ionic gz_common-main-win
@@ -332,6 +336,8 @@ branch_ci ionic gz_utils-main-win
 branch_ci ionic sdformat-ci-main-homebrew-amd64
 branch_ci ionic sdformat-ci-main-noble-amd64
 branch_ci ionic sdformat-main-win
+install_ci __upcoming__ gz_cmake4-install-pkg-noble-amd64
+install_ci __upcoming__ gz_cmake4-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_tools3-install-pkg-noble-amd64
 install_ci __upcoming__ gz_tools3-install_bottle-homebrew-amd64
 install_ci citadel gz_citadel-install-pkg-focal-amd64


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092

Needed to make a pre-release of gz-cmake4.