### PR TITLE
Ionic CI: use stable branch for gz-physics8

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -411,7 +411,7 @@ collections:
       - name: gz-physics
         major_version: 8
         repo:
-          current_branch: main
+          current_branch: gz-physics8
       - name: gz-sim
         major_version: 9
         repo:
@@ -463,6 +463,10 @@ collections:
           current_branch: main
       - name: gz-msgs
         major_version: 11
+        repo:
+          current_branch: main
+      - name: gz-physics
+        major_version: 8
         repo:
           current_branch: main
       - name: gz-plugin

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -3,6 +3,7 @@ asan_ci __upcoming__ gz_fuel_tools-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_gui-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_math-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_msgs-ci_asan-main-noble-amd64
+asan_ci __upcoming__ gz_physics-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_plugin-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_rendering-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_sensors-ci_asan-main-noble-amd64
@@ -80,7 +81,7 @@ asan_ci ionic gz_gui-ci_asan-gz-gui9-noble-amd64
 asan_ci ionic gz_launch-ci_asan-main-noble-amd64
 asan_ci ionic gz_math-ci_asan-gz-math8-noble-amd64
 asan_ci ionic gz_msgs-ci_asan-gz-msgs11-noble-amd64
-asan_ci ionic gz_physics-ci_asan-main-noble-amd64
+asan_ci ionic gz_physics-ci_asan-gz-physics8-noble-amd64
 asan_ci ionic gz_plugin-ci_asan-gz-plugin3-noble-amd64
 asan_ci ionic gz_rendering-ci_asan-gz-rendering9-noble-amd64
 asan_ci ionic gz_sensors-ci_asan-gz-sensors9-noble-amd64
@@ -104,6 +105,9 @@ branch_ci __upcoming__ gz_math-main-win
 branch_ci __upcoming__ gz_msgs-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_msgs-ci-main-noble-amd64
 branch_ci __upcoming__ gz_msgs-main-win
+branch_ci __upcoming__ gz_physics-ci-main-homebrew-amd64
+branch_ci __upcoming__ gz_physics-ci-main-noble-amd64
+branch_ci __upcoming__ gz_physics-main-win
 branch_ci __upcoming__ gz_plugin-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_plugin-ci-main-noble-amd64
 branch_ci __upcoming__ gz_plugin-main-win
@@ -349,9 +353,9 @@ branch_ci ionic gz_math-ci-gz-math8-noble-amd64
 branch_ci ionic gz_msgs-11-win
 branch_ci ionic gz_msgs-ci-gz-msgs11-homebrew-amd64
 branch_ci ionic gz_msgs-ci-gz-msgs11-noble-amd64
-branch_ci ionic gz_physics-ci-main-homebrew-amd64
-branch_ci ionic gz_physics-ci-main-noble-amd64
-branch_ci ionic gz_physics-main-win
+branch_ci ionic gz_physics-8-win
+branch_ci ionic gz_physics-ci-gz-physics8-homebrew-amd64
+branch_ci ionic gz_physics-ci-gz-physics8-noble-amd64
 branch_ci ionic gz_plugin-3-win
 branch_ci ionic gz_plugin-ci-gz-plugin3-homebrew-amd64
 branch_ci ionic gz_plugin-ci-gz-plugin3-noble-amd64
@@ -386,6 +390,8 @@ install_ci __upcoming__ gz_math8-install-pkg-noble-amd64
 install_ci __upcoming__ gz_math8-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_msgs11-install-pkg-noble-amd64
 install_ci __upcoming__ gz_msgs11-install_bottle-homebrew-amd64
+install_ci __upcoming__ gz_physics8-install-pkg-noble-amd64
+install_ci __upcoming__ gz_physics8-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_plugin3-install-pkg-noble-amd64
 install_ci __upcoming__ gz_plugin3-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_rendering9-install-pkg-noble-amd64


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092