### PR TITLE
Fix release.py ssh clone URL for vendor packages

### DIFF
--- a/release.py
+++ b/release.py
@@ -558,8 +558,8 @@ def get_vendor_github_repo(package_name) -> str:
 def get_vendor_repo_url(package_name) -> str:
     # Clone needs ssh for real pushing operations. In simulation prefer https to avoid
     # unexpected pushes and facilitate testing
-    protocol = 'https://github.com/' if DRY_RUN else 'ssh://git@github.com:'
-    return f"{protocol}{get_vendor_github_repo(package_name)}"
+    protocol = 'https://github.com' if DRY_RUN else 'ssh://git@github.com'
+    return f"{protocol}/{get_vendor_github_repo(package_name)}"
 
 
 def prepare_vendor_pr_temp_workspace(package_name, ws_dir) -> Tuple[str, str, str]:


### PR DESCRIPTION
The only piece difficult to test that we changed in #1150 is failing :( 

The ssh URL is using : instead of / and makes the vendor package PR to fail. Tested in https://github.com/gazebo-release/gz_msgs_vendor/pull/4