### PR TITLE
brew CI: prepend venv site-packages to PYTHONPATH

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -99,6 +99,9 @@ if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   # so add that folder to PYTHONPATH
   python_minor_version=$(python3 -c 'import sys; print(sys.version_info[1])')
   export PYTHONPATH=${HOMEBREW_PREFIX}/lib/python3.$python_minor_version/site-packages:$PYTHONPATH
+  # also add the venv site-packages to PYTHONPATH
+  # this seems to be needed by the gz-sim python system loader test
+  export PYTHONPATH=${WORKSPACE}/venv/lib/python3.$python_minor_version/site-packages:$PYTHONPATH
 fi
 
 if [[ -z "${DISABLE_CCACHE}" ]]; then


### PR DESCRIPTION
The gz-sim python system loader integration test is having trouble finding the protobuf python bindings, which are installed in a python virtual environment as of #1194.

## Without this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-ci-gz-sim9-homebrew-amd64&build=30)](https://build.osrfoundation.org/job/gz_sim-ci-gz-sim9-homebrew-amd64/30/) https://build.osrfoundation.org/job/gz_sim-ci-gz-sim9-homebrew-amd64/30/

Excerpt from python system loader test log:

~~~
309: [ RUN      ] PythonSystemLoaderTest.LoadMultipleSystems
309: (2024-11-10 12:40:35.172) [info] [Server.cc:145] Loading SDF world file[/Users/jenkins/jenkins-agent/workspace/gz_sim-ci-gz-sim9-homebrew-amd64/gz-sim/test/worlds/python_system_loader.sdf].
309: (2024-11-10 12:40:35.339) [info] [SystemManager.cc:54] Serving entity system service on [/entity/system/add]
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:107] Error while loading module test_model_system
309: ModuleNotFoundError: No module named 'google'
309: 
309: At:
309:   /usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/gz/msgs11/pose_pb2.py(7): <module>
309:   <frozen importlib._bootstrap>(488): _call_with_frames_removed
309:   <frozen importlib._bootstrap_external>(1022): exec_module
309:   <frozen importlib._bootstrap>(950): _load_unlocked
309:   <frozen importlib._bootstrap>(1334): _find_and_load_unlocked
309:   <frozen importlib._bootstrap>(1360): _find_and_load
309:   /Users/jenkins/jenkins-agent/workspace/gz_sim-ci-gz-sim9-homebrew-amd64/gz-sim/python/test/plugins/test_model_system.py(24): <module>
309:   <frozen importlib._bootstrap>(488): _call_with_frames_removed
309:   <frozen importlib._bootstrap_external>(1022): exec_module
309:   <frozen importlib._bootstrap>(950): _load_unlocked
309:   <frozen importlib._bootstrap>(1333): _find_and_load_unlocked
309:   <frozen importlib._bootstrap>(1360): _find_and_load
309: 
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:110] Searched in:
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   ""
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/usr/local/Cellar/gz-sim9/HEAD/lib/python"
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python313.zip"
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13"
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/lib-dynload"
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages"
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/Users/jenkins/jenkins-agent/workspace/gz_sim-ci-gz-sim9-homebrew-amd64/build/test/fake_home/.gz/sim/plugins/"
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/usr/local/Cellar/gz-sim9/HEAD/lib/gz-sim-9/plugins/"
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/Users/jenkins/jenkins-agent/workspace/gz_sim-ci-gz-sim9-homebrew-amd64/gz-sim/python/test/plugins/"
309: (2024-11-10 12:40:37.214) [error] [PythonSystemLoader.cc:113]   "/Users/jenkins/jenkins-agent/workspace/gz_sim-ci-gz-sim9-homebrew-amd64/gz-sim/python/test"
309: (2024-11-10 12:40:37.214) [debug] [SystemManager.cc:80] Loaded system [gz::sim::systems::PythonSystemLoader] for entity [4]
~~~

## With this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-ci-gz-sim9-homebrew-amd64&build=31)](https://build.osrfoundation.org/job/gz_sim-ci-gz-sim9-homebrew-amd64/31/) https://build.osrfoundation.org/job/gz_sim-ci-gz-sim9-homebrew-amd64/31/

Actually the same error message, which I think is because the `PYTHONPATH` is not preserved by the test:

~~~
309: Environment variables: 
309:  PYTHONPATH=/usr/local/Cellar/gz-sim9/HEAD/lib/python/
309: Test timeout computed to be: 240
309: Running main() from /Users/jenkins/jenkins-agent/workspace/gz_sim-ci-gz-sim9-homebrew-amd64/gz-sim/test/gtest_vendor/src/gtest_main.cc
309: [==========] Running 1 test from 1 test suite.
309: [----------] Global test environment set-up.
309: [----------] 1 test from PythonSystemLoaderTest
309: [ RUN      ] PythonSystemLoaderTest.LoadMultipleSystems
~~~

I think https://github.com/gazebosim/gz-sim/pull/2673 (which preserves the PYTHONPATH) and this PR are both needed to fix the test failure.