### PR TITLE
Replace /usr/local with HOMEBREW_PREFIX part 1

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -24,7 +24,7 @@ export HOMEBREW_PREFIX=/usr/local
 export HOMEBREW_CELLAR=${HOMEBREW_PREFIX}/Cellar
 export PATH=${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:$PATH
 
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python
+export PYTHONPATH=$PYTHONPATH:${HOMEBREW_PREFIX}/lib/python
 
 # make verbose mode?
 MAKE_VERBOSE_STR=""
@@ -90,7 +90,7 @@ if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   brew install python3
   PIP=pip3
   if ! which ${PIP}; then
-    PIP=/usr/local/opt/python/bin/pip3
+    PIP=${HOMEBREW_PREFIX}/opt/python/bin/pip3
   fi
   # TODO use a python3 venv instead.
   ${PIP} install --break-system-packages ${PIP_PACKAGES_NEEDED}
@@ -98,7 +98,7 @@ fi
 
 if [[ -z "${DISABLE_CCACHE}" ]]; then
   brew install ccache
-  export PATH=/usr/local/opt/ccache/libexec:$PATH
+  export PATH=${HOMEBREW_PREFIX}/opt/ccache/libexec:$PATH
 fi
 echo '# END SECTION'
 
@@ -123,33 +123,33 @@ export DISPLAY=$(ps ax \
 CMAKE_ARGS=""
 # set CMAKE_PREFIX_PATH if we are using qt@5
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'qt@5' }.empty?"; then
-  export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/qt@5
+  export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:${HOMEBREW_PREFIX}/opt/qt@5
 fi
 # set cmake args if we are using qwt-qt5
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'qwt-qt5' }.empty?"; then
-  CMAKE_ARGS="${CMAKE_ARGS} -DQWT_WIN_INCLUDE_DIR=/usr/local/opt/qwt-qt5/lib/qwt.framework/Headers -DQWT_WIN_LIBRARY_DIR=/usr/local/opt/qwt-qt5/lib"
+  CMAKE_ARGS="${CMAKE_ARGS} -DQWT_WIN_INCLUDE_DIR=${HOMEBREW_PREFIX}/opt/qwt-qt5/lib/qwt.framework/Headers -DQWT_WIN_LIBRARY_DIR=${HOMEBREW_PREFIX}/opt/qwt-qt5/lib"
 fi
 # Workaround for cmake@3.21.4: set PATH
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'osrf/simulation/cmake@3.21.4' }.empty?"; then
-  export PATH=/usr/local/opt/cmake@3.21.4/bin:${PATH}
+  export PATH=${HOMEBREW_PREFIX}/opt/cmake@3.21.4/bin:${PATH}
 fi
 # Workaround for ffmpeg 4: set PKG_CONFIG_PATH if we are using ffmpeg@4
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'osrf/simulation/ffmpeg@4' }.empty?"; then
-  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/opt/ffmpeg@4/lib/pkgconfig
+  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${HOMEBREW_PREFIX}/opt/ffmpeg@4/lib/pkgconfig
 fi
 # Workaround for tbb@2020_u3: set CPATH, LIBRARY_PATH, and CMAKE_PREFIX_PATH
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'osrf/simulation/tbb@2020_u3' }.empty?"; then
-  export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/tbb@2020_u3
-  export CPATH=${CPATH}:/usr/local/opt/tbb@2020_u3/include
-  export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/tbb@2020_u3/lib
+  export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:${HOMEBREW_PREFIX}/opt/tbb@2020_u3
+  export CPATH=${CPATH}:${HOMEBREW_PREFIX}/opt/tbb@2020_u3/include
+  export LIBRARY_PATH=${LIBRARY_PATH}:${HOMEBREW_PREFIX}/opt/tbb@2020_u3/lib
 fi
 # if we are using gts, need to add gettext library path since it is keg-only
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'gettext' }.empty?"; then
-  export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/gettext/lib
+  export LIBRARY_PATH=${LIBRARY_PATH}:${HOMEBREW_PREFIX}/opt/gettext/lib
 fi
 # if we are using boost, need to add icu4c library path since it is keg-only
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'icu4c' }.empty?"; then
-  export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/icu4c/lib
+  export LIBRARY_PATH=${LIBRARY_PATH}:${HOMEBREW_PREFIX}/opt/icu4c/lib
 fi
 # set Python3_EXECUTABLE if this homebrew formula defines the python_cmake_arg method
 if brew ruby -e "exit '${PROJECT_FORMULA}'.f.respond_to?(:python_cmake_arg)"; then
@@ -158,13 +158,13 @@ fi
 
 # if we are using dart@6.10.0 (custom OR port), need to add dartsim library path since it is keg-only
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'osrf/simulation/dartsim@6.10.0' }.empty?"; then
-  export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/dartsim@6.10.0
-  export DYLD_FALLBACK_LIBRARY_PATH=${DYLD_FALLBACK_LIBRARY_PATH}:/usr/local/opt/dartsim@6.10.0/lib:/usr/local/opt/octomap/local
-  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/opt/dartsim@6.10.0/lib/pkgconfig
+  export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:${HOMEBREW_PREFIX}/opt/dartsim@6.10.0
+  export DYLD_FALLBACK_LIBRARY_PATH=${DYLD_FALLBACK_LIBRARY_PATH}:${HOMEBREW_PREFIX}/opt/dartsim@6.10.0/lib:${HOMEBREW_PREFIX}/opt/octomap/local
+  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${HOMEBREW_PREFIX}/opt/dartsim@6.10.0/lib/pkgconfig
 fi
 
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-      -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/${PROJECT_FORMULA}/HEAD \
+      -DCMAKE_INSTALL_PREFIX=${HOMEBREW_PREFIX}/Cellar/${PROJECT_FORMULA}/HEAD \
      ${CMAKE_ARGS} \
      ${WORKSPACE}/${PROJECT_PATH}
 echo '# END SECTION'


### PR DESCRIPTION
One of our brew build scripts has a `HOMEBREW_PREFIX` variable to represent the location where brew is installed (either `/usr/local` for Intel macOS machines or `/opt/homebrew` for arm macOS machines), but it also has many paths hard-coded to /usr/local. In preparation for supporting arm-based CI machines, use the `HOMEBREW_PREFIX` variable more widely.