### PR TITLE
release.py: Use correct base branch when creating vendor package PRs

### DIFF
--- a/release.py
+++ b/release.py
@@ -562,7 +562,7 @@ def get_vendor_repo_url(package_name) -> str:
     return f"{protocol}/{get_vendor_github_repo(package_name)}"
 
 
-def prepare_vendor_pr_temp_workspace(package_name, ws_dir) -> Tuple[str, str, str]:
+def prepare_vendor_pr_temp_workspace(package_name, ros_distro, ws_dir) -> Tuple[str, str, str]:
     gz_vendor_tool = os.path.join(ws_dir, "gz_vendor")
     # Create virtualenv for vendor dependencies
     venv_dir = os.path.join(ws_dir, "venv")
@@ -575,7 +575,7 @@ def prepare_vendor_pr_temp_workspace(package_name, ws_dir) -> Tuple[str, str, st
            gz_vendor_tool]
     _, _err_tool = check_call(cmd, IGNORE_DRY_RUN)
     gz_vendor_repo = os.path.join(ws_dir, 'gz_vendor_repo')
-    cmd = ['git', 'clone', '-q',
+    cmd = ['git', 'clone', '-q', '-b', ros_distro,
            get_vendor_repo_url(package_name),
            gz_vendor_repo]
     _, _err_repo = check_call(cmd, IGNORE_DRY_RUN)
@@ -656,7 +656,7 @@ def create_pr_in_gz_vendor_repo(args, ros_distro) -> str:
         ws_dir = tempfile.mkdtemp()
         # Prepare the temporary workspace
         vendor_tool_path, vendor_repo_path, venv_dir = \
-            prepare_vendor_pr_temp_workspace(args.package, ws_dir)
+            prepare_vendor_pr_temp_workspace(args.package, ros_distro, ws_dir)
         # Run updating script on the temporary workspace
         execute_update_vendor_package_tool(
             vendor_tool_path, vendor_repo_path, venv_dir)


### PR DESCRIPTION
When creating vendor packages for Harmonic versions, the script starts from the default branch instead of the branch that corresponds to the matching ROS version. Here's an example of an incorrect PR https://github.com/gazebo-release/gz_sim_vendor/pull/6