### PR TITLE
brew CI: use correct python and set PYTHONPATH

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -88,6 +88,8 @@ fi
 
 if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   brew install python3
+  # reset command hash since python3 has already been invoked in this script
+  hash -r
   rm -rf ${WORKSPACE}/venv
   python3 -m venv ${WORKSPACE}/venv
   . ${WORKSPACE}/venv/bin/activate

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -94,6 +94,11 @@ if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   python3 -m venv ${WORKSPACE}/venv
   . ${WORKSPACE}/venv/bin/activate
   pip3 install ${PIP_PACKAGES_NEEDED}
+  # For python 3.X, our formulae install python bindings to
+  # ${HOMEBREW_PREFIX}/lib/python3.X/site-packages
+  # so add that folder to PYTHONPATH
+  python_minor_version=$(python3 -c 'import sys; print(sys.version_info[1])')
+  export PYTHONPATH=${HOMEBREW_PREFIX}/lib/python3.$python_minor_version/site-packages:$PYTHONPATH
 fi
 
 if [[ -z "${DISABLE_CCACHE}" ]]; then


### PR DESCRIPTION
Follow-up to #1194:

* https://github.com/gazebo-tooling/release-tools/commit/ad0867bc76c415e93756f74e40b4f9663f1635e3: use `hash -r` to ensure that we use the correct `python3` executable
* https://github.com/gazebo-tooling/release-tools/commit/55fc23a7c1a9a486c5d83bf87dfb46dd2090899b: add the brew python3's site-packages to `PYTHONPATH` so we can use the installed python bindings from gazebo formulae

### without this branch:

* python test failures: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdf15-homebrew-amd64&build=23)](https://build.osrfoundation.org/job/sdformat-ci-sdf15-homebrew-amd64/23/) https://build.osrfoundation.org/job/sdformat-ci-sdf15-homebrew-amd64/23/

### with this branch

* clean: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdf15-homebrew-amd64&build=25)](https://build.osrfoundation.org/job/sdformat-ci-sdf15-homebrew-amd64/25/) https://build.osrfoundation.org/job/sdformat-ci-sdf15-homebrew-amd64/25/