### PR TITLE
brew CI: upgrade when installing pip packages

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -93,7 +93,7 @@ if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
     PIP=${HOMEBREW_PREFIX}/opt/python/bin/pip3
   fi
   # TODO use a python3 venv instead.
-  ${PIP} install --break-system-packages ${PIP_PACKAGES_NEEDED}
+  ${PIP} install --break-system-packages --upgrade ${PIP_PACKAGES_NEEDED}
 fi
 
 if [[ -z "${DISABLE_CCACHE}" ]]; then


### PR DESCRIPTION
Needed to fix protobuf version errors. For example:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-gz-transport14-homebrew-amd64&build=24)](https://build.osrfoundation.org/job/gz_transport-ci-gz-transport14-homebrew-amd64/24/) https://build.osrfoundation.org/job/gz_transport-ci-gz-transport14-homebrew-amd64/24/

~~~
102: ==================================== ERRORS ====================================
102: __________ ERROR collecting gz-transport/python/test/options_TEST.py ___________
102: ../../gz-transport/python/test/options_TEST.py:1: in <module>
102:     from gz.msgs11.stringmsg_pb2 import StringMsg
102: /usr/local/lib/python/gz/msgs11/stringmsg_pb2.py:12: in <module>
102:     _runtime_version.ValidateProtobufRuntimeVersion(
102: /Users/jenkins/Library/Python/3.13/lib/python/site-packages/google/protobuf/runtime_version.py:106: in ValidateProtobufRuntimeVersion
102:     _ReportVersionError(
102: /Users/jenkins/Library/Python/3.13/lib/python/site-packages/google/protobuf/runtime_version.py:47: in _ReportVersionError
102:     raise VersionError(msg)
102: E   google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading gz/msgs/stringmsg.proto: gencode 5.28.3 runtime 5.28.2. Runtime version cannot be older than the linked gencode version. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.
102: - generated xml file: /Users/jenkins/jenkins-agent/workspace/gz_transport-ci-gz-transport14-homebrew-amd64/build/test_results/options_TEST.xml -
102: =========================== short test summary info ============================
102: ERROR ../../gz-transport/python/test/options_TEST.py - google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading gz/msgs/stringmsg.proto: gencode 5.28.3 runtime 5.28.2. Runtime version cannot be older than the linked gencode version. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.
102: !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
102: =============================== 1 error in 0.11s ===============================
102/102 Test #102: options_TEST.py ........................................***Failed    0.28 sec
~~~

When running `pip install protobuf`:

~~~
+ pip3 install --break-system-packages pytest protobuf
Requirement already satisfied: pytest in /Users/jenkins/Library/Python/3.13/lib/python/site-packages (8.3.3)
Requirement already satisfied: protobuf in /Users/jenkins/Library/Python/3.13/lib/python/site-packages (5.28.2)
Requirement already satisfied: iniconfig in /Users/jenkins/Library/Python/3.13/lib/python/site-packages (from pytest) (2.0.0)
Requirement already satisfied: packaging in /Users/jenkins/Library/Python/3.13/lib/python/site-packages (from pytest) (24.1)
Requirement already satisfied: pluggy<2,>=1.5 in /Users/jenkins/Library/Python/3.13/lib/python/site-packages (from pytest) (1.5.0)
~~~

Using `--upgrade` with `pip install` should upgrade outdated packages, which should fix these protobuf errors.

Testing with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-gz-transport14-homebrew-amd64&build=25)](https://build.osrfoundation.org/job/gz_transport-ci-gz-transport14-homebrew-amd64/25/) https://build.osrfoundation.org/job/gz_transport-ci-gz-transport14-homebrew-amd64/25/