### PR TITLE
Use stable branch for gz-gui9

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -403,7 +403,7 @@ collections:
       - name: gz-gui
         major_version: 9
         repo:
-          current_branch: main
+          current_branch: gz-gui9
       - name: gz-sensors
         major_version: 9
         repo:
@@ -449,8 +449,8 @@ collections:
         major_version: 4
         repo:
           current_branch: main
-      - name: gz-utils
-        major_version: 3
+      - name: gz-gui
+        major_version: 9
         repo:
           current_branch: main
       - name: gz-math
@@ -459,6 +459,10 @@ collections:
           current_branch: main
       - name: gz-rendering
         major_version: 9
+        repo:
+          current_branch: main
+      - name: gz-utils
+        major_version: 3
         repo:
           current_branch: main
     ci:

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -1,4 +1,5 @@
 asan_ci __upcoming__ gz_cmake-ci_asan-main-noble-amd64
+asan_ci __upcoming__ gz_gui-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_math-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_rendering-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_tools-ci_asan-main-noble-amd64
@@ -69,7 +70,7 @@ asan_ci harmonic sdformat-ci_asan-sdf14-jammy-amd64
 asan_ci ionic gz_cmake-ci_asan-gz-cmake4-noble-amd64
 asan_ci ionic gz_common-ci_asan-main-noble-amd64
 asan_ci ionic gz_fuel_tools-ci_asan-main-noble-amd64
-asan_ci ionic gz_gui-ci_asan-main-noble-amd64
+asan_ci ionic gz_gui-ci_asan-gz-gui9-noble-amd64
 asan_ci ionic gz_launch-ci_asan-main-noble-amd64
 asan_ci ionic gz_math-ci_asan-gz-math8-noble-amd64
 asan_ci ionic gz_msgs-ci_asan-main-noble-amd64
@@ -85,6 +86,9 @@ asan_ci ionic sdformat-ci_asan-main-noble-amd64
 branch_ci __upcoming__ gz_cmake-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_cmake-ci-main-noble-amd64
 branch_ci __upcoming__ gz_cmake-main-win
+branch_ci __upcoming__ gz_gui-ci-main-homebrew-amd64
+branch_ci __upcoming__ gz_gui-ci-main-noble-amd64
+branch_ci __upcoming__ gz_gui-main-win
 branch_ci __upcoming__ gz_math-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_math-ci-main-noble-amd64
 branch_ci __upcoming__ gz_math-main-win
@@ -309,9 +313,9 @@ branch_ci ionic gz_common-main-win
 branch_ci ionic gz_fuel_tools-ci-main-homebrew-amd64
 branch_ci ionic gz_fuel_tools-ci-main-noble-amd64
 branch_ci ionic gz_fuel_tools-main-win
-branch_ci ionic gz_gui-ci-main-homebrew-amd64
-branch_ci ionic gz_gui-ci-main-noble-amd64
-branch_ci ionic gz_gui-main-win
+branch_ci ionic gz_gui-9-win
+branch_ci ionic gz_gui-ci-gz-gui9-homebrew-amd64
+branch_ci ionic gz_gui-ci-gz-gui9-noble-amd64
 branch_ci ionic gz_launch-ci-main-homebrew-amd64
 branch_ci ionic gz_launch-ci-main-noble-amd64
 branch_ci ionic gz_launch-main-win
@@ -350,6 +354,8 @@ branch_ci ionic sdformat-ci-main-noble-amd64
 branch_ci ionic sdformat-main-win
 install_ci __upcoming__ gz_cmake4-install-pkg-noble-amd64
 install_ci __upcoming__ gz_cmake4-install_bottle-homebrew-amd64
+install_ci __upcoming__ gz_gui9-install-pkg-noble-amd64
+install_ci __upcoming__ gz_gui9-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_math8-install-pkg-noble-amd64
 install_ci __upcoming__ gz_math8-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_rendering9-install-pkg-noble-amd64


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092

Needed to make a pre-release of gz-gui9.