### PR TITLE
brew CI: use python venv for pip installs

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -88,6 +88,7 @@ fi
 
 if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   brew install python3
+  rm -rf ${WORKSPACE}/venv
   python3 -m venv ${WORKSPACE}/venv
   . ${WORKSPACE}/venv/bin/activate
   pip3 install ${PIP_PACKAGES_NEEDED}

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -88,12 +88,9 @@ fi
 
 if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   brew install python3
-  PIP=pip3
-  if ! which ${PIP}; then
-    PIP=${HOMEBREW_PREFIX}/opt/python/bin/pip3
-  fi
-  # TODO use a python3 venv instead.
-  ${PIP} install --break-system-packages ${PIP_PACKAGES_NEEDED}
+  python3 -m venv ${WORKSPACE}/venv
+  . ${WORKSPACE}/venv/bin/activate
+  pip3 install ${PIP_PACKAGES_NEEDED}
 fi
 
 if [[ -z "${DISABLE_CCACHE}" ]]; then


### PR DESCRIPTION
Alternative to https://github.com/gazebo-tooling/release-tools/pull/1193.

This should ensure that freshly installed `pip` packages are used.

Test with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-gz-transport14-homebrew-amd64&build=27)](https://build.osrfoundation.org/job/gz_transport-ci-gz-transport14-homebrew-amd64/27/) https://build.osrfoundation.org/job/gz_transport-ci-gz-transport14-homebrew-amd64/27/