### PR TITLE
Workaround to exclude false positives in GCC warning plugin

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilation.groovy
@@ -80,6 +80,7 @@ class OSRFLinuxCompilation extends OSRFLinuxBase
               filters {
                 'io.jenkins.plugins.analysis.core.filter.ExcludeFile' {
                   pattern('.*ALSA lib.*')
+                  pattern('\\d+: \\(')
                 }
               }
               isEnabledForFailure(false)


### PR DESCRIPTION
Fixes https://github.com/gazebosim/gz-sim/issues/2555