### PR TITLE
Use stable branch gz-transport14

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -399,7 +399,7 @@ collections:
       - name: gz-transport
         major_version: 14
         repo:
-          current_branch: main
+          current_branch: gz-transport14
       - name: gz-gui
         major_version: 9
         repo:
@@ -469,6 +469,10 @@ collections:
         major_version: 9
         repo:
           current_branch: main
+      - name: gz-transport
+        major_version: 14
+        repo:
+          current_branch: gz-transport14
       - name: gz-utils
         major_version: 3
         repo:

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -472,7 +472,7 @@ collections:
       - name: gz-transport
         major_version: 14
         repo:
-          current_branch: gz-transport14
+          current_branch: main
       - name: gz-utils
         major_version: 3
         repo:

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -5,7 +5,7 @@ asan_ci __upcoming__ gz_msgs-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_rendering-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_sensors-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_tools-ci_asan-main-noble-amd64
-asan_ci __upcoming__ gz_transport-ci_asan-main-noble-amd64
+asan_ci __upcoming__ gz_transport-ci_asan-gz-transport14-noble-amd64
 asan_ci __upcoming__ gz_utils-ci_asan-main-noble-amd64
 asan_ci __upcoming__ sdformat-ci_asan-main-noble-amd64
 asan_ci citadel gz_cmake-ci_asan-ign-cmake2-focal-amd64
@@ -108,9 +108,9 @@ branch_ci __upcoming__ gz_sensors-main-win
 branch_ci __upcoming__ gz_tools-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_tools-ci-main-noble-amd64
 branch_ci __upcoming__ gz_tools-main-win
-branch_ci __upcoming__ gz_transport-ci-main-homebrew-amd64
-branch_ci __upcoming__ gz_transport-ci-main-noble-amd64
-branch_ci __upcoming__ gz_transport-main-win
+branch_ci __upcoming__ gz_transport-14-win
+branch_ci __upcoming__ gz_transport-ci-gz-transport14-homebrew-amd64
+branch_ci __upcoming__ gz_transport-ci-gz-transport14-noble-amd64
 branch_ci __upcoming__ gz_utils-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_utils-ci-main-noble-amd64
 branch_ci __upcoming__ gz_utils-main-win
@@ -359,9 +359,9 @@ branch_ci ionic gz_sim-main-win
 branch_ci ionic gz_tools-2-win
 branch_ci ionic gz_tools-ci-gz-tools2-homebrew-amd64
 branch_ci ionic gz_tools-ci-gz-tools2-noble-amd64
+branch_ci ionic gz_transport-14-win
 branch_ci ionic gz_transport-ci-gz-transport14-homebrew-amd64
 branch_ci ionic gz_transport-ci-gz-transport14-noble-amd64
-branch_ci ionic gz_transport-14-win
 branch_ci ionic gz_utils-3-win
 branch_ci ionic gz_utils-ci-gz-utils3-homebrew-amd64
 branch_ci ionic gz_utils-ci-gz-utils3-noble-amd64

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -5,7 +5,7 @@ asan_ci __upcoming__ gz_msgs-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_rendering-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_sensors-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_tools-ci_asan-main-noble-amd64
-asan_ci __upcoming__ gz_transport-ci_asan-gz-transport14-noble-amd64
+asan_ci __upcoming__ gz_transport-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_utils-ci_asan-main-noble-amd64
 asan_ci __upcoming__ sdformat-ci_asan-main-noble-amd64
 asan_ci citadel gz_cmake-ci_asan-ign-cmake2-focal-amd64
@@ -108,9 +108,9 @@ branch_ci __upcoming__ gz_sensors-main-win
 branch_ci __upcoming__ gz_tools-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_tools-ci-main-noble-amd64
 branch_ci __upcoming__ gz_tools-main-win
-branch_ci __upcoming__ gz_transport-14-win
-branch_ci __upcoming__ gz_transport-ci-gz-transport14-homebrew-amd64
-branch_ci __upcoming__ gz_transport-ci-gz-transport14-noble-amd64
+branch_ci __upcoming__ gz_transport-ci-main-homebrew-amd64
+branch_ci __upcoming__ gz_transport-ci-main-noble-amd64
+branch_ci __upcoming__ gz_transport-main-win
 branch_ci __upcoming__ gz_utils-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_utils-ci-main-noble-amd64
 branch_ci __upcoming__ gz_utils-main-win

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -5,6 +5,7 @@ asan_ci __upcoming__ gz_msgs-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_rendering-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_sensors-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_tools-ci_asan-main-noble-amd64
+asan_ci __upcoming__ gz_transport-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_utils-ci_asan-main-noble-amd64
 asan_ci __upcoming__ sdformat-ci_asan-main-noble-amd64
 asan_ci citadel gz_cmake-ci_asan-ign-cmake2-focal-amd64
@@ -83,7 +84,7 @@ asan_ci ionic gz_rendering-ci_asan-gz-rendering9-noble-amd64
 asan_ci ionic gz_sensors-ci_asan-gz-sensors9-noble-amd64
 asan_ci ionic gz_sim-ci_asan-main-noble-amd64
 asan_ci ionic gz_tools-ci_asan-gz-tools2-noble-amd64
-asan_ci ionic gz_transport-ci_asan-main-noble-amd64
+asan_ci ionic gz_transport-ci_asan-gz-transport14-noble-amd64
 asan_ci ionic gz_utils-ci_asan-gz-utils3-noble-amd64
 asan_ci ionic sdformat-ci_asan-sdf15-noble-amd64
 branch_ci __upcoming__ gz_cmake-ci-main-homebrew-amd64
@@ -107,6 +108,9 @@ branch_ci __upcoming__ gz_sensors-main-win
 branch_ci __upcoming__ gz_tools-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_tools-ci-main-noble-amd64
 branch_ci __upcoming__ gz_tools-main-win
+branch_ci __upcoming__ gz_transport-ci-main-homebrew-amd64
+branch_ci __upcoming__ gz_transport-ci-main-noble-amd64
+branch_ci __upcoming__ gz_transport-main-win
 branch_ci __upcoming__ gz_utils-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_utils-ci-main-noble-amd64
 branch_ci __upcoming__ gz_utils-main-win
@@ -355,9 +359,9 @@ branch_ci ionic gz_sim-main-win
 branch_ci ionic gz_tools-2-win
 branch_ci ionic gz_tools-ci-gz-tools2-homebrew-amd64
 branch_ci ionic gz_tools-ci-gz-tools2-noble-amd64
-branch_ci ionic gz_transport-ci-main-homebrew-amd64
-branch_ci ionic gz_transport-ci-main-noble-amd64
-branch_ci ionic gz_transport-main-win
+branch_ci ionic gz_transport-ci-gz-transport14-homebrew-amd64
+branch_ci ionic gz_transport-ci-gz-transport14-noble-amd64
+branch_ci ionic gz_transport-14-win
 branch_ci ionic gz_utils-3-win
 branch_ci ionic gz_utils-ci-gz-utils3-homebrew-amd64
 branch_ci ionic gz_utils-ci-gz-utils3-noble-amd64
@@ -378,6 +382,8 @@ install_ci __upcoming__ gz_sensors9-install-pkg-noble-amd64
 install_ci __upcoming__ gz_sensors9-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_tools3-install-pkg-noble-amd64
 install_ci __upcoming__ gz_tools3-install_bottle-homebrew-amd64
+install_ci __upcoming__ gz_transport14-install-pkg-noble-amd64
+install_ci __upcoming__ gz_transport14-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_utils3-install-pkg-noble-amd64
 install_ci __upcoming__ gz_utils3-install_bottle-homebrew-amd64
 install_ci __upcoming__ sdformat15-install-pkg-noble-amd64


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092

Needed to make a pre-release of gz-transport14.