### PR TITLE
Ionic CI: use stable branch for gz-common6

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -379,7 +379,7 @@ collections:
       - name: gz-common
         major_version: 6
         repo:
-          current_branch: main
+          current_branch: gz-common6
       - name: gz-msgs
         major_version: 11
         repo:
@@ -447,6 +447,10 @@ collections:
           current_branch: main
       - name: gz-cmake
         major_version: 4
+        repo:
+          current_branch: main
+      - name: gz-common
+        major_version: 6
         repo:
           current_branch: main
       - name: gz-fuel-tools

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -1,4 +1,5 @@
 asan_ci __upcoming__ gz_cmake-ci_asan-main-noble-amd64
+asan_ci __upcoming__ gz_common-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_fuel_tools-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_gui-ci_asan-main-noble-amd64
 asan_ci __upcoming__ gz_math-ci_asan-main-noble-amd64
@@ -75,7 +76,7 @@ asan_ci harmonic gz_transport-ci_asan-gz-transport13-jammy-amd64
 asan_ci harmonic gz_utils-ci_asan-gz-utils2-jammy-amd64
 asan_ci harmonic sdformat-ci_asan-sdf14-jammy-amd64
 asan_ci ionic gz_cmake-ci_asan-gz-cmake4-noble-amd64
-asan_ci ionic gz_common-ci_asan-main-noble-amd64
+asan_ci ionic gz_common-ci_asan-gz-common6-noble-amd64
 asan_ci ionic gz_fuel_tools-ci_asan-gz-fuel-tools10-noble-amd64
 asan_ci ionic gz_gui-ci_asan-gz-gui9-noble-amd64
 asan_ci ionic gz_launch-ci_asan-main-noble-amd64
@@ -93,6 +94,9 @@ asan_ci ionic sdformat-ci_asan-sdf15-noble-amd64
 branch_ci __upcoming__ gz_cmake-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_cmake-ci-main-noble-amd64
 branch_ci __upcoming__ gz_cmake-main-win
+branch_ci __upcoming__ gz_common-ci-main-homebrew-amd64
+branch_ci __upcoming__ gz_common-ci-main-noble-amd64
+branch_ci __upcoming__ gz_common-main-win
 branch_ci __upcoming__ gz_fuel_tools-ci-main-homebrew-amd64
 branch_ci __upcoming__ gz_fuel_tools-ci-main-noble-amd64
 branch_ci __upcoming__ gz_fuel_tools-main-win
@@ -335,9 +339,9 @@ branch_ci harmonic sdformat-sdf14-win
 branch_ci ionic gz_cmake-4-win
 branch_ci ionic gz_cmake-ci-gz-cmake4-homebrew-amd64
 branch_ci ionic gz_cmake-ci-gz-cmake4-noble-amd64
-branch_ci ionic gz_common-ci-main-homebrew-amd64
-branch_ci ionic gz_common-ci-main-noble-amd64
-branch_ci ionic gz_common-main-win
+branch_ci ionic gz_common-6-win
+branch_ci ionic gz_common-ci-gz-common6-homebrew-amd64
+branch_ci ionic gz_common-ci-gz-common6-noble-amd64
 branch_ci ionic gz_fuel_tools-10-win
 branch_ci ionic gz_fuel_tools-ci-gz-fuel-tools10-homebrew-amd64
 branch_ci ionic gz_fuel_tools-ci-gz-fuel-tools10-noble-amd64
@@ -382,6 +386,8 @@ branch_ci ionic sdformat-ci-sdf15-noble-amd64
 branch_ci ionic sdformat-sdf15-win
 install_ci __upcoming__ gz_cmake4-install-pkg-noble-amd64
 install_ci __upcoming__ gz_cmake4-install_bottle-homebrew-amd64
+install_ci __upcoming__ gz_common6-install-pkg-noble-amd64
+install_ci __upcoming__ gz_common6-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_fuel_tools10-install-pkg-noble-amd64
 install_ci __upcoming__ gz_fuel_tools10-install_bottle-homebrew-amd64
 install_ci __upcoming__ gz_gui9-install-pkg-noble-amd64


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092