### PR TITLE
Refactor build.sh initial lines and include SHELL_ON_ERRORS

### DIFF
--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -8,13 +8,11 @@ echo '# BEGIN SECTION: setup the testing enviroment'
 # Define the name to be used in docker
 export DOCKER_JOB_NAME="debian_ratt_builder"
 . "${SCRIPT_DIR}/lib/boilerplate_prepare.sh"
+. "${SCRIPT_DIR}/lib/_common_scripts.bash"
 echo '# END SECTION'
 
 cat > build.sh << DELIM
-###################################################
-# Make project-specific changes here
-#
-set -ex
+$(generate_buildsh_header)
 
 if ${USE_UNSTABLE}; then
    TARGET_DISTRO='unstable'

--- a/jenkins-scripts/docker/gz-source-generation.bash
+++ b/jenkins-scripts/docker/gz-source-generation.bash
@@ -6,11 +6,11 @@ echo '# BEGIN SECTION: setup the testing enviroment'
 # Define the name to be used in docker
 export DOCKER_JOB_NAME="source_generation_job"
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 echo '# END SECTION'
 
 cat > build.sh << DELIM
-#!/bin/bash
-set -ex
+$(generate_buildsh_header)
 
 PKG_DIR=\$WORKSPACE/pkgs
 SOURCES_DIR=\$WORKSPACE/sources

--- a/jenkins-scripts/docker/lib/_common_scripts.bash
+++ b/jenkins-scripts/docker/lib/_common_scripts.bash
@@ -1,1 +1,14 @@
 export APT_INSTALL="sudo DEBIAN_FRONTEND=noninteractive apt-get install -y"
+
+generate_buildsh_header()
+{
+  SHELL_ON_ERRORS=${SHELL_ON_ERRORS:-false}
+  echo "#!/bin/bash"
+  echo "set -ex"
+  if ${SHELL_ON_ERRORS}; then
+    echo 'trap "/bin/bash" 0 INT QUIT ABRT PIPE TERM'
+  fi
+  if $GENERIC_ENABLE_TIMING; then
+    echo "source ${TIMING_DIR}/_time_lib.sh ${WORKSPACE}"
+  fi
+}

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -19,13 +19,10 @@ fi
 [[ -z $GENERIC_ENABLE_CPPCHECK ]] && GENERIC_ENABLE_CPPCHECK=true
 [[ -z $GENERIC_ENABLE_TESTS ]] && GENERIC_ENABLE_TESTS=true
 
-cat > build.sh << DELIM_HEADER
-#!/bin/bash
-set -ex
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 
-if $GENERIC_ENABLE_TIMING; then
-  source ${TIMING_DIR}/_time_lib.sh ${WORKSPACE}
-fi
+cat > build.sh << DELIM_HEADER
+$(generate_buildsh_header)
 DELIM_HEADER
 
 # Process the source build of dependencies if needed

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -49,6 +49,10 @@ source ${SCRIPT_DIR}/../lib/boilerplate_timing_prepare.sh
 init_stopwatch TOTAL_TIME
 init_stopwatch CREATE_TESTING_ENVIROMENT
 
+# Enable shell on errors is designed to help debuging but never
+# to be run on Jenkins.
+SHELL_ON_ERRORS=${SHELL_ON_ERRORS:-false}
+
 # Default values - Provide them is prefered
 if [ -z ${DISTRO} ]; then
     DISTRO=bionic

--- a/jenkins-scripts/docker/lib/debbuild-backport.bash
+++ b/jenkins-scripts/docker/lib/debbuild-backport.bash
@@ -12,13 +12,10 @@ fi
 export ENABLE_REAPER=false
 
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 
 cat > build.sh << DELIM
-###################################################
-# Make project-specific changes here
-#
-#!/usr/bin/env bash
-set -ex
+$(generate_buildsh_header)
 
 cd $WORKSPACE/build
 

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -20,14 +20,11 @@ fi
 export ENABLE_REAPER=false
 
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 . ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 
 cat > build.sh << DELIM
-###################################################
-# Make project-specific changes here
-#
-#!/usr/bin/env bash
-set -ex
+$(generate_buildsh_header)
 
 cd $WORKSPACE/build
 

--- a/jenkins-scripts/docker/lib/debbuild-bloom-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-bloom-base.bash
@@ -23,14 +23,11 @@ export ENABLE_REAPER=false
 PACKAGE_UNDERSCORE_NAME=${PACKAGE//-/_}
 
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 . ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 
 cat > build.sh << DELIM
-###################################################
-# Make project-specific changes here
-#
-#!/usr/bin/env bash
-set -ex
+$(generate_buildsh_header)
 
 cd $WORKSPACE/build
 

--- a/jenkins-scripts/docker/lib/debian-git-repo-base.bash
+++ b/jenkins-scripts/docker/lib/debian-git-repo-base.bash
@@ -5,6 +5,7 @@
 export ENABLE_REAPER=false
 
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 . ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 
 # The git plugin leaves a repository copy with a detached HEAD
@@ -26,11 +27,7 @@ if [[ -z ${BRANCH} ]]; then
 fi
 
 cat > build.sh << DELIM
-###################################################
-# Make project-specific changes here
-#
-#!/usr/bin/env bash
-set -ex
+$(generate_buildsh_header)
 
 if ${CLONE_NEEDED}; then
 echo '# BEGIN SECTION: clone the git repo'

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -143,9 +143,12 @@ if [[ -z ${OSRF_REPOS_TO_USE} ]]; then
   fi
 fi
 
+# Enable shell on errors is designed to help debuging but never
+# to be run on Jenkins.
+SHELL_ON_ERRORS=${SHELL_ON_ERRORS:-false}
+
 echo '# BEGIN SECTION: create the Dockerfile'
 cat > Dockerfile << DELIM_DOCKER
-#!/bin/bash
 #######################################################
 # Docker file to run build.sh
 

--- a/jenkins-scripts/docker/lib/gazebo_ros_pkgs-check-release.bash
+++ b/jenkins-scripts/docker/lib/gazebo_ros_pkgs-check-release.bash
@@ -9,6 +9,7 @@ export ENABLE_REAPER=false
 
 DOCKER_JOB_NAME="gazebo_ros_pkgs_ci"
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 . ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 
 ROS_SETUP_PREINSTALL_HOOK="""
@@ -20,7 +21,8 @@ ${GAZEBO_MODEL_INSTALLATION}
 
 if ${ROS2}; then
 cat > build.sh << DELIM_CHECKOUT
-set -ex
+$(generate_buildsh_header)
+
 source /opt/ros/${ROS_DISTRO}/setup.bash
 TEST_TIMEOUT=90
 
@@ -36,10 +38,7 @@ fi
 DELIM_CHECKOUT
 else
 cat > build.sh << DELIM_CHECKOUT
-###################################################
-# Make project-specific changes here
-#
-set -ex
+$(generate_buildsh_header)
 
 [[ -d ${WORKSPACE}/gazebo_ros_demos ]] && rm -fr ${WORKSPACE}/gazebo_ros_demos
 git clone https://github.com/ros-simulation/gazebo_ros_demos ${WORKSPACE}/gazebo_ros_demos

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -25,6 +25,7 @@ echo '# BEGIN SECTION: setup the testing enviroment'
 # Define the name to be used in docker
 DOCKER_JOB_NAME="abi_job"
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 echo '# END SECTION'
 
 # Could be empty, just fine
@@ -44,12 +45,7 @@ if [[ "${NEED_C17_COMPILER}" == "true" ]]; then
 fi
 
 cat > build.sh << DELIM
-#!/bin/bash
-
-###################################################
-# Make project-specific changes here
-#
-set -ex
+$(generate_buildsh_header)
 
 if [ `expr length "${ABI_JOB_PRECHECKER_HOOK} "` -gt 1 ]; then
 echo '# BEGIN SECTION: running pre ABI hook'

--- a/jenkins-scripts/docker/lib/generic-install-base.bash
+++ b/jenkins-scripts/docker/lib/generic-install-base.bash
@@ -9,12 +9,7 @@ DOCKER_JOB_NAME="install_job"
 echo '# END SECTION'
 
 cat > build.sh << DELIM
-#!/bin/bash
-
-###################################################
-# Make project-specific changes here
-#
-set -ex
+$(generate_buildsh_header)
 
 if [ `expr length "${INSTALL_JOB_PREINSTALL_HOOK} "` -gt 1 ]; then
 echo '# BEGIN SECTION: running pre install hook'

--- a/jenkins-scripts/docker/lib/gzdev-base-linux.bash
+++ b/jenkins-scripts/docker/lib/gzdev-base-linux.bash
@@ -1,14 +1,12 @@
 echo '# BEGIN SECTION: setup the testing enviroment'
 export DOCKER_JOB_NAME="gzdev"
 . "${SCRIPT_DIR}/lib/boilerplate_prepare.sh"
+. "${SCRIPT_DIR}/lib/_common_scripts.bash"
+. "${SCRIPT_DIR}/lib/_install_nvidia_docker.sh"
 echo '# END SECTION'
 
-. ${SCRIPT_DIR}/lib/_install_nvidia_docker.sh
-
 cat > build.sh << DELIM
-###################################################
-#
-set -ex
+$(generate_buildsh_header)
 
 export MAKE_JOBS=${MAKE_JOBS}
 export DISPLAY=${DISPLAY}


### PR DESCRIPTION
The PR mainly implement the option to use `SHELL_ON_ERRORS` variable to define a trap in the `build.sh` script that will allow a local run of it that permits the jump into a shell inside the container if something fails. Relevant lines are in `jenkins-scripts/docker/lib/_common_scripts.bash`. This should help with #923 .

To avoid code duplication all over the place the PR also refactor the creation of the initial lines in `build.sh` to be in a single function include shebang, SHELL_ON_ERRORS, set -ex and timing.

Tested it in: [![Build Status](https://build.osrfoundation.org/job/gz_msgs-ci-pr_any-noble-amd64/43/badge/icon)](https://build.osrfoundation.org/job/gz_msgs-ci-pr_any-noble-amd64/43/)