### PR TITLE
Conda legacy env: use vs2019 package and fixed versions

### DIFF
--- a/conda/envs/legacy/pixi.lock
+++ b/conda/envs/legacy/pixi.lock
@@ -8,17 +8,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.7.1-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.1-h8343317_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-hec4eb1f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-heb4867d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.3.1-hbdc6101_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.28.3-hcfe8598_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_0.conda
@@ -45,8 +46,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.4-py39h9399b63_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cppzmq-4.10.0-h2e2a08d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cppzmq-4.10.0-h7e20d1c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.8.0-he654da7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dartsim-6.13.2-hdf3b901_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
@@ -57,46 +58,48 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-hadc09e8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_hbb807a5_703.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h3ef53d8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_hf3b701a_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h54ed35b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.2.1-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h4b96d29_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.3-py39h2b1cf14_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.8.0-py39h41b90d8_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.1-hf074850_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.2-h44428e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.4-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.4-hfc55251_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyhd81877a_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.11-hfc55251_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h1220068_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jsoncpp-1.9.6-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hf8d3e68_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
@@ -104,26 +107,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-hb8260a3_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-hba137d9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.86.0-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.3-default_hb5137d0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.3-default_h9c6a7e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h127d8a8_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h5d6823c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libdrm-cos7-x86_64-2.4.97-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
@@ -132,15 +134,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.3-hd5b9bfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.8.0-h4d9a814_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.4-h783c2da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-core-devel-cos7-x86_64-1.0.1-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-cos7-x86_64-1.0.1-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-devel-cos7-x86_64-1.0.1-ha675448_1106.tar.bz2
@@ -148,63 +149,64 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-gles-cos7-x86_64-1.0.1-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-glx-cos7-x86_64-1.0.1-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-opengl-cos7-x86_64-1.0.1-ha675448_1106.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_he43201b_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h01aab08_1018.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.3-ha7bfdaf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libode-0.16.2-h3d6467e_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h5c8f2c3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h5c8f2c3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h6481b9d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.2.0-h2e90f83_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.2.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2023.2.0-hd5fc58b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2023.2.0-h3ecfda7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2023.2.0-h2e90f83_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2023.2.0-h2e90f83_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2023.2.0-h3ecfda7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2023.2.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2023.2.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2023.2.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.2.0-hfe87413_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.2.0-h59595ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.3-hca62329_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-3.14.0-h780b84a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.1-h2a13503_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h8917695_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h72606ae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.7-h2774228_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.49.2-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-h4ab18f5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebsockets-4.3.3-ha6cc734_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.4-hb346dea_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h662e7e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-hc051c1a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h4ab18f5_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-khr-devel-cos7-x86_64-18.3.4-ha675448_1106.tar.bz2
@@ -214,33 +216,38 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libgl-cos7-x86_64-18.3.4-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libgl-devel-cos7-x86_64-18.3.4-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libglapi-cos7-x86_64-18.3.4-ha675448_1106.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.6-h9d307f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.100-hca3bf56_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py39h474f0d3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/octomap-1.9.8-h924138e_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-1.10.12.1-h21539af_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-1.10.12.1-hfa30d70_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-next-2.2.6-hd9d6a18_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.1-hccdc605_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.2.2-haf962dd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-5.28.2-py39hf88036b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-23.11.0-h590f24d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.3-h8e811e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.3.0-h1d62c97_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-3.14.0-py39he80948d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh1ec8472_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh415d2e4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
@@ -248,85 +255,88 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.3-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.20-h13acc7a_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.19-h0755675_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-5_cp39.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py39h8cd3c5a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h374914d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h5810be5_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qwt-6.3.0-h7c222af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.5-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.2.2-h40894ad_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.2.2-h983345b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.28.5-h77f46ba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-hdb0a2a9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.13.0-hd2e6256_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/swig-4.3.0-heed6a68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.46.0-h6d4b2fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.8.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/swig-4.2.0-h1bc8f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.0.0-hceb3a55_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.16.3-hf0b6e87_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024b-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-h7fd8c06_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vcstool-0.3.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vulkan-headers-1.3.231.1-h924138e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-hac6953d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.42-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-hb9d3cd8_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-hb9d3cd8_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.14-h7f98852_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.2.1-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.0-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.1.3-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-randrproto-1.5.0-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-hb9d3cd8_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1005.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-hb9d3cd8_1008.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.4-h9c3ff4c_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4ab18f5_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-h27826a3_1.tar.bz2
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.7.1-h0425590_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.1-h0b8f51a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hd2997c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.5-h2f3a684_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bullet-cpp-3.25-py39h645c48f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.3-ha64f414_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cfitsio-4.3.1-hf28c5f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.28.3-hef020d8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_0.conda
@@ -353,8 +363,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.6.4-py39h36a3f59_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppzmq-4.10.0-hf1bdad7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.10.1-h3ec0cbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppzmq-4.10.0-hb912365_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.8.0-h7daf2e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dartsim-6.13.2-hb8f669c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
@@ -365,45 +375,47 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.4-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fcl-0.7.0-h31587c3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.0-gpl_hb5dfa50_703.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-h7e74b68_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_hed0588d_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-hba58ff8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-10.2.1-h2a328a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.15.0-h8dda3cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h6cb32c8_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h57e7d35_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h5428426_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.9.3-py39h70a7a3d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-ha61d561_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.13.0-h5ad3122_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geotiff-1.7.3-h17a0a10_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.8.0-py39h28251d5_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.12.1-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geotiff-1.7.1-he43841b_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.2-hc486b8e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.2-h78ca943_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.78.4-hd84c7bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.78.4-hd84c7bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h2f0025b_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h6d82d15_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h13f6c1a_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_hd1676c9_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyhd81877a_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.11-hd84c7bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.18-hd4cd8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.17-hf9262ea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jsoncpp-1.9.6-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/kealib-1.5.3-h8fde926_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
@@ -411,26 +423,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.16-h922389a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.7.4-h2c0effa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-25_linuxaarch64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.84.0-hcc9b45e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.84.0-hb41fec8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.86.0-h8af1aa0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-25_linuxaarch64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libccd-double-2.1-h2f0025b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.3-default_he324ac1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.3-default_h4390ef5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_hb368394_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf9b4efe_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.8.0-h4e8248e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.19-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libdrm-cos7-aarch64-2.4.97-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.4-h5ad3122_0.conda
@@ -439,15 +449,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.9.3-h80360e1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-3.8.0-h18a4eec_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.78.4-h311d5f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-core-devel-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-devel-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
@@ -455,59 +464,60 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-gles-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-glx-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-opengl-cos7-aarch64-1.0.1-ha675448_1106.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.2-default_hab9fc21_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libkml-1.3.0-h62bc5a7_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libkml-1.3.0-h7d16752_1018.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-25_linuxaarch64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.3-h2edbd07_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h9180261_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libode-0.16.2-py39h387a81e_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h0b9eccb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.28-pthreads_h9d3fd7e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-haa99d6a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-haa99d6a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-he24a241_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2023.2.0-h3e0449b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2023.2.0-h3e0449b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2023.2.0-h2f0025b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2023.2.0-hd429f41_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2023.2.0-hc6dd956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2023.2.0-hc6dd956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2023.2.0-h2f0025b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2023.2.0-h2f0025b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2023.2.0-h2f0025b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2023.2.0-hf7f7b40_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2023.2.0-h2f0025b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.2-h029595c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.3-hf20323b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h00090f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-hbcf326e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.3-hcf0348d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-3.14.0-hc71ff50_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.1-hb6ba311_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-hd8968fb_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.20-h68df207_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspatialite-5.1.0-h08d9e07_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.47.0-hc4a20ef_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.18-hb9de7d4_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspatialite-5.1.0-h78899c2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.0-hf51ef55_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-256.7-hd54d049_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-h1708d11_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.49.2-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.13.4-hf4efe5d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h49dc7a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.10.1-h4156a30_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h68df207_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lzo-2.10-h31becfc_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-khr-devel-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
@@ -517,32 +527,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libgl-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libgl-devel-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libglapi-cos7-aarch64-18.3.4-ha675448_1106.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/minizip-4.0.7-h77a9e90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/minizip-4.0.6-h8bbf78b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.9-h65af167_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.0.33-hb6794ad_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.0.33-hf629957_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.106-hcffee33_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.100-h8c4e863_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py39h91c28bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/octomap-1.9.8-hdd96247_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-1.10.12.1-hacfc540_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-1.10.12.1-h70aca81_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-next-2.2.6-hbad1a05_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.1-haace395_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-hdf561d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.0-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.2-h0d9d63b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.4.0-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.54.0-h7579590_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.42-hd0f9c67_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hb9de7d4_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.5.0-h07e4b22_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/protobuf-5.28.2-py39h7dbf29c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/poppler-23.11.0-h3cd87ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/postgresql-16.3-h2294c5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.3.0-h7b42f86_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/protobuf-3.14.0-py39h99ab00b_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-16.1-h729494f_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh1ec8472_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh415d2e4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
@@ -550,28 +564,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.3-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.9.20-h4a649e4_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.9.19-h4ac3b42_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.9-5_cp39.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.2-py39h060674a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h3c8598d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5992497_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qwt-6.3.0-h473b47b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.5-h86ecc28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.2.2-ha7facd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.2.2-hcdc5f17_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.28.5-h4e7748e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-h8d0c38d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spdlog-1.13.0-h6b8df57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.47.0-h578a6b9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.3.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.46.0-hdc7ab3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.0.0-h243be18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tiledb-2.16.3-hdb54b9b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-10.0.0-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tzcode-2024b-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-4.0.1-h8d8f337_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.1.2-h17cf362_0.conda
@@ -579,19 +595,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/vcstool-0.3.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xerces-c-3.2.5-h595f43b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.0-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.9-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.1-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xerces-c-3.2.5-hf13c1fb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h57736b2_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-h055a233_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
@@ -600,26 +616,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.0-h57736b2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h57736b2_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zeromq-4.3.5-h5efb499_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zeromq-4.3.4-h01db608_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h68df207_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-hd8af866_1.tar.bz2
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.1-h0dbab56_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hbd69f2e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-h0a2e257_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.3.1-h9b0cee5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.28.3-hf0feee3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cmake-0.2.28-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/colcon-common-extensions-0.3.0-py39hcbf5309_2.conda
@@ -643,8 +660,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/console_bridge-1.0.2-h5362a0b_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.6.4-py39hf73967f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cppzmq-4.10.0-h42135b4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/curl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cppzmq-4.10.0-h449d27f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/curl-8.8.0-h0dd56e1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-6.13.2-h56f4d5f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_0.conda
@@ -653,106 +670,117 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.4-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-he22821c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-7.1.0-gpl_h89ca9b9_703.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-h8958603_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_h66c0b5b_108.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-hf9aaf8f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-10.2.1-h181d51b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/freeimage-3.18.0-h8310ca0_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freeimage-3.18.0-h2b56e36_20.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.3-py39h96760b6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.42.12-hed59a49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.8.0-py39hbe60bc6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.1-h1537add_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-hcf4a93f_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h5a7288d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-he0c23c2_1005.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.2-h7025463_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.2-h4394cf3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.4-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.4-h12be248_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.3.0-h7ab893a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyhef2d1d4_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.11-h12be248_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jsoncpp-1.9.6-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-h6c43f9b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h444863b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h9a677ad_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.86.0-h57928b3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libccd-double-2.1-h63175ca_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.3-default_ha5278ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_h3a3e6c3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_hf64faad_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.8.0-hd5e4a3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.3-h042995d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.8.0-h0791e23_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.4-h16e383f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-haf3e7a6_1018.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.2-h99910a6_14.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libraw-0.21.3-h0f5434b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/librsvg-2.58.4-h33bc1f6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.3-hab9416b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-3.14.0-h7755175_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libraw-0.21.1-h5557f11_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h94c4f80_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h7bd4b97_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.49.2-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.4-h442d1da_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h283a6d9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-h2466b09_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py39hddb5d58_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/octomap-1.9.8-h91493d7_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-h58a323e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-hc646683_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-next-2.2.6-h606bb5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.1-h974021d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h72640d8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-hbb871f6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.42-h17e33f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h2bf4dc2_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/protobuf-5.28.2-py39ha51f57c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-23.11.0-hc2f3c52_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.3-h7f155c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.3.0-he13c7e8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/protobuf-3.14.0-py39h415ef7b_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh1ec8472_2.conda
@@ -763,22 +791,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.3-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.9.20-hfaddaf0_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.9.19-h4de0772_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.9-5_cp39.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py39ha51f57c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py39ha55e580_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h264fbc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_19.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qwt-6.3.0-h9417a65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruby-3.2.2-hc493ab1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruby-3.2.2-h20ad4f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.13.0-h64d2f7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.0.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.16.3-h1ffc264_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-10.0.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
@@ -792,16 +821,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vcstool-0.3.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.4-h0e60522_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-h2466b09_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zziplib-0.13.69-h3ca93ac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zziplib-0.13.69-h1d00b33_1.tar.bz2
 packages:
 - kind: conda
   name: _libgcc_mutex
@@ -879,50 +910,50 @@ packages:
   timestamp: 1718118473054
 - kind: conda
   name: aom
-  version: 3.9.1
-  build: hac33072_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
-  sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
-  md5: 346722a0be40f6edc53f12640d301338
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2706396
-  timestamp: 1718551242397
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: hcccb83c_0
+  version: 3.7.1
+  build: h0425590_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
-  sha256: ac438ce5d3d3673a9188b535fc7cda413b479f0d52536aeeac1bd82faa656ea0
-  md5: cc744ac4efe5bcaa8cca51ff5b850df0
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.7.1-h0425590_0.conda
+  sha256: 51ad9b31ff6d3cfb46ec02fd7f8669570c9414e8240e1acb22496968260c8ec0
+  md5: 53d2bb9e853b5d9bf87130dba70a6b9d
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 3250813
-  timestamp: 1718551360260
+  size: 2938408
+  timestamp: 1700530384923
 - kind: conda
   name: aom
-  version: 3.9.1
-  build: he0c23c2_0
+  version: 3.7.1
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.7.1-h59595ed_0.conda
+  sha256: 57ad60805ffc7097a690d6d0e07ba432a3dae187158e13001c392177358478f9
+  md5: 504e70332b8322cda93b7bceb5925fca
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2688122
+  timestamp: 1700530526866
+- kind: conda
+  name: aom
+  version: 3.8.2
+  build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
-  sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
-  md5: 3d7c14285d3eb3239a76ff79063f27a5
+  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.2-h63175ca_0.conda
+  sha256: dd79f4e3660ab169f4e2d9bf2d9e74001dcf6dfaa8d1168373b3450af5282286
+  md5: 6691dd6833a29c95e3a16e08841a0f43
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
   license_family: BSD
-  size: 1958151
-  timestamp: 1718551737234
+  size: 1968537
+  timestamp: 1710388705950
 - kind: conda
   name: argcomplete
   version: 3.5.1
@@ -1025,62 +1056,65 @@ packages:
   timestamp: 1660065534958
 - kind: conda
   name: blosc
-  version: 1.21.6
-  build: h85f69ea_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
-  sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
-  md5: 2390269374fded230fcbca8332a4adc0
+  version: 1.21.5
+  build: h0f2a231_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
+  sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
+  md5: 009521b7ed97cca25f8f997f9e745976
   depends:
-  - libzlib >=1.3.1,<2.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48692
+  timestamp: 1693657088079
+- kind: conda
+  name: blosc
+  version: 1.21.5
+  build: h2f3a684_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.5-h2f3a684_0.conda
+  sha256: 4b7cecdece6e31651993bd2960f6a025d8e546b4778fff101b19e66107667860
+  md5: c1f53cf8a0e36464e084d9f167365552
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35912
+  timestamp: 1693657402988
+- kind: conda
+  name: blosc
+  version: 1.21.5
+  build: hbd69f2e_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hbd69f2e_1.conda
+  sha256: a74c8a91bee3947f9865abd057ce33a1ebb728f04041bfd47bc478fdc133ca22
+  md5: 06c7d9a1cdecef43921be8b577a61ee7
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - snappy >=1.2.0,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
+  - vc >=14.3,<15
   - vc14_runtime >=14.29.30139
-  - zstd >=1.5.6,<1.6.0a0
+  - vc14_runtime >=14.38.33130
+  - zstd >=1.5.5,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 50135
-  timestamp: 1719266616208
-- kind: conda
-  name: blosc
-  version: 1.21.6
-  build: hd2997c2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hd2997c2_0.conda
-  sha256: 4349c7227053c2042b0c31daf6782cbb29ed09557d2f08d7d710ef5288040e73
-  md5: 7e34841d8b76a87cb9ed5b2028f0f37f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.0,<1.3.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 35975
-  timestamp: 1719266339092
-- kind: conda
-  name: blosc
-  version: 1.21.6
-  build: hef167b5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
-  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
-  md5: 54fe76ab3d0189acaef95156874db7f9
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.0,<1.3.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 48842
-  timestamp: 1719266029046
+  size: 50488
+  timestamp: 1712682670189
 - kind: conda
   name: bullet-cpp
   version: '3.25'
@@ -1253,89 +1287,85 @@ packages:
 - kind: conda
   name: cairo
   version: 1.18.0
-  build: h32b962e_3
-  build_number: 3
+  build: h1fef639_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
-  sha256: 127101c9c2d1a56f8791c19141ceff13fd1d1a1da28cfaca549dc99d210cec6a
-  md5: 8f43723a4925c51e55c2d81725a97db4
+  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
+  sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
+  md5: b3fe2c6381ec74afe8128e16a11eee02
   depends:
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
+  - icu >=73.2,<74.0a0
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.42.2,<1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zlib
   license: LGPL-2.1-only or MPL-1.1
-  size: 1516680
-  timestamp: 1721139332360
+  size: 1520159
+  timestamp: 1697029136038
 - kind: conda
   name: cairo
   version: 1.18.0
-  build: hdb1a16f_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
-  sha256: 8a747ad6ce32228a85c80bef8ec7387d71f8d2b0bf637edb56ff33e09794c616
-  md5: 080659f02bf2202c57f1cda4f9e51f21
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  size: 966709
-  timestamp: 1721138947987
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: hebfffa5_3
-  build_number: 3
+  build: h3faef2a_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
-  sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
-  md5: fceaedf1cdbcb02df9699a0d9b005292
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+  sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
+  md5: f907bb958910dc404647326ca80c263e
   depends:
-  - __glibc >=2.17,<3.0.a0
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
+  - icu >=73.2,<74.0a0
   - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
   - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.2,<1.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.42.2,<1.0a0
   - xorg-libice >=1.1.1,<2.0a0
   - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
-  size: 983604
-  timestamp: 1721138900054
+  size: 982351
+  timestamp: 1697028423052
+- kind: conda
+  name: cairo
+  version: 1.18.0
+  build: ha13f110_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
+  sha256: 79b6323661b535d90aaec0eac0e91ccda88cc5917d9e597a03d7de183bc22f26
+  md5: 425111f8cc6945c5d1307357dd819b9b
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.42.2,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 983779
+  timestamp: 1697028424329
 - kind: conda
   name: catkin_pkg
   version: 1.0.0
@@ -1355,6 +1385,59 @@ packages:
   license_family: BSD
   size: 53408
   timestamp: 1694652027818
+- kind: conda
+  name: cfitsio
+  version: 4.3.1
+  build: h9b0cee5_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.3.1-h9b0cee5_0.conda
+  sha256: 9fb11c689bb4c88e031c931cae23b09880e7a8c17713261844c16f5e88f349f2
+  md5: eb7f15f7b2160dec9e803a86dcbe1d03
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-fitsio
+  size: 563597
+  timestamp: 1700704657931
+- kind: conda
+  name: cfitsio
+  version: 4.3.1
+  build: hbdc6101_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.3.1-hbdc6101_0.conda
+  sha256: b91003bff71351a0132c84d69fbb5afcfa90e57d83f76a180c6a5a0289099fb1
+  md5: dcea02841b33a9c49f74ca9328de919a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: LicenseRef-fitsio
+  size: 875191
+  timestamp: 1700704197213
+- kind: conda
+  name: cfitsio
+  version: 4.3.1
+  build: hf28c5f1_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cfitsio-4.3.1-hf28c5f1_0.conda
+  sha256: 2a68d326e05a4c68df1741ec95b2c624f665f428ca833cf57b24aeed1798cbce
+  md5: 3b1ede3e444833dbd1f6ac717ae5dfb3
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: LicenseRef-fitsio
+  size: 871175
+  timestamp: 1700704108263
 - kind: conda
   name: cmake
   version: 3.28.3
@@ -1700,6 +1783,7 @@ packages:
   - python_abi 3.9.* *_cp39
   - pywin32
   license: Apache-2.0
+  license_family: APACHE
   size: 71519
   timestamp: 1731274271491
 - kind: conda
@@ -2021,116 +2105,115 @@ packages:
 - kind: conda
   name: cppzmq
   version: 4.10.0
-  build: h2e2a08d_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cppzmq-4.10.0-h2e2a08d_1.conda
-  sha256: 68da3b05fc2de16c28ed7dbd2a7c2eff05de308996eaa0f21f74618fe3afa52f
-  md5: 2ed8fb92772e2a7265b261e0885d3549
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - zeromq >=4.3.5,<4.4.0a0
-  license: MIT
-  license_family: MIT
-  size: 29049
-  timestamp: 1698741728645
-- kind: conda
-  name: cppzmq
-  version: 4.10.0
-  build: h42135b4_1
-  build_number: 1
+  build: h449d27f_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cppzmq-4.10.0-h42135b4_1.conda
-  sha256: 6256ae98cd23877fb3fff6c49d2b4d0fc3db1f3e715d23773ab16d866543fd66
-  md5: d0c9a976e232c139368c6a20786ea645
+  url: https://conda.anaconda.org/conda-forge/win-64/cppzmq-4.10.0-h449d27f_0.conda
+  sha256: 44fc1b553b9de61ee4d2b63f0920ee14fe8ab2701fdd049bd14097e581d1f2ed
+  md5: ee101750107d9ac6c493b37776e7e68e
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zeromq >=4.3.5,<4.3.6.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
   license: MIT
   license_family: MIT
-  size: 29250
-  timestamp: 1698741878322
+  size: 29059
+  timestamp: 1687288938202
 - kind: conda
   name: cppzmq
   version: 4.10.0
-  build: hf1bdad7_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cppzmq-4.10.0-hf1bdad7_1.conda
-  sha256: f3f75cca965c2ebc2dfd3cf7b0e23328f12d4eeeece16fe89711248baf8e7b15
-  md5: 2f96e41e2f8811821ec2b92cd29151f7
+  build: h7e20d1c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cppzmq-4.10.0-h7e20d1c_0.conda
+  sha256: 7cb43c4ca25ebb13b9530c9ffd3aaed10d7e8009932ebe4dff074f8c5035e3ab
+  md5: f85c289d3ed537d22caff759539ae49f
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - zeromq >=4.3.5,<4.4.0a0
+  - zeromq >=4.3.4,<4.4.0a0
   license: MIT
   license_family: MIT
-  size: 29266
-  timestamp: 1698741761245
+  size: 28937
+  timestamp: 1687288516306
+- kind: conda
+  name: cppzmq
+  version: 4.10.0
+  build: hb912365_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cppzmq-4.10.0-hb912365_0.conda
+  sha256: 73276961a8a1b449eec524b5334cf9f303c66e6575583bd78c15260fa528faf1
+  md5: 02c8ca03eb5ae671d1feb3289ff6df71
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - zeromq >=4.3.4,<4.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 29152
+  timestamp: 1687288585419
 - kind: conda
   name: curl
-  version: 8.10.1
-  build: h1ee3ff0_0
+  version: 8.8.0
+  build: h0dd56e1_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/curl-8.10.1-h1ee3ff0_0.conda
-  sha256: e7e6104403b70a78f1000a1e79b63a8235d7e9ebc8d9139044678c4fb5e9de2b
-  md5: d52f0bd89f1df927bfc1fc82d89db5b5
+  url: https://conda.anaconda.org/conda-forge/win-64/curl-8.8.0-h0dd56e1_1.conda
+  sha256: 0bd9f9c1f956154f9b97bdfd1f4d48aaeaff15b4b4e57f60194fc909b726a674
+  md5: f54b1f38d384e9ef7ddd256c01782833
   depends:
   - krb5 >=1.21.3,<1.22.0a0
-  - libcurl 8.10.1 h1ee3ff0_0
+  - libcurl 8.8.0 hd5e4a3a_1
   - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: curl
   license_family: MIT
-  size: 160629
-  timestamp: 1726660527493
+  size: 154960
+  timestamp: 1719603202164
 - kind: conda
   name: curl
-  version: 8.10.1
-  build: h3ec0cbf_0
+  version: 8.8.0
+  build: h7daf2e0_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.10.1-h3ec0cbf_0.conda
-  sha256: d89c2ed08c9b76499d153cbe2d9e7050f5126b018408b5aa5e6272b6397d2c7f
-  md5: a8e29b757c73d8e089ec6a24249934bb
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.8.0-h7daf2e0_1.conda
+  sha256: e1b7c2fdf9e5c27de8d62cd1ef86571af6ce9c57259ac8f64702be98d2f79775
+  md5: af7824989968474981d345504948cde5
   depends:
   - krb5 >=1.21.3,<1.22.0a0
-  - libcurl 8.10.1 h3ec0cbf_0
-  - libgcc >=13
+  - libcurl 8.8.0 h4e8248e_1
+  - libgcc-ng >=12
   - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 176987
-  timestamp: 1726659850406
+  size: 168532
+  timestamp: 1719602887457
 - kind: conda
   name: curl
-  version: 8.10.1
-  build: hbbe4b11_0
+  version: 8.8.0
+  build: he654da7_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/curl-8.10.1-hbbe4b11_0.conda
-  sha256: f2c6de198ae7505ab33ce7e86b7767f6492489cfb5635cad164822a9d73f3a5e
-  md5: 73c561c6b84bda71776c9fa21517e7eb
+  url: https://conda.anaconda.org/conda-forge/linux-64/curl-8.8.0-he654da7_1.conda
+  sha256: a7bb4f8d1cba26c238cd0469b7bdcdc032cf06b0ac0de09992638744eaab9954
+  md5: 78678b2ddfd9bd7c7861b8d2e3b7473b
   depends:
-  - __glibc >=2.17,<3.0.a0
   - krb5 >=1.21.3,<1.22.0a0
-  - libcurl 8.10.1 hbbe4b11_0
-  - libgcc >=13
+  - libcurl 8.8.0 hca28451_1
+  - libgcc-ng >=12
   - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 173268
-  timestamp: 1726659802291
+  size: 166499
+  timestamp: 1719602741040
 - kind: conda
   name: dartsim
   version: 6.13.2
@@ -2454,6 +2537,23 @@ packages:
   size: 130354
   timestamp: 1730967212801
 - kind: conda
+  name: expat
+  version: 2.6.4
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.4-he0c23c2_0.conda
+  sha256: b4f8c3d94f6f592e9ec85c71ef329028fe24cd55db1711a4ad4e2e564c8b28a7
+  md5: 1acbf46a31d414144777e85efebd3640
+  depends:
+  - libexpat 2.6.4 he0c23c2_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 230629
+  timestamp: 1730967460961
+- kind: conda
   name: fcl
   version: 0.7.0
   build: h31587c3_4
@@ -2516,212 +2616,197 @@ packages:
   timestamp: 1697962374660
 - kind: conda
   name: ffmpeg
-  version: 7.1.0
-  build: gpl_h89ca9b9_703
-  build_number: 703
+  version: 6.1.1
+  build: gpl_h66c0b5b_108
+  build_number: 108
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-7.1.0-gpl_h89ca9b9_703.conda
-  sha256: a34efc4ef64ab895a9cc61e68a83ce8b31fb5be63ae265a9a3d45fb2632e06f4
-  md5: 1e9cd6a8b46e035522bc0c21f0c47e49
+  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_h66c0b5b_108.conda
+  sha256: b3e1c32f150a4f8afba0ba304af7a1cb073d5d46f8e29a671ce9c0ae1cf965c3
+  md5: 3918f1f54a5d4ae01671879fa8649a37
   depends:
-  - aom >=3.9.1,<3.10.0a0
+  - aom >=3.8.2,<3.9.0a0
   - bzip2 >=1.0.8,<2.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
+  - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libexpat >=2.6.3,<3.0a0
+  - harfbuzz >=8.3.0,<9.0a0
   - libiconv >=1.17,<2.0a0
   - libopus >=1.3.1,<2.0a0
-  - librsvg >=2.58.4,<3.0a0
-  - libxml2 >=2.13.4,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libxml2 >=2.12.6,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - svt-av1 >=2.0.0,<2.0.1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
   - xz >=5.2.6,<6.0a0
-  constrains:
-  - __cuda  >=12.4
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 9985429
-  timestamp: 1730673229363
+  size: 9616766
+  timestamp: 1712658196820
 - kind: conda
   name: ffmpeg
-  version: 7.1.0
-  build: gpl_hb5dfa50_703
-  build_number: 703
+  version: 6.1.1
+  build: gpl_hed0588d_101
+  build_number: 101
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.0-gpl_hb5dfa50_703.conda
-  sha256: 23f0818106ae1383a902d944065f6538a0bf43ebac81853f5e7e6e44df8c3ac6
-  md5: 5cf67e86859e5d31dd6c8969317e558d
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_hed0588d_101.conda
+  sha256: a4d922eb21610002c7de83c060cee77ac975c51c5731576a72729909d76400cb
+  md5: 1bf99f8834ae492d7004232811ac2210
   depends:
-  - aom >=3.9.1,<3.10.0a0
+  - aom >=3.7.1,<3.8.0a0
   - bzip2 >=1.0.8,<2.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
+  - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=9.0.0,<10.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
   - lame >=3.100,<3.101.0a0
-  - libass >=0.17.3,<0.17.4.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
+  - libass >=0.17.1,<0.17.2.0a0
+  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-arm-cpu-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-auto-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-hetero-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-ir-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-onnx-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-paddle-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-pytorch-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.2.0,<2023.2.1.0a0
   - libopus >=1.3.1,<2.0a0
-  - librsvg >=2.58.4,<3.0a0
-  - libstdcxx >=13
-  - libvpx >=1.14.1,<1.15.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2 >=2.13.4,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - libstdcxx-ng >=12
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.4,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openh264 >=2.4.0,<2.4.1.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
   - xz >=5.2.6,<6.0a0
-  constrains:
-  - __cuda  >=12.4
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 9911501
-  timestamp: 1730672295104
+  size: 9333773
+  timestamp: 1705437584449
 - kind: conda
   name: ffmpeg
-  version: 7.1.0
-  build: gpl_hbb807a5_703
-  build_number: 703
+  version: 6.1.1
+  build: gpl_hf3b701a_101
+  build_number: 101
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_hbb807a5_703.conda
-  sha256: b3c25c9eeee63f39ebff7dc1840734aab3e784a084a8352d5099aa9a9c07e42f
-  md5: ebcb1e523d36a81af8f0910856c06946
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_hf3b701a_101.conda
+  sha256: dd61e0f57a45f362fac3656036b4401c60ebea4e19d184d54b2c0783551d4a97
+  md5: bcfdefa4f8552558a11f50b7d3b1685b
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - aom >=3.9.1,<3.10.0a0
+  - aom >=3.7.1,<3.8.0a0
   - bzip2 >=1.0.8,<2.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
+  - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=9.0.0,<10.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
   - lame >=3.100,<3.101.0a0
-  - libass >=0.17.3,<0.17.4.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
+  - libass >=0.17.1,<0.17.2.0a0
+  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-gpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-npu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-auto-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-hetero-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-intel-gpu-plugin >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-ir-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-onnx-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-paddle-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-pytorch-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.2.0,<2023.2.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.2.0,<2023.2.1.0a0
   - libopus >=1.3.1,<2.0a0
-  - librsvg >=2.58.4,<3.0a0
-  - libstdcxx >=13
-  - libva >=2.22.0,<3.0a0
-  - libvpx >=1.14.1,<1.15.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2 >=2.13.4,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - libstdcxx-ng >=12
+  - libva >=2.20.0,<3.0a0
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.4,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openh264 >=2.4.0,<2.4.1.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
   - xz >=5.2.6,<6.0a0
-  constrains:
-  - __cuda  >=12.4
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 10317421
-  timestamp: 1730672187649
+  size: 9789070
+  timestamp: 1705437549019
 - kind: conda
   name: flann
   version: 1.9.2
-  build: h3ef53d8_2
-  build_number: 2
+  build: h54ed35b_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h3ef53d8_2.conda
-  sha256: 3a223373e848d0ea14971f7698e51ef2a7497504c10306492c066165d0a0bb06
-  md5: a0f60c2f07bf0c101da8c3e632a4beb7
+  url: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h54ed35b_1.conda
+  sha256: f728f524a49dc6538ead0a3e7f2962d17831f8225162641e4f4f6b2f76c420bc
+  md5: 28b54e73fd09bbea7f5e5fa31060542a
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
-  - hdf5 >=1.14.4,<1.14.5.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
   - libgcc >=13
   - libstdcxx >=13
   - lz4-c >=1.9.3,<1.10.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1569288
-  timestamp: 1728027997028
+  size: 1561831
+  timestamp: 1724963964399
 - kind: conda
   name: flann
   version: 1.9.2
-  build: h7e74b68_2
-  build_number: 2
+  build: hba58ff8_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-h7e74b68_2.conda
-  sha256: 6e58d82896893d72bfbe563b4ba712bb4e41705d2c00a44db87b9412cc4a8008
-  md5: 4abc7d16d4acd76357c7b44bcca7de62
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-hba58ff8_1.conda
+  sha256: 85b0c8a33c8105007a326526f75f6ce16b7f54872bb89ac2f2ce2cb3fad789e7
+  md5: d095b682fee5346940676e2c6ae36e26
   depends:
   - _openmp_mutex >=4.5
-  - hdf5 >=1.14.4,<1.14.5.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
   - libgcc >=13
   - libstdcxx >=13
   - lz4-c >=1.9.3,<1.10.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1788051
-  timestamp: 1728028128815
+  size: 1781748
+  timestamp: 1724964164889
 - kind: conda
   name: flann
   version: 1.9.2
-  build: h8958603_2
-  build_number: 2
+  build: hf9aaf8f_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-h8958603_2.conda
-  sha256: 8306e932c7060caea1fe2d0089a70f8cbccde75fdb8b0abf87acdd252cee1e09
-  md5: f43541fd0ebf62584cb598891a5d90b5
+  url: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-hf9aaf8f_1.conda
+  sha256: d1cc6c9b02075e1eecb9aa27d8547123e96e6f128075984f0f635224a70af5a3
+  md5: 27036de317eb059e687a06a535e22fe1
   depends:
-  - hdf5 >=1.14.4,<1.14.5.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 4333500
-  timestamp: 1728028612163
+  size: 4426772
+  timestamp: 1724964500191
 - kind: conda
   name: fmt
   version: 10.2.1
@@ -2823,64 +2908,60 @@ packages:
   timestamp: 1727511233259
 - kind: conda
   name: fontconfig
-  version: 2.15.0
-  build: h765892d_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
-  sha256: ed122fc858fb95768ca9ca77e73c8d9ddc21d4b2e13aaab5281e27593e840691
-  md5: 9bb0026a2131b09404c59c4290c697cd
+  version: 2.14.2
+  build: h14ed4e7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+  sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
+  md5: 0f69b688f52ff6da70bccb7ff7001d1d
   depends:
+  - expat >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
-  - libexpat >=2.6.3,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 272010
+  timestamp: 1674828850194
+- kind: conda
+  name: fontconfig
+  version: 2.14.2
+  build: ha9a116f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
+  sha256: 71143b04d9beeb76264a54cb42a2953ff858a95f7383531fcb3a33ac6433e7f6
+  md5: 6d2d19ea85f9d41534cd28fdefd59a25
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 280375
+  timestamp: 1674830224830
+- kind: conda
+  name: fontconfig
+  version: 2.14.2
+  build: hbde0cde_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+  sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
+  md5: 08767992f1a4f1336a257af1241034bd
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vs2015_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 192355
-  timestamp: 1730284147944
-- kind: conda
-  name: fontconfig
-  version: 2.15.0
-  build: h7e30c49_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
-  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
-  md5: 8f5b0b297b59e1ac160ad4beec99dbee
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - freetype >=2.12.1,<3.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 265599
-  timestamp: 1730283881107
-- kind: conda
-  name: fontconfig
-  version: 2.15.0
-  build: h8dda3cd_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.15.0-h8dda3cd_1.conda
-  sha256: fe023bb8917c8a3138af86ef537b70c8c5d60c44f93946a87d1e8bb1a6634b55
-  md5: 112b71b6af28b47c624bcbeefeea685b
-  depends:
-  - freetype >=2.12.1,<3.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 277832
-  timestamp: 1730284967179
+  size: 190111
+  timestamp: 1674829354122
 - kind: conda
   name: fonts-conda-ecosystem
   version: '1'
@@ -2934,80 +3015,79 @@ packages:
 - kind: conda
   name: freeimage
   version: 3.18.0
-  build: h3a85593_22
-  build_number: 22
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
-  sha256: 03ccff5d255eab7a1736de9eeb539fbb1333036fa5e37ea7c8ec428270067c99
-  md5: bbdf3d43d752b793ac81f27b28c49e2d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - imath >=3.1.12,<3.1.13.0a0
-  - jxrlib >=1.1,<1.2.0a0
-  - libgcc >=13
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libraw >=0.21.3,<0.22.0a0
-  - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openexr >=3.3.1,<3.4.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
-  size: 467860
-  timestamp: 1729024045245
-- kind: conda
-  name: freeimage
-  version: 3.18.0
-  build: h6cb32c8_22
-  build_number: 22
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h6cb32c8_22.conda
-  sha256: 0a0ed82992c87aa67604569d35b6180863ca21081e94739194e6adde3f92f84d
-  md5: f6891bd5c49b824889b065446edefe37
-  depends:
-  - imath >=3.1.12,<3.1.13.0a0
-  - jxrlib >=1.1,<1.2.0a0
-  - libgcc >=13
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libraw >=0.21.3,<0.22.0a0
-  - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openexr >=3.3.1,<3.4.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
-  size: 453451
-  timestamp: 1729024016441
-- kind: conda
-  name: freeimage
-  version: 3.18.0
-  build: h8310ca0_22
-  build_number: 22
+  build: h2b56e36_20
+  build_number: 20
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/freeimage-3.18.0-h8310ca0_22.conda
-  sha256: 89ff5bd00c94d201b76f90b939cbd9ec013171c45d9967f7dac71d330cd10343
-  md5: 5c8c15da921f6a9388d37c4fc81dad4a
+  url: https://conda.anaconda.org/conda-forge/win-64/freeimage-3.18.0-h2b56e36_20.conda
+  sha256: d468cc411cc1f2026bb0f0824cef91c0c169bb15bbb896c9296983544d4a4c62
+  md5: edf5248ab529f40786a1771601cf5e6b
   depends:
-  - imath >=3.1.12,<3.1.13.0a0
+  - imath >=3.1.11,<3.1.12.0a0
   - jxrlib >=1.1,<1.2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libraw >=0.21.3,<0.22.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openexr >=3.3.1,<3.4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libraw >=0.21.1,<0.22.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openexr >=3.2.2,<3.3.0a0
   - openjpeg >=2.5.2,<3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
-  size: 465887
-  timestamp: 1729024520954
+  size: 464417
+  timestamp: 1709289209333
+- kind: conda
+  name: freeimage
+  version: 3.18.0
+  build: h4b96d29_20
+  build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h4b96d29_20.conda
+  sha256: 07d34a47867f15878dff3d5ae11a7fa24bb03587878ce1798314d03fc6d3d6a5
+  md5: 41069afbb9fb02e6e19dd80b4a2c46e7
+  depends:
+  - imath >=3.1.11,<3.1.12.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libraw >=0.21.1,<0.22.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openexr >=3.2.2,<3.3.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
+  size: 461394
+  timestamp: 1709288677517
+- kind: conda
+  name: freeimage
+  version: 3.18.0
+  build: h57e7d35_20
+  build_number: 20
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h57e7d35_20.conda
+  sha256: 2b0aaed03c5c95116760bcce18cff771d56173bec9eef71c1d69dc569eb08197
+  md5: 62dd0b91dba275f0bb07b4f0d56b7bde
+  depends:
+  - imath >=3.1.11,<3.1.12.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libraw >=0.21.1,<0.22.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openexr >=3.2.2,<3.3.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
+  size: 448323
+  timestamp: 1709288728011
 - kind: conda
   name: freetype
   version: 2.12.1
@@ -3127,20 +3207,6 @@ packages:
 - kind: conda
   name: fribidi
   version: 1.0.10
-  build: h8d14728_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
-  sha256: e0323e6d7b6047042970812ee810c6b1e1a11a3af4025db26d0965ae5d206104
-  md5: 807e81d915f2bb2e49951648615241f6
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: LGPL-2.1
-  size: 64567
-  timestamp: 1604417122064
-- kind: conda
-  name: fribidi
-  version: 1.0.10
   build: hb9de7d4_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
@@ -3153,64 +3219,66 @@ packages:
   timestamp: 1604417149643
 - kind: conda
   name: gdal
-  version: 3.9.3
-  build: py39h2b1cf14_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.3-py39h2b1cf14_2.conda
-  sha256: 82e9bec85d59c2a7b1df0c5dd1a142d59e7bbfefe1a82fde9059bfcc36134686
-  md5: 50168260934270cc3188ca9f5f0428b4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libgdal-core 3.9.3.*
-  - libkml >=1.3.0,<1.4.0a0
-  - libstdcxx >=13
-  - libxml2 >=2.12.7,<3.0a0
-  - numpy >=1.19,<3
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: MIT
-  license_family: MIT
-  size: 1534420
-  timestamp: 1730219779993
-- kind: conda
-  name: gdal
-  version: 3.9.3
-  build: py39h70a7a3d_2
-  build_number: 2
+  version: 3.8.0
+  build: py39h28251d5_7
+  build_number: 7
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.9.3-py39h70a7a3d_2.conda
-  sha256: 4cd1c86718c354f3761330b3f68d11ded7ae2edd75fa6bbdf7b53529cbe623e4
-  md5: 33d5770b3c90e9392a0d2d112e9aee7b
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.8.0-py39h28251d5_7.conda
+  sha256: 707c62bca31b0e96bef9d0a136697f1ae321f5e907d4e6101abcf75dca88b2c0
+  md5: 32cf1f4a1dad3e6ae4f7a61af68c2d64
   depends:
-  - libgcc >=13
-  - libgdal-core 3.9.3.*
-  - libkml >=1.3.0,<1.4.0a0
-  - libstdcxx >=13
-  - libxml2 >=2.12.7,<3.0a0
-  - numpy >=1.19,<3
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libgdal 3.8.0 h18a4eec_7
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.6,<3.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - openssl >=3.2.0,<4.0a0
   - python >=3.9,<3.10.0a0
   - python >=3.9,<3.10.0a0 *_cpython
   - python_abi 3.9.* *_cp39
   license: MIT
   license_family: MIT
-  size: 1495969
-  timestamp: 1730220500404
+  size: 1457629
+  timestamp: 1701001672292
 - kind: conda
   name: gdal
-  version: 3.9.3
-  build: py39h96760b6_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.3-py39h96760b6_2.conda
-  sha256: 2d9dfa6aba054bb0b1c0fe6243b3befd5a52bf1e3aad46781d64dfe139db64a2
-  md5: 8b5b32373f79a3f2a2cc60398690f911
+  version: 3.8.0
+  build: py39h41b90d8_7
+  build_number: 7
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.8.0-py39h41b90d8_7.conda
+  sha256: 10e2ea868c983f6a882f0bfff65c2e5714bb4f0b404d8a21398b52af79689b6a
+  md5: 2a8ee3e0af59bd4ffbd884ec548f1e84
   depends:
-  - libgdal-core 3.9.3.*
-  - libkml >=1.3.0,<1.4.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - numpy >=1.19,<3
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libgdal 3.8.0 h4d9a814_7
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.6,<3.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - openssl >=3.2.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: MIT
+  license_family: MIT
+  size: 1494208
+  timestamp: 1701001457957
+- kind: conda
+  name: gdal
+  version: 3.8.0
+  build: py39hbe60bc6_7
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.8.0-py39hbe60bc6_7.conda
+  sha256: 6643749c85299cce75ccee28fe319f9bea42d90beea41809aaf3742a788e118d
+  md5: e5e858490bfd9436fa2d65256d293fd2
+  depends:
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libgdal 3.8.0 h0791e23_7
+  - libxml2 >=2.11.6,<3.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - openssl >=3.2.0,<4.0a0
   - python >=3.9,<3.10.0a0
   - python_abi 3.9.* *_cp39
   - ucrt >=10.0.20348.0
@@ -3218,8 +3286,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 1469918
-  timestamp: 1730221489595
+  size: 1462192
+  timestamp: 1701003418063
 - kind: conda
   name: gdbm
   version: '1.18'
@@ -3237,171 +3305,112 @@ packages:
   size: 194790
   timestamp: 1597622040785
 - kind: conda
-  name: gdk-pixbuf
-  version: 2.42.12
-  build: ha61d561_0
+  name: geos
+  version: 3.12.1
+  build: h1537add_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.1-h1537add_0.conda
+  sha256: d7a6bb89063df38b24843e5b4c99da602333ac4e1c1e39c069f2021827d3c98d
+  md5: 02fdccc66ed44a8f9f3731d15f445724
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 1561705
+  timestamp: 1699778438983
+- kind: conda
+  name: geos
+  version: 3.12.1
+  build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-ha61d561_0.conda
-  sha256: 608f64aa9cf3085e91da8d417aa7680715130b4da73d8aabc50b19e29de697d2
-  md5: 332ed304e6d1c1333ccbdc0fdd722fe9
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.12.1-h2f0025b_0.conda
+  sha256: 7e041dcaa524aeb7564f1cd3c7ba25ba1f1ed57c18b0516da92eccbd44844f24
+  md5: ac30e662102643639f9421aa80723e2b
   depends:
   - libgcc-ng >=12
-  - libglib >=2.80.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 536613
-  timestamp: 1715784386033
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-only
+  size: 1678795
+  timestamp: 1699778041248
 - kind: conda
-  name: gdk-pixbuf
-  version: 2.42.12
-  build: hb9ae30d_0
+  name: geos
+  version: 3.12.1
+  build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
-  sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
-  md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
+  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.1-h59595ed_0.conda
+  sha256: 2593b255cb9c4639d6ea261c47aaed1380216a366546f0468e95c36c2afd1c1a
+  md5: 8c0f4f71f5a59ceb0c6fa9f51501066d
   depends:
   - libgcc-ng >=12
-  - libglib >=2.80.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 528149
-  timestamp: 1715782983957
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-only
+  size: 1736070
+  timestamp: 1699778102442
 - kind: conda
-  name: gdk-pixbuf
-  version: 2.42.12
-  build: hed59a49_0
+  name: geotiff
+  version: 1.7.1
+  build: hcf4a93f_14
+  build_number: 14
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.42.12-hed59a49_0.conda
-  sha256: 7a7768a5e65092242071f99b4cafe3e59546f9260ae472d3aa10a9a9aa869c3c
-  md5: 350196a65e715882abefffd1a702172d
+  url: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-hcf4a93f_14.conda
+  sha256: 12f8e01f8cb4dccfbd16af9f88f81aa6ccda8607d98a9eb1f7f305c3f455439f
+  md5: ba4fadef391cfecb95ad9dc8617fe481
   depends:
-  - libglib >=2.80.2,<3.0a0
-  - libintl >=0.22.5,<1.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
   - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 523967
-  timestamp: 1715783547727
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 125625
+  timestamp: 1695943530332
 - kind: conda
-  name: geos
-  version: 3.13.0
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
-  sha256: 5c70d6d16e044859edca85feb9d4f1c3c6062aaf88d650826f5ccdf8c44336de
-  md5: 40b4ab956c90390e407bb177f8a58bab
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: LGPL-2.1-only
-  size: 1869233
-  timestamp: 1725676083126
-- kind: conda
-  name: geos
-  version: 3.13.0
-  build: h5a68840_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
-  sha256: 2b46d6f304f70dfca304169299908b558bd1e83992acb5077766eefa3d3fe35f
-  md5: 08a30fe29a645fc5c768c0968db116d3
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.1-only
-  size: 1665961
-  timestamp: 1725676536384
-- kind: conda
-  name: geos
-  version: 3.13.0
-  build: h5ad3122_0
+  name: geotiff
+  version: 1.7.1
+  build: he43841b_14
+  build_number: 14
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.13.0-h5ad3122_0.conda
-  sha256: cb4591c01e2cb9b9b48e52f050bc7bc89e6ec48c4d55ff8caa2babdc5b952b32
-  md5: 7e15d067b9fa7cfd65e9a38ecdfbecad
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/geotiff-1.7.1-he43841b_14.conda
+  sha256: 8535dd84cd351cf85fdfc5e25578d594d5cc9a6d91a27ad8814b07cef8f312b4
+  md5: 88145472883e82c07f2e3fd37c2445f8
   depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  license: LGPL-2.1-only
-  size: 1821820
-  timestamp: 1725676037102
-- kind: conda
-  name: geotiff
-  version: 1.7.3
-  build: h17a0a10_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/geotiff-1.7.3-h17a0a10_3.conda
-  sha256: 08573ea147a8ed8a4198ca7d3682b1399fd2447f59943920e69c94eca8edd7f9
-  md5: 3a1a66142835725b8f386fc84e6bf791
-  depends:
-  - libgcc >=13
+  - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx >=13
+  - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.8.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.0,<9.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
   - zlib
   license: MIT
   license_family: MIT
-  size: 139256
-  timestamp: 1726603012108
+  size: 138002
+  timestamp: 1695943097847
 - kind: conda
   name: geotiff
-  version: 1.7.3
-  build: h496ac4d_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
-  sha256: 116120a2f4411618800c2a5ce246dfc313298e545ce1ffaa85f28cc3ac2236ac
-  md5: fb20f424102030f3952532cc7aebdbd8
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  license: MIT
-  license_family: MIT
-  size: 123087
-  timestamp: 1726603487099
-- kind: conda
-  name: geotiff
-  version: 1.7.3
-  build: h77b800c_3
-  build_number: 3
+  version: 1.7.1
+  build: hf074850_14
+  build_number: 14
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
-  sha256: 94c7d002c70a4802a78ac2925ad6b36327cff85e0af6af2825b11a968c81ec20
-  md5: 4eb52aecb43e7c72f8e4fca0c386354e
+  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.1-hf074850_14.conda
+  sha256: b00958767cb5607bdb3bbcec0b2056b3e48c0f9e34c31ed8ac01c9bd36704dab
+  md5: 1d53ee057d8481bd2b4c2c34c8e92aac
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx >=13
+  - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.8.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.0,<9.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
   - zlib
   license: MIT
   license_family: MIT
-  size: 131394
-  timestamp: 1726602918349
+  size: 133225
+  timestamp: 1695943012677
 - kind: conda
   name: gettext
   version: 0.22.5
@@ -3422,6 +3431,27 @@ packages:
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
   size: 481962
   timestamp: 1723626297896
+- kind: conda
+  name: gettext
+  version: 0.22.5
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_3.conda
+  sha256: 8cbfe8fc9421438fcfd06e08ace5587dcceb544ce46f773e116e414a51d6b3ff
+  md5: 85bbe942c8b188fa70f6ffb88a80ae2e
+  depends:
+  - gettext-tools 0.22.5 h5a7288d_3
+  - libasprintf 0.22.5 h5728263_3
+  - libasprintf-devel 0.22.5 h5728263_3
+  - libgettextpo 0.22.5 h5728263_3
+  - libgettextpo-devel 0.22.5 h5728263_3
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
+  - libintl-devel 0.22.5 h5728263_3
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 34015
+  timestamp: 1723630597857
 - kind: conda
   name: gettext
   version: 0.22.5
@@ -3458,6 +3488,25 @@ packages:
   license_family: GPL
   size: 2954814
   timestamp: 1723626262722
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: h5a7288d_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h5a7288d_3.conda
+  sha256: 363dcc414ece1d82d5b031afea67901ad03edea6b5f1051bea985e699c090f13
+  md5: 7c631c844abcba0d855c7b6204d42e9d
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3411654
+  timestamp: 1723630236515
 - kind: conda
   name: gettext-tools
   version: 0.22.5
@@ -3554,106 +3603,111 @@ packages:
   timestamp: 1712692454246
 - kind: conda
   name: glib
-  version: 2.82.2
-  build: h44428e9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.2-h44428e9_0.conda
-  sha256: f89540cbca9d981fd65d2f3913e8aaa3fe30bc76aa0f70015be4a2169539025b
-  md5: f19f985ab043e8843045410f3b99de8a
-  depends:
-  - glib-tools 2.82.2 h4833e2c_0
-  - libffi >=3.4,<4.0a0
-  - libglib 2.82.2 h2ff4ddf_0
-  - packaging
-  - python *
-  license: LGPL-2.1-or-later
-  size: 602771
-  timestamp: 1729191500463
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: h7025463_0
+  version: 2.78.4
+  build: h12be248_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.2-h7025463_0.conda
-  sha256: 68632bb5aec001fcd09b7f9ea415fab09ad479eb640fb667141cbb747a8d48b5
-  md5: c295bf0ccb6823efdf40ebc5992384c4
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.4-h12be248_0.conda
+  sha256: 941aaf433be2b147738b4f2729008faa6639ed55b59381605f1cfb8d0dabac27
+  md5: 0080f150ed83685497f841f4b70fca1f
   depends:
-  - glib-tools 2.82.2 h4394cf3_0
-  - libffi >=3.4,<4.0a0
-  - libglib 2.82.2 h7025463_0
-  - libintl >=0.22.5,<1.0a0
-  - libintl-devel
-  - packaging
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.78.4 h12be248_0
+  - libglib 2.78.4 h16e383f_0
+  - libzlib >=1.2.13,<2.0.0a0
   - python *
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-or-later
-  size: 573556
-  timestamp: 1729192350624
+  size: 506268
+  timestamp: 1708285308336
 - kind: conda
   name: glib
-  version: 2.82.2
-  build: hc486b8e_0
+  version: 2.78.4
+  build: hd84c7bf_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.2-hc486b8e_0.conda
-  sha256: 5735b3f53735ea78c0d7e98b112488576f03bcbf85fb7e5b0deb05dd35ea08b1
-  md5: 395da692fd81ebafd8c969683bb2bf41
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.78.4-hd84c7bf_0.conda
+  sha256: f29f89e7f4c2e7a6262221e670a71b5e3f4d14dbe8c2e24c54508aece3145d3f
+  md5: 5e68216c6a4a4b45f4cddc51feea64a4
   depends:
-  - glib-tools 2.82.2 h78ca943_0
-  - libffi >=3.4,<4.0a0
-  - libglib 2.82.2 hc486b8e_0
-  - packaging
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.78.4 hd84c7bf_0
+  - libgcc-ng >=12
+  - libglib 2.78.4 h311d5f7_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   - python *
   license: LGPL-2.1-or-later
-  size: 616163
-  timestamp: 1729191610267
+  size: 498854
+  timestamp: 1708284974363
+- kind: conda
+  name: glib
+  version: 2.78.4
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.4-hfc55251_0.conda
+  sha256: 316c95dcbde46b7418d2b667a7e0c1d05101b673cd8c691d78d8699600a07a5b
+  md5: f36a7b2420c3fc3c48a3d609841d8fee
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.78.4 hfc55251_0
+  - libgcc-ng >=12
+  - libglib 2.78.4 h783c2da_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - python *
+  license: LGPL-2.1-or-later
+  size: 489127
+  timestamp: 1708284952839
 - kind: conda
   name: glib-tools
-  version: 2.82.2
-  build: h4394cf3_0
+  version: 2.78.4
+  build: h12be248_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.2-h4394cf3_0.conda
-  sha256: 2c502b66fb68ed3dd4ce9f8121ae8f613df08a83c354c55435994dd9a8ee780a
-  md5: 5aa50df298dca67e20ad24c622d1a27c
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.4-h12be248_0.conda
+  sha256: 936c16a45216916d3fecce9353953bac0dcf3e24cf4999d5cab7b7e601dd274c
+  md5: 9e2a4c1cace3fbdeb11f20578484ddaf
   depends:
-  - libglib 2.82.2 h7025463_0
-  - libintl >=0.22.5,<1.0a0
+  - libglib 2.78.4 h16e383f_0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-or-later
-  size: 96434
-  timestamp: 1729192296587
+  size: 145970
+  timestamp: 1708285241564
 - kind: conda
   name: glib-tools
-  version: 2.82.2
-  build: h4833e2c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_0.conda
-  sha256: 4d6d7175a841be9dd25f5041c9b9419b25f4f5e8de8f289b3c7914a76f5a24d4
-  md5: 12859f91830f58b1803e32846651c6f6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libglib 2.82.2 h2ff4ddf_0
-  license: LGPL-2.1-or-later
-  size: 114038
-  timestamp: 1729191458625
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h78ca943_0
+  version: 2.78.4
+  build: hd84c7bf_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.2-h78ca943_0.conda
-  sha256: 4f8eaa6d7fe07a6e6bc06787256a416b14d4ed424474b11875d0ca7aeff1256c
-  md5: 3053283d0c0e78ab5935c9e17f803358
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.78.4-hd84c7bf_0.conda
+  sha256: 071cb1dc84dbac95c7d0056a6f04a84b68e364db97af82476ebbaa8a6e3480e9
+  md5: 3295bd48d87b4bd8d6277ea9c4d67e3b
   depends:
-  - libgcc >=13
-  - libglib 2.82.2 hc486b8e_0
+  - libgcc-ng >=12
+  - libglib 2.78.4 h311d5f7_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   license: LGPL-2.1-or-later
-  size: 126325
-  timestamp: 1729191584153
+  size: 122978
+  timestamp: 1708284924796
+- kind: conda
+  name: glib-tools
+  version: 2.78.4
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.4-hfc55251_0.conda
+  sha256: e94494b895f77ba54922ffb1dcfb7f1a987591b823eb5ce608afb2e2391d7d82
+  md5: d184ba1bf15a2bbb3be6118c90fd487d
+  depends:
+  - libgcc-ng >=12
+  - libglib 2.78.4 h783c2da_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later
+  size: 111383
+  timestamp: 1708284914557
 - kind: conda
   name: gmp
   version: 6.3.0
@@ -3684,6 +3738,44 @@ packages:
   license: GPL-2.0-or-later OR LGPL-3.0-or-later
   size: 460055
   timestamp: 1718980856608
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: hb077bed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
+  sha256: 52d824a5d2b8a5566cd469cae6ad6920469b5a15b3e0ddc609dd29151be71be2
+  md5: 33eded89024f21659b1975886a4acf70
+  depends:
+  - libgcc-ng >=12
+  - libidn2 >=2,<3.0a0
+  - libstdcxx-ng >=12
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1974935
+  timestamp: 1701111180127
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: hb309da9_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
+  sha256: 8c69e7e8073e3a9c5c4c4e0cd77e406abcf2a41b0cd3b98edbb5c6d612fd4562
+  md5: 324ec92c368d1ae5f40fe93470ec0317
+  depends:
+  - libgcc-ng >=12
+  - libidn2 >=2,<3.0a0
+  - libstdcxx-ng >=12
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 2021021
+  timestamp: 1701110217449
 - kind: conda
   name: graphite2
   version: 1.3.13
@@ -3735,144 +3827,148 @@ packages:
   timestamp: 1711634622644
 - kind: conda
   name: gst-plugins-base
-  version: 1.24.7
-  build: h0a52356_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
-  sha256: 6606a2686c0aed281a60fb546703e62c66ea9afa1e46adcca5eb428a3ff67f9e
-  md5: d368425fbd031a2f8e801a40c3415c72
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.12,<1.3.0a0
-  - gstreamer 1.24.7 hf3bb09a_0
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
-  - libogg >=1.3.5,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx >=13
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libxcb >=1.16,<2.0.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  - xorg-libxxf86vm >=1.1.5,<2.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2822378
-  timestamp: 1725536496791
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: h570c1df_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
-  sha256: d6db93e096d0213dd14004a0bd084f11b2d5af4a35a7ac319611c2885f87dc28
-  md5: 8d35b3a3d8b4a85ab93ab40314c9246a
-  depends:
-  - alsa-lib >=1.2.12,<1.3.0a0
-  - gstreamer 1.24.7 h37d20eb_0
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
-  - libogg >=1.3.5,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx >=13
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libxcb >=1.16,<2.0.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  - xorg-libxxf86vm >=1.1.5,<2.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2761700
-  timestamp: 1725540779840
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: hb0a98b8_0
+  version: 1.22.9
+  build: h001b923_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
-  sha256: c8951e6af014cdeff2de740d1e6e4781ac6813853739c56c6e07266e7aefcf28
-  md5: 92edfae477856e97db6c2610dea95bb1
+  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_1.conda
+  sha256: e2c37128de5bdc12e3656c9c50e7b1459d8890ea656b866e68293e334356b652
+  md5: ef961ec5b46ac75cebd3d68460691c27
   depends:
-  - gstreamer 1.24.7 h5006eae_0
-  - libglib >=2.80.3,<3.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libogg >=1.3.5,<1.4.0a0
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer 1.22.9 hb4038d2_1
+  - libglib >=2.78.4,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
   - libvorbis >=1.3.7,<1.4.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2061727
-  timestamp: 1725537068521
+  size: 2035564
+  timestamp: 1711211913043
 - kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: h37d20eb_0
+  name: gst-plugins-base
+  version: 1.22.9
+  build: h6d82d15_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
-  sha256: 85a9acd103a2477506c3c92b27dcd4ec5f77bab353fa7a33817f0894bb11a824
-  md5: c672dd04a62139ba21f2ba130b88f235
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h6d82d15_0.conda
+  sha256: 3590c472419063398d53efe1c14342a8cb566e4caad71e30cd01b61498a1afcd
+  md5: f931eeddcd3ae8698ab520656b4509aa
   depends:
-  - glib >=2.80.3,<3.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx >=13
+  - alsa-lib >=1.2.10,<1.3.0.0a0
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer 1.22.9 hed71854_0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2027297
-  timestamp: 1725538984316
+  size: 2667153
+  timestamp: 1706159806777
+- kind: conda
+  name: gst-plugins-base
+  version: 1.22.9
+  build: h8e1006c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
+  sha256: a4312c96a670fdbf9ff0c3efd935e42fa4b655ff33dcc52c309b76a2afaf03f0
+  md5: 614b81f8ed66c56b640faee7076ad14a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer 1.22.9 h98fc4e7_0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2709696
+  timestamp: 1706154948546
 - kind: conda
   name: gstreamer
-  version: 1.24.7
-  build: h5006eae_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
-  sha256: bd3ad109ef3e2e49da8710ff49378b3fa5da916aa2351d932d1b9018b7123512
-  md5: 58e1df95fdab219039e39033302771e8
+  version: 1.22.9
+  build: h98fc4e7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
+  sha256: aa2395bf1790f72d2706bac77430f765ec1318ca22e60e791c13ae452c045263
+  md5: bcc7157b06fce7f5e055402a8135dfd8
   depends:
-  - glib >=2.80.3,<3.0a0
-  - libglib >=2.80.3,<3.0a0
+  - __glibc >=2.17,<3.0.a0
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.3,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
   - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1981554
+  timestamp: 1706154826325
+- kind: conda
+  name: gstreamer
+  version: 1.22.9
+  build: hb4038d2_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_1.conda
+  sha256: 4d42bc24434db62c093748ea3ad0b6ba3872b6810b761363585513ebd79b4f87
+  md5: 70557ab875e72c1f21e8d2351aeb9c54
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.4,<3.0a0
+  - libglib >=2.78.4,<3.0a0
+  - libiconv >=1.17,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2022487
-  timestamp: 1725536894511
+  size: 1936661
+  timestamp: 1711211717228
 - kind: conda
   name: gstreamer
-  version: 1.24.7
-  build: hf3bb09a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
-  sha256: 9c059cc7dcb2732da8face18b1c0351da148ef26db0563fed08e818ea0515bb1
-  md5: c78bc4ef0afb3cd2365d9973c71fc876
+  version: 1.22.9
+  build: hed71854_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_0.conda
+  sha256: 248b95cb18326001b0eccf8aaaa2bd167bab2d95fa05781744ed9bd0e38183f7
+  md5: 076c2e12d015e6b2542bd3e6d6168fee
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - glib >=2.80.3,<3.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.3,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
   - libiconv >=1.17,<2.0a0
-  - libstdcxx >=13
+  - libstdcxx-ng >=12
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2023966
-  timestamp: 1725536373253
+  size: 1988942
+  timestamp: 1706157645872
 - kind: conda
   name: gts
   version: 0.7.6
@@ -3927,135 +4023,185 @@ packages:
   timestamp: 1686545222091
 - kind: conda
   name: harfbuzz
-  version: 9.0.0
-  build: h2bedf89_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
-  sha256: 20f42ec76e075902c22c1f8ddc71fb88eff0b93e74f5705c1e72220030965810
-  md5: 254f119aaed2c0be271c1114ae18d09b
+  version: 8.3.0
+  build: h3d44ed6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
+  sha256: 4b55aea03b18a4084b750eee531ad978d4a3690f63019132c26c6ad26bbe3aed
+  md5: 5a6f6c00ef982a9bc83558d9ac8f64a0
   depends:
   - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
   - graphite2
-  - icu >=75.1,<76.0a0
-  - libglib >=2.80.3,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.1,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1547473
+  timestamp: 1699925311766
+- kind: conda
+  name: harfbuzz
+  version: 8.3.0
+  build: h7ab893a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.3.0-h7ab893a_0.conda
+  sha256: 5365595303d95810d10662b46f9e857cedc82757cc7b5576bda30e15d66bb3ad
+  md5: b8ef0beb91df83c5e6038c9509b9f730
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=73.2,<74.0a0
+  - libglib >=2.78.1,<3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 1095620
-  timestamp: 1721187287831
+  size: 1070592
+  timestamp: 1699926990335
 - kind: conda
   name: harfbuzz
-  version: 9.0.0
-  build: hbf49d6b_1
-  build_number: 1
+  version: 8.3.0
+  build: hebeb849_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
-  sha256: 7496782c3bc0ebbb4de9bc92a3111f42b8a57417fa31ecb87058f250215fabc9
-  md5: ceb458f664cab8550fcd74fff26451db
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
+  sha256: f6f39bb13d0070565e8975ad5f23005ce894655422a1c50089e6d754c69be084
+  md5: 1c06a74f88f085c2af16809fe4c31b73
   depends:
   - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
   - graphite2
-  - icu >=75.1,<76.0a0
+  - icu >=73.2,<74.0a0
   - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
+  - libglib >=2.78.1,<3.0a0
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
-  size: 1614644
-  timestamp: 1721188789883
+  size: 1583124
+  timestamp: 1699927567410
 - kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: hda332d3_1
-  build_number: 1
+  name: hdf4
+  version: 4.2.15
+  build: h2a13503_7
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
-  sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
-  md5: 76b32dcf243444aea9c6b804bcfa40b8
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+  sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  md5: bd77f8da987968ec3927990495dc22e4
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
   - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
   - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 1603653
-  timestamp: 1721186240105
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_h13f6c1a_103
-  build_number: 103
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h13f6c1a_103.conda
-  sha256: 5cfbcaf9cd0c38fd9c97ea923cf1ec9720889d61092009bb6310b13328bdc934
-  md5: be63ad231183d7ebd7b7d0d46145a800
-  depends:
-  - libaec >=1.1.3,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgcc >=13
-  - libgfortran
-  - libgfortran5 >=13.3.0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 4018790
-  timestamp: 1730836761211
+  size: 756742
+  timestamp: 1695661547874
 - kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_h2d575fe_103
-  build_number: 103
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
-  sha256: 50bcd6cd6e8853321e87d359571d187f8e18fa1c73b711074e551417c2163483
-  md5: f8416d7ff13707bd8eb75d6b8235857e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libaec >=1.1.3,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgcc >=13
-  - libgfortran
-  - libgfortran5 >=13.3.0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3940636
-  timestamp: 1730830832687
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_hd5d9e70_103
-  build_number: 103
+  name: hdf4
+  version: 4.2.15
+  build: h5557f11_7
+  build_number: 7
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
-  sha256: c7fefe41464651e807f61d42803a670f25dbe0cb59677af97b9dda3e8cb675fd
-  md5: 6d72be86cae448cfc7bf93d51cd642bb
+  url: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+  sha256: 52fa5dde69758c19c69ab68a3d7ebfb2c9042e3a55d405c29a59d3b0584fd790
+  md5: 84344a916a73727c1326841007b52ca8
   depends:
-  - libaec >=1.1.3,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 2049966
-  timestamp: 1730830694091
+  size: 779637
+  timestamp: 1695662145568
+- kind: conda
+  name: hdf4
+  version: 4.2.15
+  build: hb6ba311_7
+  build_number: 7
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
+  sha256: 70d1e2d3e0b9ae1b149a31a4270adfbb5a4ceb2f8c36d17feffcd7bcb6208022
+  md5: e1b6676b77b9690d07ea25de48aed97e
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 773862
+  timestamp: 1695661552544
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_h2b43c12_105
+  build_number: 105
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
+  sha256: 56c803607a64b5117a8b4bcfdde722e4fa40970ddc4c61224b0981cbb70fb005
+  md5: 5788de34381caf624b78c4981618dc0a
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2039111
+  timestamp: 1717587493910
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_hd1676c9_105
+  build_number: 105
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_hd1676c9_105.conda
+  sha256: 1361452c161a780f0e1e7a185917d738b609327350ef1711430cd9e06a881b84
+  md5: 55dd1e8edf52fc44e71cf1c6890032c8
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3988950
+  timestamp: 1717596727874
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_hdf9ad27_105
+  build_number: 105
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
+  sha256: 2278fa07da6f96e807d402cd55480624d67d2dee202191aaaf278ce5ab23605a
+  md5: 7e1729554e209627636a0f6fabcdd115
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3911675
+  timestamp: 1717587866574
 - kind: conda
   name: humanfriendly
   version: '10.0'
@@ -4070,6 +4216,7 @@ packages:
   - __unix
   - python >=3.9
   license: MIT
+  license_family: MIT
   size: 73296
   timestamp: 1731259242894
 - kind: conda
@@ -4087,105 +4234,104 @@ packages:
   - pyreadline3
   - python >=3.9
   license: MIT
+  license_family: MIT
   size: 73777
   timestamp: 1731259588877
 - kind: conda
   name: icu
-  version: '75.1'
-  build: he02047a_0
+  version: '73.2'
+  build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
-  md5: 8b189310083baabfb622af68fd9d3ae3
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+  md5: cc47e1facc155f91abd89b11e48e72ff
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
-  size: 12129203
-  timestamp: 1720853576813
+  size: 12089150
+  timestamp: 1692900650789
 - kind: conda
   name: icu
-  version: '75.1'
-  build: he0c23c2_0
+  version: '73.2'
+  build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
-  sha256: 1d04369a1860a1e9e371b9fc82dd0092b616adcf057d6c88371856669280e920
-  md5: 8579b6bb8d18be7c0b27fb08adeeeb40
+  url: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+  sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
+  md5: 0f47d9e3192d9e09ae300da0d28e0f56
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 14544252
-  timestamp: 1720853966338
+  size: 13422193
+  timestamp: 1692901469029
 - kind: conda
   name: icu
-  version: '75.1'
-  build: hf9b3779_0
+  version: '73.2'
+  build: h787c7f5_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
-  sha256: 813298f2e54ef087dbfc9cc2e56e08ded41de65cff34c639cc8ba4e27e4540c9
-  md5: 268203e8b983fddb6412b36f2024e75c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
+  sha256: aedb9c911ede5596c87e1abd763ed940fab680d71fdb953bce8e4094119d47b3
+  md5: 9d3c29d71f28452a2e843aff8cbe09d2
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
-  size: 12282786
-  timestamp: 1720853454991
+  size: 12237094
+  timestamp: 1692900632394
 - kind: conda
   name: imath
-  version: 3.1.12
-  build: h7955e40_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
-  sha256: 4d8d07a4d5079d198168b44556fb86d094e6a716e8979b25a9f6c9c610e9fe56
-  md5: 37f5e1ab0db3691929f37dee78335d1b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 159630
-  timestamp: 1725971591485
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: hbb528cf_0
+  version: 3.1.11
+  build: h12be248_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
-  sha256: 184c796615cebaa73246f351144f164ee7b61ea809e4ba3c5d98fa9ca333e058
-  md5: c25af729c8c1c41f96202f8a96652bbe
+  url: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.11-h12be248_0.conda
+  sha256: fa7e36df9074ac6d1e67bd655a784b280e83d1cbac24fecdc5c21c716b832809
+  md5: c6849d593fda3d4992a8126d251f50c3
   depends:
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 160408
-  timestamp: 1725972042635
+  size: 160297
+  timestamp: 1709194525395
 - kind: conda
   name: imath
-  version: 3.1.12
-  build: hf428078_0
+  version: 3.1.11
+  build: hd84c7bf_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
-  sha256: ad8f18472425da83ba0e9324ab715f5d232cece8b0efaf218bd2ea9e1b6adb6d
-  md5: ae8535ff689663fe430bec00be24a854
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.11-hd84c7bf_0.conda
+  sha256: d638c7d4b83752864f9c4cbd088c06186086bd38925cc51168fd2ef43f0984ca
+  md5: 3029ebe5cd9a477ee282d80e09e7522a
   depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 153368
-  timestamp: 1725971683794
+  size: 154784
+  timestamp: 1709193935481
+- kind: conda
+  name: imath
+  version: 3.1.11
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.11-hfc55251_0.conda
+  sha256: b394465d3c6a9c5b17351562a87df2a5ef541d66f1a2d95d80fe28c9ca7638c3
+  md5: 07268e57799c7ad50809cadc297a515e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162530
+  timestamp: 1709194196768
 - kind: conda
   name: importlib-metadata
   version: 8.5.0
@@ -4232,33 +4378,35 @@ packages:
   timestamp: 1723739573141
 - kind: conda
   name: json-c
-  version: '0.18'
-  build: h6688a6e_0
+  version: '0.17'
+  build: h1220068_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
-  sha256: 09e706cb388d3ea977fabcee8e28384bdaad8ce1fc49340df5f868a2bd95a7da
-  md5: 38f5dbc9ac808e31c00650f7be1db93f
+  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h1220068_1.conda
+  sha256: 0caf06ccfbd6f9a7b3a1e09fa83e318c9e84f2d1c1003a9e486f2600f4096720
+  md5: f8f0f0c4338bad5c34a4e9e11460481d
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 82709
-  timestamp: 1726487116178
+  size: 83682
+  timestamp: 1720812978049
 - kind: conda
   name: json-c
-  version: '0.18'
-  build: hd4cd8d4_0
+  version: '0.17'
+  build: hf9262ea_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.18-hd4cd8d4_0.conda
-  sha256: 54794a9aaeabb4d9010574f92e13c20f2fe9a8b5ec7cacf033d50cc339c86e32
-  md5: 9c23430bcadd724434a88657abbeef46
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.17-hf9262ea_1.conda
+  sha256: 43d4fd9b19a367464d232b6fb0f8ee945328c4ece5c76b6e69b3f23d87f6e42f
+  md5: f9f65f64ab18c6bbbd6cd780c8ae3a1f
   depends:
-  - libgcc >=13
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 89391
-  timestamp: 1726487169057
+  size: 88473
+  timestamp: 1720813047136
 - kind: conda
   name: jsoncpp
   version: 1.9.6
@@ -4350,6 +4498,59 @@ packages:
   license_family: BSD
   size: 239104
   timestamp: 1703333860145
+- kind: conda
+  name: kealib
+  version: 1.5.3
+  build: h6c43f9b_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-h6c43f9b_2.conda
+  sha256: 19c981a049651439cfd851bbf785144d0f10db1f605ce19001a8eb27da6def94
+  md5: 873b3deabbefe46d00cc81ce7d9547a7
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 133242
+  timestamp: 1725399840908
+- kind: conda
+  name: kealib
+  version: 1.5.3
+  build: h8fde926_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/kealib-1.5.3-h8fde926_2.conda
+  sha256: c5eef2274b13963a420556af38e4ff381afddd70932d5af849ac628db5664dfd
+  md5: bf18eca141ff623d990be9a71d3060c5
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 151058
+  timestamp: 1725399311167
+- kind: conda
+  name: kealib
+  version: 1.5.3
+  build: hf8d3e68_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hf8d3e68_2.conda
+  sha256: a45cb038fce2b6fa154cf0c71485a75b59cb1d8d6b0465bdcb23736aca6bf2ac
+  md5: ffe68c611ae0ccfda4e7a605195e22b3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 180005
+  timestamp: 1725399272056
 - kind: conda
   name: kernel-headers_linux-64
   version: 3.10.0
@@ -4621,65 +4822,6 @@ packages:
   size: 194365
   timestamp: 1657977692274
 - kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
-  sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
-  md5: e1f604644fe8d78e22660e2fec6756bc
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  constrains:
-  - libabseil-static =20240722.0=cxx17*
-  - abseil-cpp =20240722.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1310521
-  timestamp: 1727295454064
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h5ad3122_1.conda
-  sha256: 590e47dce38031a8893e70491f3b71e214de7781cab53b6f017aa6f6841cb076
-  md5: 6fe6b3694c4792a8e26755d3b06f0b80
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  constrains:
-  - abseil-cpp =20240722.0
-  - libabseil-static =20240722.0=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1328502
-  timestamp: 1727295490806
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_he0c23c2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
-  sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
-  md5: 3f59a73b07a05530b252ecb07dd882b9
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libabseil-static =20240722.0=cxx17*
-  - abseil-cpp =20240722.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1777570
-  timestamp: 1727296115119
-- kind: conda
   name: libaec
   version: 1.1.3
   build: h2f0025b_0
@@ -4796,6 +4938,18 @@ packages:
 - kind: conda
   name: libasprintf
   version: 0.22.5
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+  sha256: 8e41136b7e4ec44c1c0bae0ff51cdb0d04e026d0b44eaaf5a9ff8b4e1b6b019b
+  md5: 9f661052be1d477dcf61ee3cd77ce5ee
+  license: LGPL-2.1-or-later
+  size: 49776
+  timestamp: 1723629333404
+- kind: conda
+  name: libasprintf
+  version: 0.22.5
   build: h87f4aca_3
   build_number: 3
   subdir: linux-aarch64
@@ -4824,6 +4978,20 @@ packages:
   license: LGPL-2.1-or-later
   size: 42817
   timestamp: 1723626012203
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_3.conda
+  sha256: bc04e8255b7f2edea6eb74fe0ee2eba7ce58d002de4f9bc57946f2b89bada062
+  md5: 524de7ba10ea8a2d85286beac4654119
+  depends:
+  - libasprintf 0.22.5 h5728263_3
+  license: LGPL-2.1-or-later
+  size: 36244
+  timestamp: 1723629552895
 - kind: conda
   name: libasprintf-devel
   version: 0.22.5
@@ -4857,47 +5025,48 @@ packages:
   timestamp: 1723626026096
 - kind: conda
   name: libass
-  version: 0.17.3
-  build: h1dc1e6a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
-  sha256: 52afd5e79681185ea33da0e7548aa3721be7e9a153a90f004c5adc33d61f7a14
-  md5: 2a66267ba586dadd110cc991063cfff7
+  version: 0.17.1
+  build: h36b5d3b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
+  sha256: 49e6709371fae03e2e1ee54914e8825511a1444b8a4e649cff7ffe565a20af35
+  md5: 9dd28617627c9ae4a0783402ab53e09f
   depends:
-  - __glibc >=2.17,<3.0.a0
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libexpat >=2.6.2,<3.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
   - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: ISC
   license_family: OTHER
-  size: 133110
-  timestamp: 1719985879751
+  size: 133027
+  timestamp: 1693027070371
 - kind: conda
   name: libass
-  version: 0.17.3
-  build: hcc173ff_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
-  sha256: 93d84d22f9fa360c175ce6b0bdd4ec33c0f6399eb6e6a17fcbf8b34375343528
-  md5: 7a3fcba797d23512f55ef23e68ae4ec9
+  version: 0.17.1
+  build: h8fe9dca_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
+  sha256: 1bc3e44239a11613627488b7a9b6c021ec6b52c5925abd666832db0cb2a59f05
+  md5: c306fd9cc90c0585171167d09135a827
   depends:
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libexpat >=2.6.2,<3.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
   - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: ISC
   license_family: OTHER
-  size: 145939
-  timestamp: 1719986023948
+  size: 126896
+  timestamp: 1693027051367
 - kind: conda
   name: libblas
   version: 3.9.0
@@ -4963,16 +5132,16 @@ packages:
 - kind: conda
   name: libboost
   version: 1.84.0
-  build: h444863b_6
-  build_number: 6
+  build: h9a677ad_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h444863b_6.conda
-  sha256: 35b268b5ba31a6a4672b260905dac64a05e8801199d11d934b1a766897612cc9
-  md5: 51b2f4207c1c2fc0b89de6dab95699a6
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h9a677ad_3.conda
+  sha256: f5f278d97f047c78399bd1bdae0400710b3a111ea410c04f83afccbaef85a85d
+  md5: 15fe09b41b103f6df1d21b7ddf8b2187
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -4981,53 +5150,94 @@ packages:
   constrains:
   - boost-cpp =1.84.0
   license: BSL-1.0
-  size: 2340139
-  timestamp: 1725326974927
+  size: 2429887
+  timestamp: 1715810207463
 - kind: conda
   name: libboost
   version: 1.84.0
-  build: hb8260a3_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-hb8260a3_6.conda
-  sha256: f0863cc9af17a6bff5add1a882ed57cb8a135ad81578e96855a73cf2d0760a45
-  md5: 6d387a528d4d10a97c6def56fa32d5a1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 2827751
-  timestamp: 1725325861944
-- kind: conda
-  name: libboost
-  version: 1.84.0
-  build: hcc9b45e_6
-  build_number: 6
+  build: hb41fec8_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.84.0-hcc9b45e_6.conda
-  sha256: 81917a4b9d9404b1f14d07deb49a954660e9b201c05f26a0fc0a916e63797fa0
-  md5: bff2d0382ffd2c7cc10a39555aafa473
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.84.0-hb41fec8_3.conda
+  sha256: 7b7e3866ad60acf5f95bde6a2512a42c96125bc7ce063e402b4388e5fc132bb1
+  md5: e281631562efb9990df969b61f51bfc4
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   constrains:
   - boost-cpp =1.84.0
   license: BSL-1.0
-  size: 3040559
-  timestamp: 1725325905578
+  size: 2960886
+  timestamp: 1715808268456
+- kind: conda
+  name: libboost
+  version: 1.84.0
+  build: hba137d9_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-hba137d9_3.conda
+  sha256: 5bcba13bdbae847c2e3a08e3357c35bdc01a7d593c3d35652d6cf696428b121b
+  md5: 0302d3052e643fd778d1021530b6a3e1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp =1.84.0
+  license: BSL-1.0
+  size: 2846684
+  timestamp: 1715807756203
+- kind: conda
+  name: libboost-headers
+  version: 1.86.0
+  build: h57928b3_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.86.0-h57928b3_2.conda
+  sha256: 46c16663537bc826bf588ef9e969d9640f30112fa5f1594e81e887b76191bbc1
+  md5: 7eb947a8d9ecad0ab0657bb1b664171f
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 14161145
+  timestamp: 1725335148281
+- kind: conda
+  name: libboost-headers
+  version: 1.86.0
+  build: h8af1aa0_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.86.0-h8af1aa0_2.conda
+  sha256: 9e6e0a45945311f70b4791fda7c24c226e6ce26678cfd4d3d8ee47d9c9c6a409
+  md5: dafa4e322422014641b36218da5c438e
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 14027520
+  timestamp: 1725333814862
+- kind: conda
+  name: libboost-headers
+  version: 1.86.0
+  build: ha770c72_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.86.0-ha770c72_2.conda
+  sha256: 3d35c77a0f61b0574c21e7f6c21fb2b4418207209ec0aca482150306462fa997
+  md5: 71c65a3b7692ad969ef238cb8dd1bfb0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 14067511
+  timestamp: 1725333818163
 - kind: conda
   name: libcap
   version: '2.69'
@@ -5171,89 +5381,115 @@ packages:
   size: 36657
   timestamp: 1687342325491
 - kind: conda
-  name: libclang-cpp19.1
-  version: 19.1.3
-  build: default_hb5137d0_0
+  name: libclang
+  version: 15.0.7
+  build: default_h127d8a8_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.3-default_hb5137d0_0.conda
-  sha256: 576c1826a91f93ef7c433fc6481334d21177996bd72ff6901f58fae8f6a765db
-  md5: 311e6a1d041db3d6a8a8437750d4234f
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h127d8a8_5.conda
+  sha256: 606b79c8a4a926334191d79f4a1447aac1d82c43344e3a603cbba31ace859b8f
+  md5: 09b94dd3a7e304df5b83176239347920
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libllvm19 >=19.1.3,<19.2.0a0
-  - libstdcxx >=13
+  - libclang13 15.0.7 default_h5d6823c_5
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 20548148
-  timestamp: 1730335997703
+  size: 133467
+  timestamp: 1711064002817
 - kind: conda
-  name: libclang-cpp19.1
-  version: 19.1.3
-  build: default_he324ac1_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.3-default_he324ac1_0.conda
-  sha256: fe708e1e180f77e414cc83e78b3171fbb4bd453a64a74a022918ddaeed654ef0
-  md5: 9ac4956d6676bdb251279d8c27406954
-  depends:
-  - libgcc >=13
-  - libllvm19 >=19.1.3,<19.2.0a0
-  - libstdcxx >=13
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 20104055
-  timestamp: 1730333285641
-- kind: conda
-  name: libclang13
-  version: 19.1.3
-  build: default_h4390ef5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.3-default_h4390ef5_0.conda
-  sha256: 95ca8571d07fd61851e04786d1c6d9830427c72a03873fb7c8b6b4114e548bb8
-  md5: d23cae404c2763d07fee33a9299f2d63
-  depends:
-  - libgcc >=13
-  - libllvm19 >=19.1.3,<19.2.0a0
-  - libstdcxx >=13
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 11612409
-  timestamp: 1730333501142
-- kind: conda
-  name: libclang13
-  version: 19.1.3
-  build: default_h9c6a7e4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.3-default_h9c6a7e4_0.conda
-  sha256: 7537cfefd76ffb0208484a2dc7d35d3752c6c42c80edabbc5f0dcae354d4b41e
-  md5: b8a8cd77810b20754f358f2327812552
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libllvm19 >=19.1.3,<19.2.0a0
-  - libstdcxx >=13
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 11827604
-  timestamp: 1730336232401
-- kind: conda
-  name: libclang13
-  version: 19.1.3
-  build: default_ha5278ca_0
+  name: libclang
+  version: 15.0.7
+  build: default_h3a3e6c3_5
+  build_number: 5
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.3-default_ha5278ca_0.conda
-  sha256: 02e9e0ee3f9a7b375d1a268f90f1f2ffe31bccacb904b9f36270255e9a02df6e
-  md5: fe6aa50eeb307558f8974f115305388f
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_h3a3e6c3_5.conda
+  sha256: 562dea76c17c30ed6d78734a9e40008f45cdab15611439d7d4e8250e0040f3ef
+  md5: 26e1a5a4ff7f8e3f5fb89be829818a75
   depends:
-  - libzlib >=1.3.1,<2.0a0
+  - libclang13 15.0.7 default_hf64faad_5
+  - libxml2 >=2.12.6,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zstd >=1.5.6,<1.6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 26749218
-  timestamp: 1730355727736
+  size: 148436
+  timestamp: 1711068015076
+- kind: conda
+  name: libclang
+  version: 15.0.7
+  build: default_hb368394_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_hb368394_5.conda
+  sha256: d1434b409bfb07b32e0ec11c84885b5bff6dbd5a56639a8a3fe221f409b64c90
+  md5: 9c12c3c12f5dab6ec1b6421149cbd09c
+  depends:
+  - libclang13 15.0.7 default_hf9b4efe_5
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 134146
+  timestamp: 1711066878589
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_h5d6823c_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h5d6823c_5.conda
+  sha256: 91ecfcf545a5d4588e9fad5db2b5b04eeef18cae1c03b790829ef8b978f06ccd
+  md5: 2d694a9ffdcc30e89dea34a8dcdab6ae
+  depends:
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 9583734
+  timestamp: 1711063939856
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_hf64faad_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_hf64faad_5.conda
+  sha256: b952b85a6124442be3fe8af23d56f123548f7b28067f60615f7233197469a02d
+  md5: 2f96c58f89abccb04bbc8cd57961111f
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21892425
+  timestamp: 1711067804682
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_hf9b4efe_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf9b4efe_5.conda
+  sha256: a274eac14210ad07fab66aaf611251b4e0f46260dd52d39b035ef5991837f448
+  md5: 873ad4ee72c905267ac4334456608985
+  depends:
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 9429799
+  timestamp: 1711066800274
 - kind: conda
   name: libcups
   version: 2.3.3
@@ -5292,124 +5528,110 @@ packages:
   timestamp: 1689195353551
 - kind: conda
   name: libcurl
-  version: 8.10.1
-  build: h1ee3ff0_0
+  version: 8.8.0
+  build: h4e8248e_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.8.0-h4e8248e_1.conda
+  sha256: 26e97d16d80beea469b85706f954978ff224e8b18c2b5e8f093bfb0406ba927f
+  md5: d3629660719854a4fc487c6a3dcd66b3
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 422332
+  timestamp: 1719602868026
+- kind: conda
+  name: libcurl
+  version: 8.8.0
+  build: hca28451_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_1.conda
+  sha256: 6b5b64cdcdb643368ebe236de07eedee99b025bb95129bbe317c46e5bdc693f3
+  md5: b8afb3e3cb3423cc445cf611ab95fdb0
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 410158
+  timestamp: 1719602718702
+- kind: conda
+  name: libcurl
+  version: 8.8.0
+  build: hd5e4a3a_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
-  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
-  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.8.0-hd5e4a3a_1.conda
+  sha256: ebe665ec226672e7e6e37f2b1fe554db83f9fea5267cbc5a849ab34d8546b2c3
+  md5: 88fbd2ea44690c6dfad8737659936461
   depends:
   - krb5 >=1.21.3,<1.22.0a0
   - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: curl
   license_family: MIT
-  size: 342388
-  timestamp: 1726660508261
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h3ec0cbf_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
-  sha256: 7c4983001c727f713b4448280ed4803d301087c184cd2819ba0b788ca62b73d1
-  md5: f43539295c4e0cd15202d41bc72b8a26
-  depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 439171
-  timestamp: 1726659843118
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: hbbe4b11_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
-  sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
-  md5: 6e801c50a40301f6978c53976917b277
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 424900
-  timestamp: 1726659794676
+  size: 334189
+  timestamp: 1719603160758
 - kind: conda
   name: libdeflate
-  version: '1.22'
-  build: h2466b09_0
+  version: '1.19'
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.19-h31becfc_0.conda
+  sha256: 77f04fced83cf1da09ffb7ef16d531ac889d944dbffe8a4dc00b61e4bae076a5
+  md5: 014e57e35f2dc95c9a12f63d4378e093
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 68075
+  timestamp: 1694922340786
+- kind: conda
+  name: libdeflate
+  version: '1.19'
+  build: hcfcfb64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
-  sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
-  md5: a3439ce12d4e3cd887270d9436f9a4c8
+  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+  sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
+  md5: 002b1b723b44dbd286b9e3708762433c
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 155506
-  timestamp: 1728177485361
+  size: 153203
+  timestamp: 1694922596415
 - kind: conda
   name: libdeflate
-  version: '1.22'
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
-  sha256: 986207f130703897300ddc3637c52e86a5b21c735fe384bf48554d9a6d91c56d
-  md5: ff6a44e8b1707d02be2fe9a36ea88d4a
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 69601
-  timestamp: 1728177137503
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: hb9d3cd8_0
+  version: '1.19'
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
-  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
-  md5: b422943d5d772b7cc858b36ad2a92db5
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+  sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
+  md5: 1635570038840ee3f9c71d22aa5b8b6d
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 72242
-  timestamp: 1728177071251
-- kind: conda
-  name: libdrm
-  version: 2.4.123
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
-  sha256: 9a5dc3585a6468b266fc80e21fd2b6f3d8236818ee3fa853b6972ab0a44d7804
-  md5: 4e3c67f6999ea7ccac41611f930d19d4
-  depends:
-  - libgcc-ng >=13
-  - libpciaccess >=0.18,<0.19.0a0
-  license: MIT
-  license_family: MIT
-  size: 273843
-  timestamp: 1724719291504
+  size: 67080
+  timestamp: 1694922285678
 - kind: conda
   name: libdrm
   version: 2.4.123
@@ -5490,35 +5712,6 @@ packages:
   license_family: BSD
   size: 134104
   timestamp: 1597617110769
-- kind: conda
-  name: libegl
-  version: 1.7.0
-  build: ha4b6fd6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
-  sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
-  md5: c151d5eb730e9b7480e6d48c0fc44048
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  license: LicenseRef-libglvnd
-  size: 44840
-  timestamp: 1731330973553
-- kind: conda
-  name: libegl
-  version: 1.7.0
-  build: hd24410f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
-  sha256: 8962abf38a58c235611ce356b9899f6caeb0352a8bce631b0bcc59352fda455e
-  md5: cf105bce884e4ef8c8ccdca9fe6695e7
-  depends:
-  - libglvnd 1.7.0 hd24410f_2
-  license: LicenseRef-libglvnd
-  size: 53551
-  timestamp: 1731330990477
 - kind: conda
   name: libev
   version: '4.33'
@@ -5814,142 +6007,172 @@ packages:
   size: 736802
   timestamp: 1721392376840
 - kind: conda
-  name: libgdal-core
-  version: 3.9.3
-  build: h042995d_2
-  build_number: 2
+  name: libgdal
+  version: 3.8.0
+  build: h0791e23_7
+  build_number: 7
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.3-h042995d_2.conda
-  sha256: 93db19e8d4c154f87858bf899df9939fd4d447813f1cf388ef19f9a45f18ef9f
-  md5: b44638b26dc33246d046a8ed3004ce46
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.8.0-h0791e23_7.conda
+  sha256: a5d8919d60f3d16001081a86fc123c2fe5dd3423135caec7bac0a15f61d4ab38
+  md5: 4ed7867f065c7a1196e198ac8a399dce
   depends:
-  - blosc >=1.21.6,<2.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - geotiff >=1.7.3,<1.8.0a0
+  - blosc >=1.21.5,<2.0a0
+  - cfitsio >=4.3.1,<4.3.2.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - kealib >=1.5.2,<1.6.0a0
   - lerc >=4.0.0,<5.0a0
-  - libarchive >=3.7.4,<3.8.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libexpat >=2.6.3,<3.0a0
+  - libaec >=1.1.2,<2.0a0
+  - libarchive >=3.7.2,<3.8.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libexpat >=2.5.0,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - libpng >=1.6.44,<1.7.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.1,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.11.6,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.3.2,<4.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - proj >=9.5.0,<9.6.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - poppler >=23.11.0,<23.12.0a0
+  - postgresql
+  - proj >=9.3.0,<9.3.1.0a0
+  - tiledb >=2.16,<2.17.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - xerces-c >=3.2.5,<3.3.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - libgdal 3.9.3.*
+  - zstd >=1.5.5,<1.6.0a0
   license: MIT
   license_family: MIT
-  size: 8035558
-  timestamp: 1730221244847
+  size: 8784714
+  timestamp: 1701002604278
 - kind: conda
-  name: libgdal-core
-  version: 3.9.3
-  build: h80360e1_2
-  build_number: 2
+  name: libgdal
+  version: 3.8.0
+  build: h18a4eec_7
+  build_number: 7
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.9.3-h80360e1_2.conda
-  sha256: a273ec4f9155d339c384cd60fab93cbdccb68bac95f8d74eebdc86a729b828d2
-  md5: 84d63c4f16d469872cddfe3d749e66cc
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-3.8.0-h18a4eec_7.conda
+  sha256: 35990ccf440380ba1455af22ae71e9a086e85d06f677ddbe4fd8e96d92d19d66
+  md5: e6506d2f0f6f86bcc774a1294de5cfb8
   depends:
-  - blosc >=1.21.6,<2.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - geotiff >=1.7.3,<1.8.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
+  - blosc >=1.21.5,<2.0a0
+  - cfitsio >=4.3.1,<4.3.2.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - json-c >=0.17,<0.18.0a0
+  - kealib >=1.5.2,<1.6.0a0
   - lerc >=4.0.0,<5.0a0
-  - libarchive >=3.7.4,<3.8.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
+  - libaec >=1.1.2,<2.0a0
+  - libarchive >=3.7.2,<3.8.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - libpng >=1.6.44,<1.7.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.1,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
   - libuuid >=2.38.1,<3.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.11.6,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.3.2,<4.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - xerces-c >=3.2.5,<3.3.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - poppler >=23.11.0,<23.12.0a0
+  - postgresql
+  - proj >=9.3.0,<9.3.1.0a0
+  - tiledb >=2.16,<2.17.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - libgdal 3.9.3.*
+  - zstd >=1.5.5,<1.6.0a0
   license: MIT
   license_family: MIT
-  size: 10264896
-  timestamp: 1730220235563
+  size: 10634978
+  timestamp: 1701001248111
 - kind: conda
-  name: libgdal-core
-  version: 3.9.3
-  build: hd5b9bfb_2
-  build_number: 2
+  name: libgdal
+  version: 3.8.0
+  build: h4d9a814_7
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.3-hd5b9bfb_2.conda
-  sha256: ac788fcbb7ae09f7d771f08ecfd4a985af8e608e8ae7b04a878dced496cd0d48
-  md5: b70c6b3de9d4779d40dc3194f3958889
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.8.0-h4d9a814_7.conda
+  sha256: c0db0e39d4d606dc1dd4c8852c9fc36992536fc1275be10c46a6515a2aba0b2c
+  md5: b86d1e4b9ee4969e7e390c6f4598d381
   depends:
   - __glibc >=2.17,<3.0.a0
-  - blosc >=1.21.6,<2.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - geotiff >=1.7.3,<1.8.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
+  - blosc >=1.21.5,<2.0a0
+  - cfitsio >=4.3.1,<4.3.2.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - json-c >=0.17,<0.18.0a0
+  - kealib >=1.5.2,<1.6.0a0
   - lerc >=4.0.0,<5.0a0
-  - libarchive >=3.7.4,<3.8.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
+  - libaec >=1.1.2,<2.0a0
+  - libarchive >=3.7.2,<3.8.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - libpng >=1.6.44,<1.7.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.1,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
   - libuuid >=2.38.1,<3.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.11.6,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.3.2,<4.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - xerces-c >=3.2.5,<3.3.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - poppler >=23.11.0,<23.12.0a0
+  - postgresql
+  - proj >=9.3.0,<9.3.1.0a0
+  - tiledb >=2.16,<2.17.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - libgdal 3.9.3.*
+  - zstd >=1.5.5,<1.6.0a0
   license: MIT
   license_family: MIT
-  size: 10427151
-  timestamp: 1730219530936
+  size: 11069562
+  timestamp: 1701001067510
 - kind: conda
   name: libgettextpo
   version: 0.22.5
@@ -5965,6 +6188,22 @@ packages:
   license_family: GPL
   size: 199824
   timestamp: 1723626215655
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+  sha256: 6747bd29a0896b21ee1fe07bd212210475655354a3e8033c25b797e054ddd821
+  md5: e46c142e2d2d9ccef31ad3d176b10fab
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 171120
+  timestamp: 1723629671164
 - kind: conda
   name: libgettextpo
   version: 0.22.5
@@ -5997,6 +6236,23 @@ packages:
   license_family: GPL
   size: 36989
   timestamp: 1723626232155
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_3.conda
+  sha256: 5039a89ebb9751408a2f507afb344241afe47a4e1b06c281af2decf5b734f79a
+  md5: e618841b85fefbb8b76d2caa163baaec
+  depends:
+  - libgettextpo 0.22.5 h5728263_3
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 40036
+  timestamp: 1723629819549
 - kind: conda
   name: libgettextpo-devel
   version: 0.22.5
@@ -6049,6 +6305,36 @@ packages:
   size: 54105
   timestamp: 1729089471124
 - kind: conda
+  name: libgfortran-ng
+  version: 14.2.0
+  build: h69a702a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
+  sha256: 423f1e2403f0c665748e42d335e421e53fd03c08d457cfb6f360d329d9459851
+  md5: 0a7f4cd238267c88e5d69f7826a407eb
+  depends:
+  - libgfortran 14.2.0 h69a702a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54106
+  timestamp: 1729027945817
+- kind: conda
+  name: libgfortran-ng
+  version: 14.2.0
+  build: he9431aa_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
+  sha256: cdd5bae1e33d6bdafe837c2e6ea594faf5bb7f880272ac1984468c7967adff41
+  md5: 5e90005d310d69708ba0aa7f4fed1de6
+  depends:
+  - libgfortran 14.2.0 he9431aa_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54111
+  timestamp: 1729089714658
+- kind: conda
   name: libgfortran5
   version: 14.2.0
   build: hb6113d0_1
@@ -6083,162 +6369,108 @@ packages:
   size: 1462645
   timestamp: 1729027735353
 - kind: conda
-  name: libgl
-  version: 1.7.0
-  build: ha4b6fd6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-  sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
-  md5: 928b8be80851f5d8ffb016f9c81dae7a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  - libglx 1.7.0 ha4b6fd6_2
-  license: LicenseRef-libglvnd
-  size: 134712
-  timestamp: 1731330998354
-- kind: conda
-  name: libgl
-  version: 1.7.0
-  build: hd24410f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
-  sha256: 3e954380f16255d1c8ae5da3bd3044d3576a0e1ac2e3c3ff2fe8f2f1ad2e467a
-  md5: 0d00176464ebb25af83d40736a2cd3bb
-  depends:
-  - libglvnd 1.7.0 hd24410f_2
-  - libglx 1.7.0 hd24410f_2
-  license: LicenseRef-libglvnd
-  size: 145442
-  timestamp: 1731331005019
-- kind: conda
   name: libglib
-  version: 2.82.2
-  build: h2ff4ddf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
-  sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
-  md5: 13e8e54035ddd2b91875ba399f0f7c04
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=13
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  constrains:
-  - glib 2.82.2 *_0
-  license: LGPL-2.1-or-later
-  size: 3931898
-  timestamp: 1729191404130
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h7025463_0
+  version: 2.78.4
+  build: h16e383f_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
-  sha256: 7dfbf492b736f8d379f8c3b32a823f0bf2167ff69963e4c940339b146a04c54a
-  md5: 3e379c1b908a7101ecbc503def24613f
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.4-h16e383f_0.conda
+  sha256: d4350c4c8d7947b4f1b13918e04f07a35d2eb88cc1b6bccefe12eb92bd1aa660
+  md5: 72dc4e1cdde0894015567c90f9c4e261
   depends:
+  - gettext >=0.21.1,<1.0a0
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.42,<10.43.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - glib 2.82.2 *_0
+  - glib 2.78.4 *_0
   license: LGPL-2.1-or-later
-  size: 3810166
-  timestamp: 1729192227078
+  size: 2627113
+  timestamp: 1708285165773
 - kind: conda
   name: libglib
-  version: 2.82.2
-  build: hc486b8e_0
+  version: 2.78.4
+  build: h311d5f7_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
-  sha256: 6797d24de7acd298f81a86078c64e4f3fea6d551a3e8892205c9e72a37a7cc3c
-  md5: 47f6d85fe47b865e56c539f2ba5f4dad
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.78.4-h311d5f7_0.conda
+  sha256: 4af15473d7caf710092847aca9753c6238437bedf331a0c03c58493e6e0f0c74
+  md5: dbd5d88e94a97bd81602a1927b721008
   depends:
+  - gettext >=0.21.1,<1.0a0
   - libffi >=3.4,<4.0a0
-  - libgcc >=13
+  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.42,<10.43.0a0
   constrains:
-  - glib 2.82.2 *_0
+  - glib 2.78.4 *_0
   license: LGPL-2.1-or-later
-  size: 4020802
-  timestamp: 1729191545578
+  size: 2784381
+  timestamp: 1708284870003
+- kind: conda
+  name: libglib
+  version: 2.78.4
+  build: h783c2da_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.4-h783c2da_0.conda
+  sha256: 3a03a5254d2fd29c1e0ffda7250e22991dfbf2c854301fd56c408d97a647cfbd
+  md5: d86baf8740d1a906b9716f2a0bac2f2d
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  constrains:
+  - glib 2.78.4 *_0
+  license: LGPL-2.1-or-later
+  size: 2692079
+  timestamp: 1708284870228
 - kind: conda
   name: libglu
   version: 9.0.0
-  build: h5eeb66e_1004
-  build_number: 1004
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
-  sha256: d4b60ab4337f7513c2c40419b04f3f8d71dc12bdf7e5baf0517d936296f11d78
-  md5: 0554e8a9ccab69bc8033d0bebed1b933
+  build: hac7e632_1003
+  build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
+  sha256: 8368435c41105dc3e1c02896a02ecaa21b77d0b0d67fc8b06a16ba885c86f917
+  md5: 50c389a09b6b7babaef531eb7cb5e0ca
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
+  license: SGI-2
+  size: 331249
+  timestamp: 1694431884320
+- kind: conda
+  name: libglu
+  version: 9.0.0
+  build: hf4b6fbe_1003
+  build_number: 1003
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
+  sha256: fdb8b42c6e2ad5c70d7f05c4f4d87d20fa38468146e61ddf66cc42fdc5e99ef7
+  md5: 815755517215132a05c485e748449a38
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
   - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-xextproto >=7.3.0,<8.0a0
   license: SGI-2
-  size: 317747
-  timestamp: 1718880641384
-- kind: conda
-  name: libglu
-  version: 9.0.0
-  build: ha6d2627_1004
-  build_number: 1004
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
-  sha256: c4a14878c2be8c18b7e89a19917f0f6c964dd962c91a079fe5e0c6e8b8b1bbd4
-  md5: df069bea331c8486ac21814969301c1f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-xextproto >=7.3.0,<8.0a0
-  license: SGI-2
-  size: 325824
-  timestamp: 1718880563533
-- kind: conda
-  name: libglvnd
-  version: 1.7.0
-  build: ha4b6fd6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
-  sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
-  md5: 434ca7e50e40f4918ab701e3facd59a0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  license: LicenseRef-libglvnd
-  size: 132463
-  timestamp: 1731330968309
-- kind: conda
-  name: libglvnd
-  version: 1.7.0
-  build: hd24410f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
-  sha256: 57ec3898a923d4bcc064669e90e8abfc4d1d945a13639470ba5f3748bd3090da
-  md5: 9e115653741810778c9a915a2f8439e7
-  license: LicenseRef-libglvnd
-  size: 152135
-  timestamp: 1731330986070
+  size: 317590
+  timestamp: 1694431968293
 - kind: conda
   name: libglvnd-core-devel-cos7-aarch64
   version: 1.0.1
@@ -6486,37 +6718,6 @@ packages:
   size: 63006
   timestamp: 1726579374514
 - kind: conda
-  name: libglx
-  version: 1.7.0
-  build: ha4b6fd6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-  sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
-  md5: c8013e438185f33b13814c5c488acd5c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  - xorg-libx11 >=1.8.10,<2.0a0
-  license: LicenseRef-libglvnd
-  size: 75504
-  timestamp: 1731330988898
-- kind: conda
-  name: libglx
-  version: 1.7.0
-  build: hd24410f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
-  sha256: 6591af640cb05a399fab47646025f8b1e1a06a0d4bbb4d2e320d6629b47a1c61
-  md5: 1d4269e233636148696a67e2d30dad2a
-  depends:
-  - libglvnd 1.7.0 hd24410f_2
-  - xorg-libx11 >=1.8.9,<2.0a0
-  license: LicenseRef-libglvnd
-  size: 77736
-  timestamp: 1731330998960
-- kind: conda
   name: libgomp
   version: 14.2.0
   build: h77fa898_1
@@ -6679,6 +6880,36 @@ packages:
   size: 705775
   timestamp: 1702682170569
 - kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
+  sha256: 0227930e1cf1d326cfe04a17392587840cf180a91c15fbc38da8ebd297cc4146
+  md5: 7b87508d7df33b9b0e68cea0fcfef12a
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  size: 138303
+  timestamp: 1706370220301
+- kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
+  sha256: 253f9be445c58bf07b39d8f67ac08bccc5010c75a8c2070cddfb6c20e1ca4f4f
+  md5: 2b7b0d827c6447cc1d85dc06d5b5de46
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  size: 126515
+  timestamp: 1706368269716
+- kind: conda
   name: libintl
   version: 0.22.5
   build: h5728263_3
@@ -6760,62 +6991,64 @@ packages:
 - kind: conda
   name: libkml
   version: 1.3.0
-  build: h538826c_1021
-  build_number: 1021
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
-  sha256: 81a6096a2db500f0c3527ae59398eacca0634c3381559713ab28022d711dd3bd
-  md5: 431ec3b40b041576811641e2d643954e
+  build: h01aab08_1018
+  build_number: 1018
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h01aab08_1018.conda
+  sha256: f67fc0be886c7eac14dbce858bfcffbc90a55b598e897e513f0979dd2caad750
+  md5: 3eb5f16bcc8a02892199aa63555c731f
   depends:
-  - libexpat >=2.6.2,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libboost-headers
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - uriparser >=0.9.7,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 513804
+  timestamp: 1696451330826
+- kind: conda
+  name: libkml
+  version: 1.3.0
+  build: h7d16752_1018
+  build_number: 1018
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libkml-1.3.0-h7d16752_1018.conda
+  sha256: 3695e5046f617307a9c2b01763d81fc584c900d2da1b7186fe54d40c16cacc4c
+  md5: 0a2cb881ed5cf04e6e05079ee0a7a18b
+  depends:
+  - libboost-headers
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - uriparser >=0.9.7,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 482999
+  timestamp: 1696451010797
+- kind: conda
+  name: libkml
+  version: 1.3.0
+  build: haf3e7a6_1018
+  build_number: 1018
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-haf3e7a6_1018.conda
+  sha256: 74117fe100d9aa3aaab25eb705c44165f8ff6feec2e7c058212a3f5434f85d5f
+  md5: 950e8765b20b79ecbd296543f848b4ec
+  depends:
+  - libboost-headers
+  - libexpat >=2.5.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
-  - uriparser >=0.9.8,<1.0a0
+  - uriparser >=0.9.7,<1.0a0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 1651104
-  timestamp: 1724667610262
-- kind: conda
-  name: libkml
-  version: 1.3.0
-  build: h62bc5a7_1021
-  build_number: 1021
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libkml-1.3.0-h62bc5a7_1021.conda
-  sha256: a6de6940f220bbfb3af7396635b90f09d6ea49a489f478ee563b7b7263ceb961
-  md5: dfa83014442562a942f78942a259d07e
-  depends:
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc-ng >=13
-  - libstdcxx-ng >=13
-  - libzlib >=1.3.1,<2.0a0
-  - uriparser >=0.9.8,<1.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 373869
-  timestamp: 1724666898774
-- kind: conda
-  name: libkml
-  version: 1.3.0
-  build: hf539b9f_1021
-  build_number: 1021
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
-  sha256: 721c3916d41e052ffd8b60e77f2da6ee47ff0d18babfca48ccf93606f1e0656a
-  md5: e8c7620cc49de0c6a2349b6dd6e39beb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc-ng >=13
-  - libstdcxx-ng >=13
-  - libzlib >=1.3.1,<2.0a0
-  - uriparser >=0.9.8,<1.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 402219
-  timestamp: 1724667059411
+  size: 1764160
+  timestamp: 1696451646350
 - kind: conda
   name: liblapack
   version: 3.9.0
@@ -6874,83 +7107,168 @@ packages:
   size: 3736560
   timestamp: 1729643588182
 - kind: conda
-  name: libllvm19
-  version: 19.1.3
-  build: h2edbd07_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.3-h2edbd07_0.conda
-  sha256: b61b78b600ee09006512973b4f79b3efda5013bfcb3ed2563ec7c0d9bbdf44c3
-  md5: 4f335bb2183b2a9a062518cbc079dc8b
+  name: libllvm15
+  version: 15.0.7
+  build: hb3ce162_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
+  sha256: e71584c0f910140630580fdd0a013029a52fd31e435192aea2aa8d29005262d1
+  md5: 8a35df3cbc0c8b12cc8af9473ae75eef
   depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libxml2 >=2.13.4,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 39439341
-  timestamp: 1730296177275
+  size: 33321457
+  timestamp: 1701375836233
 - kind: conda
-  name: libllvm19
-  version: 19.1.3
-  build: ha7bfdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.3-ha7bfdaf_0.conda
-  sha256: 44502d37011472549367110a58ea78ff6c627f9436d1e4ebb5b34f80763dbf2a
-  md5: 8bd654307c455162668cd66e36494000
+  name: libllvm15
+  version: 15.0.7
+  build: hb4f23b0_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
+  sha256: 12da3344f2ef37dcb80b4e2d106cf36ebc267c3be6211a8306dd1dbf07399d61
+  md5: 8d7aa8eae04dc19426a417528d7041eb
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libxml2 >=2.13.4,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 40124530
-  timestamp: 1730301303455
+  size: 32882415
+  timestamp: 1701366839578
 - kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: h161d5f1_0
+  name: libnetcdf
+  version: 4.9.2
+  build: nompi_h135f659_114
+  build_number: 114
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
-  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
-  md5: 19e57602824042dfd0446292ef90488b
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
+  sha256: 055572a4c8a1c3f9ac60071ee678f5ea49cfd7ac60a636d817988a6f9d6de6ae
+  md5: a908e463c710bd6b10a9eaa89fdf003c
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - c-ares >=1.32.3,<2.0a0
-  - libev >=4.33,<4.34.0a0
-  - libev >=4.33,<5.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<3.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
   license: MIT
   license_family: MIT
-  size: 647599
-  timestamp: 1729571887612
+  size: 849172
+  timestamp: 1717671645362
+- kind: conda
+  name: libnetcdf
+  version: 4.9.2
+  build: nompi_h9180261_114
+  build_number: 114
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h9180261_114.conda
+  sha256: 287922068a7d6289c924377056e70697bc394d77e4f49206e6fa66167140d410
+  md5: 11142bc63a8d949f5f7e1f7c90c08f4a
+  depends:
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<3.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 859784
+  timestamp: 1717671546549
+- kind: conda
+  name: libnetcdf
+  version: 4.9.2
+  build: nompi_h92078aa_114
+  build_number: 114
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
+  sha256: 111fb98bf02e717c69eb78388a5b03dc7af05bfa840ac51c2b31beb70bf42318
+  md5: 819507db3802d9a179de4d161285c22f
+  depends:
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 624793
+  timestamp: 1717672198533
 - kind: conda
   name: libnghttp2
-  version: 1.64.0
-  build: hc8609a4_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
-  sha256: c093c6d370aadbf0409c20b6c54c488ee2f6fea976181919fcc63e87ee232673
-  md5: f52c614fa214a8bedece9421c771670d
+  version: 1.58.0
+  build: h47da74e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+  sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
+  md5: 700ac6ea6d53d5510591c4344d5c989a
   depends:
-  - c-ares >=1.32.3,<2.0a0
+  - c-ares >=1.23.0,<2.0a0
   - libev >=4.33,<4.34.0a0
   - libev >=4.33,<5.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
   license: MIT
   license_family: MIT
-  size: 714610
-  timestamp: 1729571912479
+  size: 631936
+  timestamp: 1702130036271
+- kind: conda
+  name: libnghttp2
+  version: 1.58.0
+  build: hb0e430d_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
+  sha256: ecc11e4f92f9d5830a90d42b4db55c66c4ad531e00dcf30d55171d934a568cb5
+  md5: 8f724cdddffa79152de61f5564a3526b
+  depends:
+  - c-ares >=1.23.0,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 677508
+  timestamp: 1702130071743
 - kind: conda
   name: libnsl
   version: 2.0.1
@@ -7120,416 +7438,367 @@ packages:
   timestamp: 1730773029647
 - kind: conda
   name: libopenvino
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
+  version: 2023.2.0
+  build: h2e90f83_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_2.conda
-  sha256: 1f804b6238951d59b3a431c2e01bd831d44e015ea6835809775bb60b6978e3b3
-  md5: ba5ac0bb9ec5aec38dec37c230b12d64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.2.0-h2e90f83_1.conda
+  sha256: 423c287b5301960dd2cec7bc8a99a992ca2403b15fea02acfd20870379a9beda
+  md5: 64ed03a487353cd858dd7babd29583b0
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 5362131
-  timestamp: 1729594675874
+  - tbb >=2021.11.0
+  size: 6023645
+  timestamp: 1705192870721
 - kind: conda
   name: libopenvino
-  version: 2024.4.0
-  build: hd7d4d4f_2
-  build_number: 2
+  version: 2023.2.0
+  build: h3e0449b_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_2.conda
-  sha256: fa92fa4e9da3cb1a6ac37004c0f63922e62d3b2fe631385c923436a51d76005e
-  md5: 842ca0bee620b70ce30d397d7eb47d26
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2023.2.0-h3e0449b_1.conda
+  sha256: 45a8d8dae8f28cf11692b730613f547ce6f9539af259f8456e2891a5cc3eb16a
+  md5: 42b33c5d79d9fe3475244c8793a68834
   depends:
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 4902384
-  timestamp: 1729590142049
+  - tbb >=2021.11.0
+  size: 5469865
+  timestamp: 1705189441751
 - kind: conda
   name: libopenvino-arm-cpu-plugin
-  version: 2024.4.0
-  build: hd7d4d4f_2
-  build_number: 2
+  version: 2023.2.0
+  build: h3e0449b_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_2.conda
-  sha256: f8c598062b07f7c7047c1a3fe5479aad30884cf02bbb49842e9fdcd1ed1468fb
-  md5: e5817f6e796293f49bd94c9ce47b2d69
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2023.2.0-h3e0449b_1.conda
+  sha256: a5558df411585802e7bd611922cfbb7893c53ba1f999c0aa6898b192c1dea311
+  md5: 7b0182381d4f613341b4a20ac50a9dbf
   depends:
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 8377593
-  timestamp: 1729590158748
+  - tbb >=2021.11.0
+  size: 5893804
+  timestamp: 1705189507927
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: h4d9b6c2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_2.conda
-  sha256: dc596ff555b7ae19a7cd62af8965445575e1441dd486b8aec6a647f9ecbada3a
-  md5: 1d05a25da36ba5f98291d7237fc6b8ce
+  version: 2023.2.0
+  build: h2f0025b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2023.2.0-h2f0025b_1.conda
+  sha256: dd7063232f2cc88d3327d4dd491e2adce4640da49ab1e3c9d602d9dd6f3ffa37
+  md5: c4c4b087d00ddfb34ab79e0fd3e75bab
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
-  - tbb >=2021.13.0
-  size: 111701
-  timestamp: 1729594696807
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
+  size: 109980
+  timestamp: 1705189571722
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: hf15766e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_2.conda
-  sha256: f0c1a7e5a5654328c88814590ed53aa98ac6d079d336c3335d9f0ba00d70ffc0
-  md5: 1f737fa48eadcbadc5e35cd86c1b0036
+  version: 2023.2.0
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.2.0-h59595ed_1.conda
+  sha256: d762a41f5c3882db6e12c3e05078e3c287f37af28d15c52275d2548916c7e0b7
+  md5: a5de9633b1391a4a93bb59f03907de72
   depends:
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libstdcxx >=13
-  - tbb >=2021.13.0
-  size: 108042
-  timestamp: 1729590183012
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
+  size: 115401
+  timestamp: 1705192912861
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: h4d9b6c2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_2.conda
-  sha256: 27b732f1ba3ae7dc8263f59e69447eebabcc76de86e2ec4c9722842a1d2f4aa8
-  md5: 838b2db868f9ab69a7bad9c065a3362d
+  version: 2023.2.0
+  build: hd429f41_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2023.2.0-hd429f41_1.conda
+  sha256: 8d5c9a4ed1014ffcb06ea581b46126ae5b9c3b1b01505ba83f9867f5cf1b701c
+  md5: 954619dd81fe68e97ec40f5ec26ab641
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
-  - tbb >=2021.13.0
-  size: 237694
-  timestamp: 1729594707449
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
+  - tbb >=2021.11.0
+  size: 219258
+  timestamp: 1705189622495
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: hf15766e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_2.conda
-  sha256: 2de62ad880f30283778fa9c148b6e9095a206f0a1f0fb6b6d5f7bcaf9572d184
-  md5: 040cfcec2cccffd2599ba746d8dac9a6
-  depends:
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libstdcxx >=13
-  - tbb >=2021.13.0
-  size: 224080
-  timestamp: 1729590192079
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h3f63f65_2
-  build_number: 2
+  version: 2023.2.0
+  build: hd5fc58b_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_2.conda
-  sha256: 0c7cd10c9e3d99d6f23e4d7b48cd8e72aeb4a1c7acb801b6ca9add0f87f238d3
-  md5: 00a6127960a3f41d4bfcabd35d5fbeec
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2023.2.0-hd5fc58b_1.conda
+  sha256: 9c6612bca234b206061fd6882c1321945bc95ae3115a4d84231652e3f11ded2c
+  md5: 198a859e2ef36b216dfccfd4760cf6bb
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
-  - pugixml >=1.14,<1.15.0a0
-  size: 197567
-  timestamp: 1729594718187
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
+  - tbb >=2021.11.0
+  size: 236005
+  timestamp: 1705192942622
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h6ef32b0_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_2.conda
-  sha256: 215665ba9169a61f30d96c197bf799b85223963af483fdd137f508e7865fa057
-  md5: b106de2dc7ebc8cb930061cffbd117e0
+  version: 2023.2.0
+  build: h3ecfda7_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2023.2.0-h3ecfda7_1.conda
+  sha256: a7f1d810be7e009aa38a0c642a4a3ea856119822e7c81c45a08807d8dd4c949a
+  md5: 6073244da65a178ba06a0eef836d91f2
   depends:
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  size: 184694
-  timestamp: 1729590203040
+  size: 182776
+  timestamp: 1705192974716
+- kind: conda
+  name: libopenvino-hetero-plugin
+  version: 2023.2.0
+  build: hc6dd956_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2023.2.0-hc6dd956_1.conda
+  sha256: 631a649b4ed090d12c18a6f9b449619364f412c36e6be34644ed1e1678db4fb1
+  md5: 396c598283ebeff53fb6f00c09ce1df7
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  size: 172014
+  timestamp: 1705189673106
 - kind: conda
   name: libopenvino-intel-cpu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
+  version: 2023.2.0
+  build: h2e90f83_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_2.conda
-  sha256: 5642443645408f030e9dfbe20dbe2c2ab6d852daf02c9a36eac123b44bf2980f
-  md5: 6cfc840bc39c17d92fb25e5a35789e5b
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2023.2.0-h2e90f83_1.conda
+  sha256: 5516227175308c666caa87da411e33d3a8fa1246f0fe0837aa307ffa4dff2039
+  md5: b5dd2d1cd051d9e6c38694a1eb19532c
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 12101994
-  timestamp: 1729594729554
+  - tbb >=2021.11.0
+  size: 9983675
+  timestamp: 1705193005754
 - kind: conda
   name: libopenvino-intel-gpu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
+  version: 2023.2.0
+  build: h2e90f83_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_2.conda
-  sha256: 508d0e36febebfb66628d8cb0312b4133c212eac1e8d891fc8977e0d85b23741
-  md5: 9e9814b40d8fdfd8485451e3fa2f1719
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2023.2.0-h2e90f83_1.conda
+  sha256: d2757371b82a46b3de4d547bef107ba8bfb67518b42cfd4e2452c1b3ebc4e7a7
+  md5: d7e9e5a70c953a88f117ec240bd5600a
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
-  - ocl-icd >=2.3.2,<3.0a0
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
+  - ocl-icd >=2.3.1,<3.0a0
+  - ocl-icd-system
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 8885078
-  timestamp: 1729594772427
-- kind: conda
-  name: libopenvino-intel-npu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_2.conda
-  sha256: a07bdb55c3214cd5b27736ee6d06abe55782ddf1cfaeb9fffee96179bf12390b
-  md5: 724719ce97feb6f310f88ae8dbb40afd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 799335
-  timestamp: 1729594804720
+  - tbb >=2021.11.0
+  size: 8026823
+  timestamp: 1705193060546
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h3f63f65_2
-  build_number: 2
+  version: 2023.2.0
+  build: h3ecfda7_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_2.conda
-  sha256: 6038aefea84aeb9534aaf6963d2b266eb757fa36c1a7a9f5e29d6d813bd85a2c
-  md5: 8908f31eab30f65636eb61ab9cb1f3ad
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2023.2.0-h3ecfda7_1.conda
+  sha256: 51a340646fbcea85c2691970edb0d2890520de792e0d5b9ed66b488a67dd7871
+  md5: c227e45d52f747f3a8b47fb1cf1b5599
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  size: 204163
-  timestamp: 1729594816408
+  size: 200679
+  timestamp: 1705193107646
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h6ef32b0_2
-  build_number: 2
+  version: 2023.2.0
+  build: hc6dd956_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_2.conda
-  sha256: 846de69b4e387684857d824974e07a42213781d6519ab59a7bca768d94c49736
-  md5: 60f6f88fa0b0cda9c635963aef4013d7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2023.2.0-hc6dd956_1.conda
+  sha256: 290023b2fb0546520cbe0e2e9b9f7aa9b5bb2d96c64f1124879041aff929cd69
+  md5: 922f315525d582e5bcff3251a1ede779
   depends:
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  size: 192130
-  timestamp: 1729590212150
+  size: 187349
+  timestamp: 1705189724156
 - kind: conda
   name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: h5c8f2c3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h5c8f2c3_2.conda
-  sha256: b68c2ee5fd08c0974ad9395ea0de809b306c261485114cbcbbc0f55c1e0285b3
-  md5: e098caa87868e8dcc7ed5d011981207d
+  version: 2023.2.0
+  build: h2f0025b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2023.2.0-h2f0025b_1.conda
+  sha256: 71e3f50ada42caf9d5a4d5bf7b0d84a436751013edc5f97253f8a4942d0aae67
+  md5: cb3fe69571d62f4b81ab7754d06fde92
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  size: 1559399
-  timestamp: 1729594827815
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
+  size: 1498395
+  timestamp: 1705189776363
 - kind: conda
   name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: haa99d6a_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-haa99d6a_2.conda
-  sha256: e33692a3da876040d877c207290e7df5bef56639466769cb7fdec935754e699d
-  md5: a626d0a2138aea9e65f978e936069fe5
+  version: 2023.2.0
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2023.2.0-h59595ed_1.conda
+  sha256: bf3bba7fd7d9c47cff8e9e279b013c4eaad504316cf071f3f992c02cc8a629aa
+  md5: 66efd7aaf42c73e74274858311f99e2d
   depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  size: 1404356
-  timestamp: 1729590221767
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
+  size: 1573978
+  timestamp: 1705193138407
 - kind: conda
   name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: h5c8f2c3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h5c8f2c3_2.conda
-  sha256: fa57b201fb92af0adc2118de8e92648959b98c0dc1a60b278ba2b79c5601eea6
-  md5: 59bb8c3502cb9d35f1fb26691730288c
+  version: 2023.2.0
+  build: h2f0025b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2023.2.0-h2f0025b_1.conda
+  sha256: 99bc6e8c0ad3356ad3f20539d3345530e01a2674228117d20feeb69cd53f0333
+  md5: 12417f505c2ccaaf51fa3f10c7ebf4d7
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  size: 653105
-  timestamp: 1729594841297
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
+  size: 725214
+  timestamp: 1705189831715
 - kind: conda
   name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: haa99d6a_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-haa99d6a_2.conda
-  sha256: 43c3ef7aeb90bcafe93e3946c063d72dc82933818eff7f9eb7a5b51bad430703
-  md5: 75480960fe1dfcfc5f8eeea26e56b4be
+  version: 2023.2.0
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2023.2.0-h59595ed_1.conda
+  sha256: e8e46c3976697932ef2581d7e6b6079c5214221195794bb16d99694a6f1a9ebf
+  md5: 11709580689d2c754f60911270f90da3
   depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  size: 605764
-  timestamp: 1729590232511
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
+  size: 691423
+  timestamp: 1705193171273
 - kind: conda
   name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: h5888daf_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_2.conda
-  sha256: a029b3ebff1e8d1d2736a548a616c20066ed6508f238782afbf3a77a4f57c6cd
-  md5: e0b88fd64dc95f715ef52e607a9af89b
+  version: 2023.2.0
+  build: h2f0025b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2023.2.0-h2f0025b_1.conda
+  sha256: 753fa76f73f2c4e3f1af640daf15cc6efd372d23a11b740e589a4208097f295b
+  md5: 941ee9d50a003764bf9f72115f143e00
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
-  size: 1075090
-  timestamp: 1729594854413
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
+  size: 860919
+  timestamp: 1705189884103
 - kind: conda
   name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: h5ad3122_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_2.conda
-  sha256: e86b89a8d7fda8d1015abc1918a23785310348f64b73012e1ea87a639e27a14a
-  md5: fbeb65db200c04bac9e95ad05b859161
+  version: 2023.2.0
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2023.2.0-h59595ed_1.conda
+  sha256: ba17fd9c257724cdd6c72b8dde78b8922212a6f9ae2451c80f1a4f9e232ed246
+  md5: 96476c2befe1597d5c6383f09de0e76e
   depends:
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libstdcxx >=13
-  size: 996903
-  timestamp: 1729590242095
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
+  size: 939991
+  timestamp: 1705193201997
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: h6481b9d_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h6481b9d_2.conda
-  sha256: fdc4871a05bbb61cfe6db1e60018d74cbd6d65d82f03b9be515c3ad41bb7ca04
-  md5: 12bf831b85f17368bc71a26ac93a8493
+  version: 2023.2.0
+  build: hf7f7b40_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2023.2.0-hf7f7b40_1.conda
+  sha256: d794b67902342dc763954d5f615f0db7b5d634c2d716ba16aec7692c9682784c
+  md5: 75ff1bf356306ef38f121405673b672e
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  - snappy >=1.2.1,<1.3.0a0
-  size: 1282840
-  timestamp: 1729594867098
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
+  - snappy >=1.1.10,<1.2.0a0
+  size: 1582807
+  timestamp: 1705189938081
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: he24a241_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-he24a241_2.conda
-  sha256: d7f2247da62e2605f768694144100637afff046989aa6b5d4aff8bc74cdeffbc
-  md5: 91a86ff710cd96f4241ef18aa594a764
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  - snappy >=1.2.1,<1.3.0a0
-  size: 1192974
-  timestamp: 1729590252604
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: h5888daf_2
-  build_number: 2
+  version: 2023.2.0
+  build: hfe87413_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_2.conda
-  sha256: a8f26058cf57159492c63fb0622ea2858763ea22338c507ff40a6e9bb792295e
-  md5: d48c774c40ea2047adbff043e9076e7a
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.2.0-hfe87413_1.conda
+  sha256: ca47204c43b29f8bf73369d00545662c413079dbdb9a5bf412a6c9b16e9c6b05
+  md5: 6458716ec9e4f86a54751da0319c8d3d
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hac27bb2_2
-  - libstdcxx >=13
-  size: 466563
-  timestamp: 1729594879557
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
+  - snappy >=1.1.10,<1.2.0a0
+  size: 1597664
+  timestamp: 1705193236183
 - kind: conda
   name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: h5ad3122_2
-  build_number: 2
+  version: 2023.2.0
+  build: h2f0025b_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_2.conda
-  sha256: b67b4c74e97a810a902e4aa81a173db9281955270dae2890afc29320df7659ae
-  md5: a3f82dbd3189dffd49ed67216f21e35a
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2023.2.0-h2f0025b_1.conda
+  sha256: 430f2f4c023a565de2fc339606c4cb1e57cf06ae48aea9f7858219573f6c7fdc
+  md5: 82ba84f58d21adcf17496de337c8e0e1
   depends:
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libstdcxx >=13
-  size: 430404
-  timestamp: 1729590264452
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h3e0449b_1
+  - libstdcxx-ng >=12
+  size: 418642
+  timestamp: 1705189991904
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2023.2.0
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.2.0-h59595ed_1.conda
+  sha256: 9fba3b61d128ddf541b172cd0c17ae0a5ee2e68fa95f205855446e4b548eb661
+  md5: 406beda7707bbd8e69e235cfafacbe46
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.2.0 h2e90f83_1
+  - libstdcxx-ng >=12
+  size: 458300
+  timestamp: 1705193268280
 - kind: conda
   name: libopus
   version: 1.3.1
@@ -7579,20 +7848,6 @@ packages:
 - kind: conda
   name: libpciaccess
   version: '0.18'
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
-  sha256: 0c6806dcd53da457c472cf22ad7793aef074cb198a10677a91b02c7dceeee770
-  md5: 6d48179630f00e8c9ad9e30879ce1e54
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 29211
-  timestamp: 1707101477910
-- kind: conda
-  name: libpciaccess
-  version: '0.18'
   build: hd590300_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
@@ -7606,316 +7861,255 @@ packages:
   timestamp: 1707101388552
 - kind: conda
   name: libpng
-  version: 1.6.44
-  build: h3ca93ac_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
-  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
-  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  version: 1.6.43
+  build: h194ca79_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
+  sha256: 6f408f3d6854f86e223289f0dda12562b047c7a1fdf3636c67ec39afcd141f43
+  md5: 1123e504d9254dd9494267ab9aba95f0
   depends:
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   license: zlib-acknowledgement
-  size: 348933
-  timestamp: 1726235196095
+  size: 294380
+  timestamp: 1708782876525
 - kind: conda
   name: libpng
-  version: 1.6.44
-  build: hadc24fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
-  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
-  md5: f4cc49d7aa68316213e4b12be35308d1
+  version: 1.6.43
+  build: h19919ed_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+  sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
+  md5: 77e398acc32617a0384553aea29e866b
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: zlib-acknowledgement
-  size: 290661
-  timestamp: 1726234747153
+  size: 347514
+  timestamp: 1708780763195
 - kind: conda
   name: libpng
-  version: 1.6.44
-  build: hc4a20ef_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
-  sha256: 23b5ce15cf9c6017641a8396bab00ae807dd9f662718cfa7f61de114d0c97647
-  md5: 5d25802b25fcc7419fa13e21affaeb3a
+  version: 1.6.43
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+  sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
+  md5: 009981dd9cfcaa4dbfa25ffaed86bcae
   depends:
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   license: zlib-acknowledgement
-  size: 294907
-  timestamp: 1726236639270
+  size: 288221
+  timestamp: 1708780443939
 - kind: conda
   name: libpq
-  version: '16.4'
-  build: h2d7952a_3
-  build_number: 3
+  version: '16.3'
+  build: ha72fbe1_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_3.conda
-  sha256: 51dddb6e5879960a1b9b3c5de0eb970373903977c0fa68a42f86bb7197c695cf
-  md5: 50e2dddb3417a419cbc2388d0b1c06f7
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
+  sha256: 117ba1e11f07b1ca0671641bd6d1f2e7fc6e27db1c317a0cdb4799ffa69f47db
+  md5: bac737ae28b79cfbafd515258d97d29e
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - openssl >=3.3.2,<4.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - openssl >=3.3.0,<4.0a0
   license: PostgreSQL
-  size: 2530022
-  timestamp: 1729085009049
+  size: 2500439
+  timestamp: 1715266400833
 - kind: conda
   name: libpq
-  version: '16.4'
-  build: hb7c570e_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_3.conda
-  sha256: cd17b7b1fa11907c28319a80c18cd025ec8344be630a2b3f7dfe97b3ef682000
-  md5: 49e510416b386a1ea805edf38ce09956
+  version: '16.3'
+  build: hab9416b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libpq-16.3-hab9416b_0.conda
+  sha256: 5cb998386c86fcbf5c3b929c0ec252e80b56d3f2ef4bc857496f5d06d3b28af1
+  md5: 84d2332f3110845bbafbfd7d5311354f
   depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - openssl >=3.3.2,<4.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - openssl >=3.3.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: PostgreSQL
-  size: 2661524
-  timestamp: 1729085053843
+  size: 3456937
+  timestamp: 1715267132646
 - kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: h029595c_0
+  name: libpq
+  version: '16.3'
+  build: hcf0348d_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.2-h029595c_0.conda
-  sha256: d8c7b6f851bfc53494d9b8e54d473c4f11ab26483a6e64df6f7967563df166b1
-  md5: 538dbe0ad9f248e2e109abb9b6809ea5
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.3-hcf0348d_0.conda
+  sha256: 8f4f0be9e86cce1a51423ccb9bfe559fb3778e2c2d62176ee52c31a029cc8d6d
+  md5: 7dd46e914b037824b9a9629ca6586fc3
   depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2802876
-  timestamp: 1728564881988
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - openssl >=3.3.0,<4.0a0
+  license: PostgreSQL
+  size: 2539253
+  timestamp: 1715266429766
 - kind: conda
   name: libprotobuf
-  version: 5.28.2
-  build: h5b01275_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
-  sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
-  md5: ab0bff36363bec94720275a681af8b83
+  version: 3.14.0
+  build: h7755175_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-3.14.0-h7755175_0.tar.bz2
+  sha256: c6014b07157908678c6584964348b28b93e2f01e946926e37580645cfeeb09ab
+  md5: 2f92571c43e1855ec3a13a9be05ac522
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  - zlib >=1.2.11,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2945348
-  timestamp: 1728565355702
+  size: 2391421
+  timestamp: 1607032492800
 - kind: conda
   name: libprotobuf
-  version: 5.28.2
-  build: hcaed137_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
-  sha256: 798c6675fb709ceaa6a9bd83e9cffe06bc98e83f519c7d7d881243d2e6d0c34d
-  md5: 97c6d2f83edd7b400a22660e2a4d1488
+  version: 3.14.0
+  build: h780b84a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-3.14.0-h780b84a_0.tar.bz2
+  sha256: 00a01791fc7cea586e04b25621e7a12afe1c1118b8436fd79342e74377557863
+  md5: 493aecaf8fe0bc914eee566e54f03a0f
   depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  - zlib >=1.2.11,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6033581
-  timestamp: 1728565880841
+  size: 2617906
+  timestamp: 1607031835405
 - kind: conda
-  name: libraw
-  version: 0.21.3
-  build: h0f5434b_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libraw-0.21.3-h0f5434b_0.conda
-  sha256: 0d2610b684cd8712bdcf0873b17b1fa3d7ce1105550264b7fd91b184a00d1a28
-  md5: 075f3d5fe250279afc5d9b221d71f84b
-  depends:
-  - lcms2 >=2.16,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.1-only
-  license_family: LGPL
-  size: 489267
-  timestamp: 1726766863050
-- kind: conda
-  name: libraw
-  version: 0.21.3
-  build: hca62329_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.3-hca62329_0.conda
-  sha256: 4b483d963686bcc1fbe225c41f48a2ec206bc97e1d9d1c16fac2d6b5709240b8
-  md5: e99091d245425cf089b814107b40c349
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  - lcms2 >=2.16,<3.0a0
-  - libgcc >=13
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.1-only
-  license_family: LGPL
-  size: 640729
-  timestamp: 1726766159397
-- kind: conda
-  name: libraw
-  version: 0.21.3
-  build: hf20323b_0
+  name: libprotobuf
+  version: 3.14.0
+  build: hc71ff50_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.3-hf20323b_0.conda
-  sha256: 94c4fe562d9f962f89e28140e04fe53868e2886e12434b834f62de9a4f7970df
-  md5: 885621c9ba4186c2b88c5033d301bb72
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-3.14.0-hc71ff50_0.tar.bz2
+  sha256: 589e51d9f43356e1c103b9bc89172abca984a32dd40d7fe621e5ffc78356a28d
+  md5: 0da199cd4d0bf0bce086a5be4b1935a5
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2430624
+  timestamp: 1607032496948
+- kind: conda
+  name: libraw
+  version: 0.21.1
+  build: h2a13503_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.1-h2a13503_2.conda
+  sha256: a23ab9470bbf0ae0505b2991f139085e0a99b32f8640a22d3c540b515c352301
+  md5: 63ab3e0cf149917a08af38b2786320c0
   depends:
   - _openmp_mutex >=4.5
-  - lcms2 >=2.16,<3.0a0
-  - libgcc >=13
+  - lcms2 >=2.15,<3.0a0
+  - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   license: LGPL-2.1-only
   license_family: LGPL
-  size: 650078
-  timestamp: 1726766243482
+  size: 637871
+  timestamp: 1695983515562
 - kind: conda
-  name: librsvg
-  version: 2.58.4
-  build: h00090f3_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h00090f3_0.conda
-  sha256: f27d29bec094cd4a9190409a0e881a8eac2affdf2bda850d9f2a580b3280ab96
-  md5: e217f742afbec9f3632e73602dadb810
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - gdk-pixbuf >=2.42.12,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - pango >=1.54.0,<2.0a0
-  constrains:
-  - __glibc >=2.17
-  license: LGPL-2.1-or-later
-  size: 6366018
-  timestamp: 1726236562130
-- kind: conda
-  name: librsvg
-  version: 2.58.4
-  build: h33bc1f6_0
+  name: libraw
+  version: 0.21.1
+  build: h5557f11_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/librsvg-2.58.4-h33bc1f6_0.conda
-  sha256: 21d3c867a7cfa28ed7e77840c0275ac4ae8a3eb4d17455b920cb0c24051d84f1
-  md5: 40b2421b8358e85cde3f153022b6f364
+  url: https://conda.anaconda.org/conda-forge/win-64/libraw-0.21.1-h5557f11_2.conda
+  sha256: 415698048e8432089194a6fdfb23b7b7a224c74cd80a51a12ffe4b0adbccfc79
+  md5: ba1769fa936edd69b4276c9ef352c2cb
   depends:
-  - cairo >=1.18.0,<2.0a0
-  - gdk-pixbuf >=2.42.12,<3.0a0
-  - libglib >=2.80.3,<3.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - pango >=1.54.0,<2.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.40.33810
-  license: LGPL-2.1-or-later
-  size: 3871820
-  timestamp: 1726228304069
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  license_family: LGPL
+  size: 489009
+  timestamp: 1695984134380
 - kind: conda
-  name: librsvg
-  version: 2.58.4
-  build: hc0ffecb_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
-  sha256: fda3197ffb24512e719d55defa02f9f70286038e56cad8c1d580ed6460f417fa
-  md5: 83f045969988f5c7a65f3950b95a8b35
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - gdk-pixbuf >=2.42.12,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - pango >=1.54.0,<2.0a0
-  constrains:
-  - __glibc >=2.17
-  license: LGPL-2.1-or-later
-  size: 6390511
-  timestamp: 1726227212382
-- kind: conda
-  name: librttopo
-  version: 1.1.0
-  build: h97f6797_17
-  build_number: 17
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
-  sha256: 1fb8a71bdbc236b8e74f0475887786735d5fa6f5d76d9a4135021279c7ff54b8
-  md5: e16e9b1333385c502bf915195f421934
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 231770
-  timestamp: 1727338518657
-- kind: conda
-  name: librttopo
-  version: 1.1.0
-  build: hbcf326e_17
-  build_number: 17
+  name: libraw
+  version: 0.21.1
+  build: hb6ba311_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-hbcf326e_17.conda
-  sha256: a0f8c760cfeb3abd948e4ca7a0415cb1b2dc166742c1ac70b9c7b37a08dccb67
-  md5: c334c7b1cf56a219ed151d8cefc904c8
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.1-hb6ba311_2.conda
+  sha256: d35b03e68c7ba811a598f343e2e61c797ac54e3a3054cb504d3b577d6a4199d3
+  md5: 2f488c05eac9228837c8ba7d44f3ea67
   depends:
-  - geos >=3.13.0,<3.13.1.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 252102
-  timestamp: 1727265887913
+  - _openmp_mutex >=4.5
+  - lcms2 >=2.15,<3.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-only
+  license_family: LGPL
+  size: 652358
+  timestamp: 1695983650199
 - kind: conda
   name: librttopo
   version: 1.1.0
-  build: hd4c2148_17
-  build_number: 17
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
-  sha256: 0f4a1c8ed579f96ccb73245b4002d7152a2a8ecd05a01d49901c5d280561f766
-  md5: 06ea16b8c60b4ce1970c06191f8639d4
+  build: h8917695_15
+  build_number: 15
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h8917695_15.conda
+  sha256: 03e248787162a1804683c614c0681c2488fa6d9f353cb32e2f8c1158157165ea
+  md5: 20c3c14bc491f30daecaa6f73e2223ae
   depends:
-  - geos >=3.13.0,<3.13.1.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 233194
+  timestamp: 1700766491991
+- kind: conda
+  name: librttopo
+  version: 1.1.0
+  build: h94c4f80_15
+  build_number: 15
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h94c4f80_15.conda
+  sha256: 1a85091ebed8272b0c9b9e5aacba1d423c6411bfa91d7777c1ede8c7a42c933b
+  md5: 3c2a870012ae8f6ffcc7735715f197b1
+  depends:
+  - geos >=3.12.1,<3.12.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 404515
-  timestamp: 1727265928370
+  size: 402764
+  timestamp: 1700767022424
+- kind: conda
+  name: librttopo
+  version: 1.1.0
+  build: hd8968fb_15
+  build_number: 15
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-hd8968fb_15.conda
+  sha256: d73cb2055f83ada5a3c9c52009f6341ff95c4a0f2581029b2b6dbf03a381ad78
+  md5: 5df2305d559d0e956da65304bbaa9ba4
+  depends:
+  - geos >=3.12.1,<3.12.2.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 249783
+  timestamp: 1700766535371
 - kind: conda
   name: libsndfile
   version: 1.2.2
@@ -7962,125 +8156,154 @@ packages:
   timestamp: 1695747735668
 - kind: conda
   name: libsodium
-  version: 1.0.20
-  build: h4ab18f5_0
+  version: 1.0.18
+  build: h36c2ea0_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
-  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
-  md5: a587892d3c13b6621a6091be690dbca2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+  sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+  md5: c3788462a6fbddafdb413a9f9053e58d
   depends:
-  - libgcc-ng >=12
+  - libgcc-ng >=7.5.0
   license: ISC
-  size: 205978
-  timestamp: 1716828628198
+  size: 374999
+  timestamp: 1605135674116
 - kind: conda
   name: libsodium
-  version: 1.0.20
-  build: h68df207_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.20-h68df207_0.conda
-  sha256: 448df5ea3c5cf1af785aad46858d7a5be0522f4234a4dc9bb764f4d11ff3b981
-  md5: 2e4a8f23bebdcb85ca8e5a0fbe75666a
-  depends:
-  - libgcc-ng >=12
-  license: ISC
-  size: 177394
-  timestamp: 1716828514515
-- kind: conda
-  name: libsodium
-  version: 1.0.20
-  build: hc70643c_0
+  version: 1.0.18
+  build: h8d14728_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
-  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
-  md5: 198bb594f202b205c7d18b936fa4524f
+  url: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+  sha256: ecc463f0ab6eaf6bc5bd6ff9c17f65595de6c7a38db812222ab8ffde0d3f4bc2
+  md5: 5c1fb45b5e2912c19098750ae8a32604
   depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: ISC
+  size: 713431
+  timestamp: 1605135918736
+- kind: conda
+  name: libsodium
+  version: 1.0.18
+  build: hb9de7d4_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.18-hb9de7d4_1.tar.bz2
+  sha256: 9ee442d889242c633bc3ce3f50ae89e6d8ebf12e04d943c371c0a56913fa069b
+  md5: d09ab3c60eebb6f14eb4d07e172775cc
+  depends:
+  - libgcc-ng >=7.5.0
+  license: ISC
+  size: 237003
+  timestamp: 1605135724993
+- kind: conda
+  name: libspatialite
+  version: 5.1.0
+  build: h72606ae_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h72606ae_3.conda
+  sha256: 9c60d2f209757e5e81adb6508b7cfd4e9ffbe7a8db954104e724bf322e7933b8
+  md5: e81575beafa769a8ca4c7b5135f336b1
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - libgcc-ng >=12
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3888079
+  timestamp: 1701354279954
+- kind: conda
+  name: libspatialite
+  version: 5.1.0
+  build: h78899c2_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libspatialite-5.1.0-h78899c2_3.conda
+  sha256: a52678e857faaa9c9873d517de0a24536e58efef8447ec7ec599bbd10cfc7f6f
+  md5: d01ac1c0c76670373fa2908500c5f84b
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - libgcc-ng >=12
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3915825
+  timestamp: 1701356267282
+- kind: conda
+  name: libspatialite
+  version: 5.1.0
+  build: h7bd4b97_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h7bd4b97_3.conda
+  sha256: 6122fc77cbf75b571281f9affa3dc324d11e21c9409c7dc3ef3b0a6c3e624032
+  md5: 93e2a9757cce46cdefa0a1b50d8c4c5a
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - sqlite
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  license: ISC
-  size: 202344
-  timestamp: 1716828757533
-- kind: conda
-  name: libspatialite
-  version: 5.1.0
-  build: h08d9e07_11
-  build_number: 11
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libspatialite-5.1.0-h08d9e07_11.conda
-  sha256: 937e9ae5d9ea46c9264a4e9d5cae3e4bd6992d2aa441cf65b5d2d37ce8487654
-  md5: 173a9cf2b71f72e3152ef1560433ab41
-  depends:
-  - freexl >=2
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - libgcc >=13
-  - librttopo >=1.1.0,<1.2.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libstdcxx >=13
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - sqlite
   - zlib
   license: MPL-1.1
   license_family: MOZILLA
-  size: 3965387
-  timestamp: 1727343696976
+  size: 8580745
+  timestamp: 1701354485547
 - kind: conda
-  name: libspatialite
-  version: 5.1.0
-  build: h1b4f908_11
-  build_number: 11
+  name: libsqlite
+  version: 3.46.0
+  build: hde9e2c9_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
-  sha256: 11d8537d472c5fc25176fda7af6b9aa47f37ba98d0467b77cb713be18ed847ea
-  md5: 43a7f3df7d100e8fc280e6636680a870
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+  sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
+  md5: 18aa975d2094c34aef978060ae7da7d8
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - freexl >=2
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - libgcc >=13
-  - librttopo >=1.1.0,<1.2.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libstdcxx >=13
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - sqlite
-  - zlib
-  license: MPL-1.1
-  license_family: MOZILLA
-  size: 4045908
-  timestamp: 1727341751247
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  license: Unlicense
+  size: 865346
+  timestamp: 1718050628718
 - kind: conda
-  name: libspatialite
-  version: 5.1.0
-  build: h939089a_11
-  build_number: 11
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
-  sha256: 76da01457b92be57ac0635cec2681c5423a46252713b144391c14aa0dffe61ba
-  md5: 3ff7b70e2c517f3a43f0b3f87475915a
+  name: libsqlite
+  version: 3.46.0
+  build: hf51ef55_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.0-hf51ef55_0.conda
+  sha256: 7b48d006be6cd089105687fb524a2c93c4218bfc398d0611340cafec55249977
+  md5: a8ae63fd6fb7d007f74ef3df95e5edf3
   depends:
-  - freexl >=2
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - librttopo >=1.1.0,<1.2.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.0,<9.6.0a0
-  - sqlite
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  license: MPL-1.1
-  license_family: MOZILLA
-  size: 8293459
-  timestamp: 1727341947641
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  license: Unlicense
+  size: 1043861
+  timestamp: 1718050586624
 - kind: conda
   name: libsqlite
   version: 3.47.0
@@ -8097,37 +8320,6 @@ packages:
   license: Unlicense
   size: 892175
   timestamp: 1730208431651
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hadc24fc_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
-  sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
-  md5: b6f02b52a174e612e89548f4663ce56a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  size: 875349
-  timestamp: 1730208050020
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hc4a20ef_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.47.0-hc4a20ef_1.conda
-  sha256: 73e143fdb966b61cd25ab804d416d87dfce43ac684e0fac3ad8b1450796331ab
-  md5: a6b185aac10d08028340858f77231b23
-  depends:
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  size: 1041855
-  timestamp: 1730208187962
 - kind: conda
   name: libssh2
   version: 1.11.0
@@ -8278,72 +8470,125 @@ packages:
   size: 430774
   timestamp: 1729786916983
 - kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: he137b08_1
-  build_number: 1
+  name: libtasn1
+  version: 4.19.0
+  build: h166bdaf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
-  sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
-  md5: 63872517c98aa305da58a757c443698e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
+  sha256: 5bfeada0e1c6ec2574afe2d17cdbc39994d693a41431338a6cb9dfa7c4d7bfc8
+  md5: 93840744a8552e9ebf6bb1a5dffc125a
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libgcc >=13
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx >=13
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: HPND
-  size: 428156
-  timestamp: 1728232228989
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 116878
+  timestamp: 1661325701583
 - kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hec21d91_1
-  build_number: 1
+  name: libtasn1
+  version: 4.19.0
+  build: h4e544f5_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
-  sha256: 14ecb9e129b1b5ffd6d4bee48de95cd2cd0973c712e1b965d3ef977cca23936d
-  md5: 1f80061f5ba6956fcdc381f34618cd8d
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
+  sha256: 96310724113f6f2ed2f3e55e19e87fe29e1678d0ee21386e4037c3703d542743
+  md5: a94c6aaaaac3c2c9dcff6967ed1064be
   depends:
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libgcc >=13
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx >=13
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: HPND
-  size: 464938
-  timestamp: 1728232266969
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 124954
+  timestamp: 1661325677442
 - kind: conda
   name: libtiff
-  version: 4.7.0
-  build: hfc51747_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
-  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
-  md5: eac317ed1cc6b9c0af0c27297e364665
+  version: 4.6.0
+  build: h1708d11_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-h1708d11_2.conda
+  sha256: e6aecca5bbf354ab34fb04d8d6ef4a50477f64997c368d734cc5d1d8b1a21d3a
+  md5: d5638e110e7f22e2602a8edd20656720
   depends:
   - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.22,<1.23.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 316074
+  timestamp: 1695664604579
+- kind: conda
+  name: libtiff
+  version: 4.6.0
+  build: h6e2ebb7_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+  sha256: f7b50b71840a5d8edd74a8bccf0c173ca2599bd136e366c35722272b4afa0500
+  md5: 08d653b74ee2dec0131ad4259ffbb126
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   license: HPND
-  size: 978865
-  timestamp: 1728232594877
+  size: 787430
+  timestamp: 1695662030293
+- kind: conda
+  name: libtiff
+  version: 4.6.0
+  build: ha9c0a0a_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+  sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
+  md5: 55ed21669b2015f77c180feb1dd41930
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 283198
+  timestamp: 1695661593314
+- kind: conda
+  name: libunistring
+  version: 0.9.10
+  build: h7f98852_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+  sha256: e88c45505921db29c08df3439ddb7f771bbff35f95e7d3103bf365d5d6ce2a6d
+  md5: 7245a044b4a1980ed83196176b78b73a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: GPL-3.0-only OR LGPL-3.0-only
+  size: 1433436
+  timestamp: 1626955018689
+- kind: conda
+  name: libunistring
+  version: 0.9.10
+  build: hf897c2e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
+  sha256: 03acebd5a01a255fe40d47f941c6cab4dc7829206d86d990b0c88cf0ff66e646
+  md5: 7c68521243dc20afba4c4c05eb09586e
+  depends:
+  - libgcc-ng >=9.3.0
+  license: GPL-3.0-only OR LGPL-3.0-only
+  size: 1409624
+  timestamp: 1626959749923
 - kind: conda
   name: libuuid
   version: 2.38.1
@@ -8419,30 +8664,24 @@ packages:
   timestamp: 1729322566955
 - kind: conda
   name: libva
-  version: 2.22.0
-  build: h8a09558_1
-  build_number: 1
+  version: 2.21.0
+  build: h4ab18f5_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
-  sha256: 0bd81019e02cce8d9d4077c96b82ca03c9b0ece67831c7437f977ca1f5a924a3
-  md5: 139262125a3eac8ff6eef898598745a3
+  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-h4ab18f5_2.conda
+  sha256: cdd0ffd791a677af28a5928c23474312fafeab718dfc93f6ce99569eb8eee8b3
+  md5: 109300f4eeeb8a61498283565106b474
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libdrm >=2.4.123,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
-  - libglx >=1.7.0,<2.0a0
-  - libxcb >=1.16,<2.0.0a0
-  - wayland >=1.23.1,<2.0a0
-  - wayland-protocols
+  - libdrm >=2.4.120,<2.5.0a0
+  - libgcc-ng >=12
   - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxfixes
+  - libxcb >=1.15.0,<1.16.0
   license: MIT
   license_family: MIT
-  size: 217708
-  timestamp: 1726828458441
+  size: 189921
+  timestamp: 1717743848819
 - kind: conda
   name: libvorbis
   version: 1.3.7
@@ -8493,34 +8732,34 @@ packages:
   timestamp: 1610609811627
 - kind: conda
   name: libvpx
-  version: 1.14.1
-  build: h0a1ffab_0
+  version: 1.13.1
+  build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
-  sha256: 918493354f78cb3bb2c3d91264afbcb312b2afe287237e7d1c85ee7e96d15b47
-  md5: 3cb63f822a49e4c406639ebf8b5d87d7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
+  sha256: c403cd479dc5acd86d9b62ddb2fb4756d7775e6c2f25db79c9efa187b759af4f
+  md5: 9a6ce789667dfdbea886b5d9e7f268a0
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 1211700
-  timestamp: 1717859955539
+  size: 1193429
+  timestamp: 1696342120210
 - kind: conda
   name: libvpx
-  version: 1.14.1
-  build: hac33072_0
+  version: 1.13.1
+  build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
-  sha256: e7d2daf409c807be48310fcc8924e481b62988143f582eb3a58c5523a6763b13
-  md5: cde393f461e0c169d9ffb2fc70f81c33
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
+  sha256: 8067e73d6e4f82eae158cb86acdc2d1cf18dd7f13807f0b93e13a07ee4c04b79
+  md5: 0974a6d3432e10bae02bcab0cce1b308
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 1022466
-  timestamp: 1717859935011
+  size: 1006029
+  timestamp: 1696342275863
 - kind: conda
   name: libwebp-base
   version: 1.4.0
@@ -8591,39 +8830,38 @@ packages:
   timestamp: 1700469113171
 - kind: conda
   name: libxcb
-  version: 1.17.0
-  build: h262b8f6_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
-  sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
-  md5: cd14ee5cca2464a425b1dbfc24d90db2
+  version: '1.15'
+  build: h0b41bf4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+  md5: 33277193f5b92bad9fdd230eb700929c
   depends:
-  - libgcc >=13
+  - libgcc-ng >=12
   - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxau
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
-  size: 397493
-  timestamp: 1727280745441
+  size: 384238
+  timestamp: 1682082368177
 - kind: conda
   name: libxcb
-  version: 1.17.0
-  build: h8a09558_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
-  md5: 92ed62436b625154323d40d5f2f11dd7
+  version: '1.15'
+  build: h2a766a3_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
+  sha256: d159fcdb8b74187b0bd32f2d9b3a9191bc8b786a97e413aa66e19c39ba7050a0
+  md5: eb3d8c8170e3d03f2564ed2024aa00c8
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc-ng >=12
   - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxau
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
-  size: 395888
-  timestamp: 1727278577118
+  size: 388526
+  timestamp: 1682083614077
 - kind: conda
   name: libxcrypt
   version: 4.4.36
@@ -8655,209 +8893,207 @@ packages:
 - kind: conda
   name: libxkbcommon
   version: 1.7.0
-  build: h2c5496b_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
-  sha256: 6804c2a7062d10de6f159f7106dc45ebccc8d42bfb925f7919e26e567fa6da6b
-  md5: e2eaefa4de2b7237af7c907b8bbc760a
+  build: h2555907_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
+  sha256: 5075106adf56dfd586d889be9c151692a8507a2d00df8ba4a9e28a6aaac6074d
+  md5: 3663134cd650738ad46bd0d643246f51
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - libxml2 >=2.12.7,<3.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.6,<3.0a0
   - xkeyboard-config
   - xorg-libxau >=1.0.11,<2.0a0
   license: MIT/X11 Derivative
   license_family: MIT
-  size: 593336
-  timestamp: 1718819935698
+  size: 595967
+  timestamp: 1711303495028
 - kind: conda
   name: libxkbcommon
   version: 1.7.0
-  build: h46f2afe_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
-  sha256: 8ed470f72c733aea32bb5d272bf458041add7923d7716d5046bd40edf7ddd67c
-  md5: 78a24e611ab9c09c518f519be49c2e46
+  build: h662e7e4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h662e7e4_0.conda
+  sha256: 3d97d7f964237f42452295d461afdbc51e93f72e2c80be516f56de80e3bb6621
+  md5: b32c0da42b1f24a98577bb3d7fc0b995
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - libxml2 >=2.12.7,<3.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.6,<3.0a0
   - xkeyboard-config
   - xorg-libxau >=1.0.11,<2.0a0
   license: MIT/X11 Derivative
   license_family: MIT
-  size: 596053
-  timestamp: 1718819931537
+  size: 593534
+  timestamp: 1711303445595
 - kind: conda
   name: libxml2
-  version: 2.13.4
-  build: h442d1da_2
-  build_number: 2
+  version: 2.12.7
+  build: h283a6d9_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.4-h442d1da_2.conda
-  sha256: 352eb281dcac491b7ed9e01082947d734a2610f3700f1ab18524590a2862f069
-  md5: 46c233e5c137a2de2d1d95ca35ad8d6a
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h283a6d9_1.conda
+  sha256: aef096aa784e61f860fab08974c6260836bf05d742fb69f304f0e9b7d557c99a
+  md5: 7ab2653cc21c44a1370ef3b409261b3d
   depends:
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 1518137
-  timestamp: 1730355951612
+  size: 1709896
+  timestamp: 1717547244225
 - kind: conda
   name: libxml2
-  version: 2.13.4
-  build: hb346dea_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.4-hb346dea_2.conda
-  sha256: a111cb7f2deb6e20ebb475e8426ce5291451476f55f0dec6c220aa51e5a5784f
-  md5: 69b90b70c434b916abf5a1d5ee5d55fb
+  version: 2.12.7
+  build: h49dc7a2_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h49dc7a2_1.conda
+  sha256: 97b3f1ac86a26afc2591ecfe85a9fa7409d8b8d2956f308ddef34dd977ad9185
+  md5: cec3f7f6dd48a5b40ac62faa55288638
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=13
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 690019
-  timestamp: 1730355770718
+  size: 751903
+  timestamp: 1717546699265
 - kind: conda
   name: libxml2
-  version: 2.13.4
-  build: hf4efe5d_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.13.4-hf4efe5d_2.conda
-  sha256: 69d6197742a7cca2c9a030bf5c6f61d943d45deeaeb3b2df92ebdfd933524ae0
-  md5: 0e28ab30d29c5a566d05bf73dfc5c184
+  version: 2.12.7
+  build: hc051c1a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-hc051c1a_1.conda
+  sha256: 576ea9134176636283ff052897bf7a91ffd8ac35b2c505dfde2890ec52849698
+  md5: 340278ded8b0dc3a73f3660bbb0adbc6
   depends:
-  - icu >=75.1,<76.0a0
-  - libgcc >=13
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 733127
-  timestamp: 1730356005200
+  size: 704984
+  timestamp: 1717546454837
 - kind: conda
   name: libzip
-  version: 1.11.2
-  build: h3135430_0
+  version: 1.10.1
+  build: h1d365fa_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
-  sha256: 8ed49d8aa0ff908e16c82f92154174027c8906429e8b63d71f0b27ecc987b43e
-  md5: 09066edc7810e4bd1b41ad01a6cc4706
+  url: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
+  sha256: 221698b52dd7a3dcfc67ff9460e9c8649fc6c86506a2a2ab6f57b97e7489bb9f
+  md5: 5c629cd12d89e2856c17b1dc5fcf44a4
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 146856
-  timestamp: 1730442305774
+  size: 146434
+  timestamp: 1694417117772
 - kind: conda
   name: libzip
-  version: 1.11.2
-  build: h3e8f909_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
-  sha256: 9ae7edbe6dcdaa0371736118a1e05ffa47c15c0118a092ff1b0a35cbb621ac2d
-  md5: faf7adbb1938c4aa7a312f110f46859b
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 117603
-  timestamp: 1730442215935
-- kind: conda
-  name: libzip
-  version: 1.11.2
-  build: h6991a6a_0
+  version: 1.10.1
+  build: h2629f0a_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
-  sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
-  md5: a7b27c075c9b7f459f1c022090697cba
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+  sha256: 84e93f189072dcfcbe77744f19c7e4171523fbecfaba7352e5a23bbe014574c7
+  md5: ac79812548e7e8cf61f7b0abdef01d3b
   depends:
-  - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 109043
-  timestamp: 1730442108429
+  size: 107198
+  timestamp: 1694416433629
+- kind: conda
+  name: libzip
+  version: 1.10.1
+  build: h4156a30_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.10.1-h4156a30_3.conda
+  sha256: 4b1a653eeb5a139431fb074830b7a099d111594b1867363772f27ac84dee0acd
+  md5: ad9400456170b46f2615bdd48dff87fe
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 114810
+  timestamp: 1694416439941
 - kind: conda
   name: libzlib
-  version: 1.3.1
-  build: h2466b09_2
-  build_number: 2
+  version: 1.2.13
+  build: h2466b09_6
+  build_number: 6
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
-  md5: 41fbfac52c601159df6c01f875de31b9
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-h2466b09_6.conda
+  sha256: 97f47db85265b596d08c044b6533013b7286fb66259c77d04da76b74414c896e
+  md5: 9f41e3481778398837720a84dd26b7b1
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - zlib 1.3.1 *_2
+  - zlib 1.2.13 *_6
   license: Zlib
   license_family: Other
-  size: 55476
-  timestamp: 1727963768015
+  size: 56119
+  timestamp: 1716874608785
 - kind: conda
   name: libzlib
-  version: 1.3.1
-  build: h86ecc28_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
-  sha256: 5a2c1eeef69342e88a98d1d95bff1603727ab1ff4ee0e421522acd8813439b84
-  md5: 08aad7cbe9f5a6b460d0976076b6ae64
-  depends:
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 66657
-  timestamp: 1727963199518
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
+  version: 1.2.13
+  build: h4ab18f5_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h4ab18f5_6.conda
+  sha256: 8ced4afed6322172182af503f21725d072a589a6eb918f8a58135c1e00d35980
+  md5: 27329162c0dc732bcf67a4e0cd488125
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc-ng >=12
   constrains:
-  - zlib 1.3.1 *_2
+  - zlib 1.2.13 *_6
   license: Zlib
   license_family: Other
-  size: 60963
-  timestamp: 1727963148474
+  size: 61571
+  timestamp: 1716874066944
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: h68df207_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h68df207_6.conda
+  sha256: 4dafc31c913daae67d20a95fc2cac5a6d8bf1d5810d663e23b3335f9ae6f411d
+  md5: d69c6550eaf76e8e385f75e5ed60aed9
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_6
+  license: Zlib
+  license_family: Other
+  size: 67224
+  timestamp: 1716874073116
 - kind: conda
   name: lz4-c
   version: 1.9.4
@@ -9198,6 +9434,48 @@ packages:
 - kind: conda
   name: minizip
   version: 4.0.6
+  build: h8bbf78b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/minizip-4.0.6-h8bbf78b_0.conda
+  sha256: fff2dbb7712365b584433ad752afabff70d1617e51db03f0935fadd8273642ea
+  md5: 5d209eca1ba55e8271d10623f189ce01
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 96471
+  timestamp: 1717297211268
+- kind: conda
+  name: minizip
+  version: 4.0.6
+  build: h9d307f2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.6-h9d307f2_0.conda
+  sha256: 5870271f8ce37344b503e6938357802e9b77ca9fe5e36104ae236b3ac720c23d
+  md5: 857b62ff5fc3b6282189798bf06aa2ca
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 91278
+  timestamp: 1717296749853
+- kind: conda
+  name: minizip
+  version: 4.0.6
   build: hb638d1e_0
   subdir: win-64
   url: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
@@ -9215,48 +9493,6 @@ packages:
   license_family: Other
   size: 85324
   timestamp: 1717296997985
-- kind: conda
-  name: minizip
-  version: 4.0.7
-  build: h401b404_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
-  sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
-  md5: 4474532a312b2245c5c77f1176989b46
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.1,<4.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: Zlib
-  license_family: Other
-  size: 91409
-  timestamp: 1718483022284
-- kind: conda
-  name: minizip
-  version: 4.0.7
-  build: h77a9e90_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/minizip-4.0.7-h77a9e90_0.conda
-  sha256: 76bfb9973b32f8d9e4740ca6854e7c0daea5e66a28352e5999de0ea06faf0085
-  md5: 7c8cd307bc5c00bdba33e1c11685b3b4
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.1,<4.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: Zlib
-  license_family: Other
-  size: 96194
-  timestamp: 1718483492963
 - kind: conda
   name: mkl
   version: 2024.2.2
@@ -9306,80 +9542,70 @@ packages:
   timestamp: 1730581373280
 - kind: conda
   name: mysql-common
-  version: 9.0.1
-  build: h266115a_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
-  sha256: bf0c230c35ca70e2c98530eb064a99f0c4d4596793a0be3ca8a3cbd92094ef82
-  md5: 85c0dc0bcd110c998b01856975486ee7
+  version: 8.0.33
+  build: hb6794ad_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.0.33-hb6794ad_6.conda
+  sha256: 58399b2cabdff285909315da99efc761d11abb18156ff642146ebaf2058163e9
+  md5: 358520a1f6cdd2314bc0c27e0d152ecd
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - openssl >=3.3.2,<4.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 649443
-  timestamp: 1729804130603
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.4,<4.0a0
+  size: 761797
+  timestamp: 1698937751674
 - kind: conda
   name: mysql-common
-  version: 9.0.1
-  build: h3f5c77f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_2.conda
-  sha256: 27cb52f00b2fedb89ed4e7ed2527caf7c5b245dac76a809d0aed58514e08d325
-  md5: cc7bc11893dd1aee492dae85f317769e
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - openssl >=3.3.2,<4.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 636837
-  timestamp: 1729806881403
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: h11569fd_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_2.conda
-  sha256: 0c014ecbb449cd10bab96bf036cae646068ce42827f582244117adc805850d04
-  md5: 94c70f21e0a1f8558941d901027215a4
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-common 9.0.1 h3f5c77f_2
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1408789
-  timestamp: 1729806960210
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: he0572af_2
-  build_number: 2
+  version: 8.0.33
+  build: hf1915f5_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
-  sha256: e376189cd11304f4089971b372dac8a1cbbab6eacda8ca978ead2c220d16b8a4
-  md5: 57a9e7ee3c0840d3c8c9012473978629
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
+  sha256: c8b2c5c9d0d013a4f6ef96cb4b339bfdc53a74232d8c61ed08178e5b1ec4eb63
+  md5: 80bf3b277c120dd294b51d404b931a75
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-common 9.0.1 h266115a_2
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1372671
-  timestamp: 1729804203990
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.4,<4.0a0
+  size: 753467
+  timestamp: 1698937026421
+- kind: conda
+  name: mysql-libs
+  version: 8.0.33
+  build: hca2cd23_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
+  sha256: 78c905637dac79b197395065c169d452b8ca2a39773b58e45e23114f1cb6dcdb
+  md5: e87530d1b12dd7f4e0f856dc07358d60
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - mysql-common 8.0.33 hf1915f5_6
+  - openssl >=3.1.4,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  size: 1530126
+  timestamp: 1698937116126
+- kind: conda
+  name: mysql-libs
+  version: 8.0.33
+  build: hf629957_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.0.33-hf629957_6.conda
+  sha256: 2b444a4577482882664617bac615948d5fa838d17356707f7c7fa57a57742dc3
+  md5: 7d88d13742ad621e0cf8f0158a03bfd6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - mysql-common 8.0.33 hb6794ad_6
+  - openssl >=3.1.4,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  size: 1567046
+  timestamp: 1698937846157
 - kind: conda
   name: ncurses
   version: '6.5'
@@ -9409,6 +9635,34 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 889086
   timestamp: 1724658547447
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h7ab15ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+  sha256: 1ef1b7efa69c7fb4e2a36a88316f307c115713698d1c12e19f55ae57c0482995
+  md5: 2bf1915cc107738811368afcb0993a59
+  depends:
+  - libgcc-ng >=12
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  size: 1011638
+  timestamp: 1686309814836
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h9d1147b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
+  sha256: 27d70a4292515e948d6a16d03d7e5f2ec64396ccf2dd81aa9725667794fd71d8
+  md5: bf4b290d849247be4a5b89cfbd30b4d7
+  depends:
+  - libgcc-ng >=12
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  size: 1123356
+  timestamp: 1686311968059
 - kind: conda
   name: nspr
   version: '4.36'
@@ -9442,41 +9696,41 @@ packages:
   timestamp: 1729545760194
 - kind: conda
   name: nss
-  version: '3.106'
-  build: hcffee33_0
+  version: '3.100'
+  build: h8c4e863_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.106-hcffee33_0.conda
-  sha256: 76115ba1a5b5fbb7e3b471c84e983b514394c800adee30b158799ecdc15ded66
-  md5: e132b0f4cec9a1476c5c4da3722fc124
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.100-h8c4e863_0.conda
+  sha256: a11d29bee156be646897cdd95c99b207889dd55b7f5c80519987e138f70a1730
+  md5: 6029b52dd71a51b08ecf62cbf374ac5e
   depends:
-  - libgcc >=13
-  - libsqlite >=3.47.0,<4.0a0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.36,<5.0a0
+  - libgcc-ng >=12
+  - libsqlite >=3.45.3,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 1990164
-  timestamp: 1729814601835
+  size: 2036728
+  timestamp: 1715188636956
 - kind: conda
   name: nss
-  version: '3.106'
-  build: hdf54f9c_0
+  version: '3.100'
+  build: hca3bf56_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
-  sha256: e5dd3e57498decdef87ff641fa6b7bd5484fce3f2783811ee5ec278bc9e71281
-  md5: efe735c7dc47dddbb14b3433d11c6feb
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.100-hca3bf56_0.conda
+  sha256: a4146d2b6636999a21afcaf957029d066637bf26239fd3170242501e38fb1fa4
+  md5: 949c4a82290ee58b3c970cef4bcfd4ad
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libsqlite >=3.47.0,<4.0a0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.36,<5.0a0
+  - libgcc-ng >=12
+  - libsqlite >=3.45.3,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 2001391
-  timestamp: 1729811441549
+  size: 2047723
+  timestamp: 1715184444840
 - kind: conda
   name: numpy
   version: 1.26.4
@@ -9561,6 +9815,21 @@ packages:
   size: 135681
   timestamp: 1710946531879
 - kind: conda
+  name: ocl-icd-system
+  version: 1.0.0
+  build: '1'
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
+  sha256: cb0ce5ce5ede1be2fd9edf88abd3ce3e6c2b7397c0283d623e4d8ccf96a1ed09
+  md5: 577a4bd049737b11a24524e39a16a1f3
+  depends:
+  - ocl-icd
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 4253
+  timestamp: 1575483836797
+- kind: conda
   name: octomap
   version: 1.9.8
   build: h91493d7_0
@@ -9609,73 +9878,19 @@ packages:
 - kind: conda
   name: ogre
   version: 1.10.12.1
-  build: h21539af_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ogre-1.10.12.1-h21539af_4.conda
-  sha256: 2a4e4c1dca86a1a9b19772257609174c5016f13c38f3065d44bcedcf532e2855
-  md5: a0f25a6a4dd63282ec4fc7ec791465bb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - freeimage >=3.18.0,<3.19.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openexr >=3.3.1,<3.4.0a0
-  - pugixml >=1.14,<1.15.0a0
-  - sdl2
-  - swig
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxaw
-  - xorg-libxt >=1.3.0,<2.0a0
-  - zlib
-  - zziplib >=0.13.69,<0.14.0a0
-  license: MIT
-  license_family: MIT
-  size: 116182999
-  timestamp: 1729043416059
-- kind: conda
-  name: ogre
-  version: 1.10.12.1
-  build: h58a323e_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-h58a323e_4.conda
-  sha256: ea11551277f826d9d4217393a1b25901f11eb7ad4a66454cff04bd5a9f59dd6b
-  md5: d13c63526c5d9673dfda15feaf06515e
-  depends:
-  - freeimage >=3.18.0,<3.19.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openexr >=3.3.1,<3.4.0a0
-  - pugixml >=1.14,<1.15.0a0
-  - sdl2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  - zziplib >=0.13.69,<0.14.0a0
-  license: MIT
-  license_family: MIT
-  size: 115923462
-  timestamp: 1729044317831
-- kind: conda
-  name: ogre
-  version: 1.10.12.1
-  build: hacfc540_4
-  build_number: 4
+  build: h70aca81_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-1.10.12.1-hacfc540_4.conda
-  sha256: 729af83832fe2183cebfd6d8f33b4ba7a85342ffeb0b900cf11bf18b46fe8e19
-  md5: ee2f56fa29f7eb3ce4e14b272ef3957c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-1.10.12.1-h70aca81_1.conda
+  sha256: e514c70d999279ea85158ce31e5f919ae85d47fe1e4e5d4814fe5a4079676956
+  md5: 6d0772ec2927b9e1c4812fca7fb725c4
   depends:
   - freeimage >=3.18.0,<3.19.0a0
   - freetype >=2.12.1,<3.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openexr >=3.3.1,<3.4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  - openexr >=3.2.2,<3.3.0a0
   - pugixml >=1.14,<1.15.0a0
   - sdl2
   - xorg-libx11 >=1.8.9,<2.0a0
@@ -9685,8 +9900,62 @@ packages:
   - zziplib >=0.13.69,<0.14.0a0
   license: MIT
   license_family: MIT
-  size: 115194526
-  timestamp: 1729043382774
+  size: 116071591
+  timestamp: 1717441946044
+- kind: conda
+  name: ogre
+  version: 1.10.12.1
+  build: hc646683_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-hc646683_1.conda
+  sha256: b48f9fdf3f9f87303b2d2debcc97b8fbf320854128013b8fffefe1e37979db21
+  md5: 364da9b408d83870cd66afce3f00234c
+  depends:
+  - freeimage >=3.18.0,<3.19.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openexr >=3.2.2,<3.3.0a0
+  - pugixml >=1.14,<1.15.0a0
+  - sdl2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  - zziplib >=0.13.69,<0.14.0a0
+  license: MIT
+  license_family: MIT
+  size: 116023684
+  timestamp: 1717443791961
+- kind: conda
+  name: ogre
+  version: 1.10.12.1
+  build: hfa30d70_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ogre-1.10.12.1-hfa30d70_2.conda
+  sha256: b3bdcfb5d69a4bbacea267dccbf6d4bc877c93373c6b752017ecb2ea9b944395
+  md5: 09d5c6b39b3ef0ce33e03b63327ace97
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=13
+  - libstdcxx-ng >=13
+  - libzlib >=1.2.13,<2.0a0
+  - openexr >=3.2.2,<3.3.0a0
+  - pugixml >=1.14,<1.15.0a0
+  - sdl2
+  - swig
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxaw
+  - xorg-libxt >=1.3.0,<2.0a0
+  - zlib
+  - zziplib >=0.13.69,<0.14.0a0
+  license: MIT
+  license_family: MIT
+  size: 116304302
+  timestamp: 1724400675957
 - kind: conda
   name: ogre-next
   version: 2.2.6
@@ -9757,93 +10026,89 @@ packages:
   timestamp: 1656366205111
 - kind: conda
   name: openexr
-  version: 3.3.1
-  build: h974021d_2
-  build_number: 2
+  version: 3.2.2
+  build: h72640d8_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.1-h974021d_2.conda
-  sha256: fc23c2cbd9694e2bbb30cfbb44a7e69ead17e2127d46f46634c68cf748e217ee
-  md5: 96786f3f3db7a7ccd89b87ee400ec2a7
+  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h72640d8_1.conda
+  sha256: 23a080dc31c2d557719c928c2685e2952d5b36b70aecbfd962824bd0b414cf9c
+  md5: 3cecd7892a09d59f64a3e119647630f9
   depends:
-  - imath >=3.1.12,<3.1.13.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - imath >=3.1.11,<3.1.12.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 1178553
-  timestamp: 1729546904039
+  size: 1208041
+  timestamp: 1709260904190
 - kind: conda
   name: openexr
-  version: 3.3.1
-  build: haace395_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.1-haace395_2.conda
-  sha256: 915f62f283331860d26cb2f6df57249ead3f8cf46a143beeed8ad0bff6311993
-  md5: c9d36ef5708c97f3398b18eb92f51fe7
-  depends:
-  - imath >=3.1.12,<3.1.13.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1353236
-  timestamp: 1729546539373
-- kind: conda
-  name: openexr
-  version: 3.3.1
-  build: hccdc605_2
-  build_number: 2
+  version: 3.2.2
+  build: haf962dd_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.1-hccdc605_2.conda
-  sha256: de1abf7be0caca0cd83174ea77a9dbfeb1d36d748508e524cd2b9253ec3d86f6
-  md5: 907ffbb8a276c12c5a8a8aed2c5a10f9
+  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.2.2-haf962dd_1.conda
+  sha256: 01d773a14124929abd6c26169d900ce439f9df8a9e37d3ea197c7f71f61e7906
+  md5: 34e58e21fc28e404207d6ce4287da264
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - imath >=3.1.12,<3.1.13.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
+  - imath >=3.1.11,<3.1.12.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1405340
-  timestamp: 1729546542495
+  size: 1466865
+  timestamp: 1709260550301
+- kind: conda
+  name: openexr
+  version: 3.2.2
+  build: hdf561d4_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-hdf561d4_1.conda
+  sha256: 138e7306bce957fda18199270997dfedca1acd6d835b0ba3e9a3090998674a6b
+  md5: 0372e30a92ab93025acce24df8eed52a
+  depends:
+  - imath >=3.1.11,<3.1.12.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1388438
+  timestamp: 1709260386569
 - kind: conda
   name: openh264
-  version: 2.4.1
+  version: 2.4.0
   build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
-  sha256: fbd43d4ab82fd6dfd1502a55ccade4aabae4a85fa2353396078da8d5c10941db
-  md5: 97fc3bbca08e95e1d7af8366d5a4ece6
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.0-h2f0025b_0.conda
+  sha256: b254180a95cd3b492459fc5808c7e179e7abec829273138bb35a12a0fe64d7a7
+  md5: 5b6008e8f2bbf580e87bdf59d84b10a1
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 770201
-  timestamp: 1706873872574
+  size: 761063
+  timestamp: 1700931496192
 - kind: conda
   name: openh264
-  version: 2.4.1
+  version: 2.4.0
   build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
-  sha256: 0d4eaf15fb771f25c924aef831d76eea11d90c824778fc1e7666346e93475f42
-  md5: 3dfcf61b8e78af08110f5229f79580af
+  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.0-h59595ed_0.conda
+  sha256: 321a8920f401bf0a5200b12bc1abe2dbd32190c382897a7631d3251425d67e37
+  md5: bfdc3111edbb41be5b44a0e7b21030c5
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 735244
-  timestamp: 1706873814072
+  size: 736306
+  timestamp: 1700931377539
 - kind: conda
   name: openh264
   version: 2.4.1
@@ -9917,12 +10182,12 @@ packages:
   timestamp: 1709159244431
 - kind: conda
   name: openssl
-  version: 3.3.2
+  version: 3.4.0
   build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
-  sha256: a45c42f3577294e22ac39ddb6ef5a64fd5322e8a6725afefbf4f2b4109340bf9
-  md5: 1dc86753693df5e3326bb8a85b74c589
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+  sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
+  md5: d0d805d9b5524a14efb51b3bff965e83
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
@@ -9930,39 +10195,71 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
-  size: 8396053
-  timestamp: 1725412961673
+  size: 8491156
+  timestamp: 1731379715927
 - kind: conda
   name: openssl
-  version: 3.3.2
+  version: 3.4.0
   build: h86ecc28_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
-  sha256: 4669d26dbf81e4d72093d8260f55d19d57204d82b1d9440be83d11d313b5990c
-  md5: 9e1e477b3f8ee3789297883faffa708b
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.4.0-h86ecc28_0.conda
+  sha256: 64dbbdd6384fa56338124783197f7ad9048c989a02264bcd2e07355e3570f113
+  md5: b2f202b5bddafac824eb610b65dde98f
   depends:
   - ca-certificates
   - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 3428083
-  timestamp: 1725412266679
+  size: 3474825
+  timestamp: 1731379200886
 - kind: conda
   name: openssl
-  version: 3.3.2
+  version: 3.4.0
   build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
-  sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
-  md5: 4d638782050ab6faa27275bed57e9b4e
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 2891789
-  timestamp: 1725410790053
+  size: 2947466
+  timestamp: 1731377666602
+- kind: conda
+  name: p11-kit
+  version: 0.24.1
+  build: h9f2702f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
+  sha256: 24c37c8d131e3e72350a398060ec163eb48db75f19339b09bcf2d860ad0367fe
+  md5: a27524877b697f8e18d38ad30ba022f5
+  depends:
+  - libffi >=3.4.2,<3.5.0a0
+  - libgcc-ng >=12
+  - libtasn1 >=4.18.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 4947687
+  timestamp: 1654869375890
+- kind: conda
+  name: p11-kit
+  version: 0.24.1
+  build: hc5aa10d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
+  sha256: aa8d3887b36557ad0c839e4876c0496e0d670afe843bf5bba4a87764b868196d
+  md5: 56ee94e34b71742bbdfa832c974e47a8
+  depends:
+  - libffi >=3.4.2,<3.5.0a0
+  - libgcc-ng >=12
+  - libtasn1 >=4.18.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 4702497
+  timestamp: 1654868759643
 - kind: conda
   name: packaging
   version: '24.1'
@@ -9979,127 +10276,55 @@ packages:
   size: 50290
   timestamp: 1718189540074
 - kind: conda
-  name: pango
-  version: 1.54.0
-  build: h4c5309f_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
-  sha256: d362237be82d5a0d532fe66ec8d68018c3b2a9705bad6d73c2b63dae2970da02
-  md5: 7df02e445367703cd87a574046e3a6f0
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.2,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  license: LGPL-2.1-or-later
-  size: 447117
-  timestamp: 1719839527713
-- kind: conda
-  name: pango
-  version: 1.54.0
-  build: h7579590_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.54.0-h7579590_1.conda
-  sha256: 98e1706ef62c766e2a57f14da95d9d6652b594f901cb9a1b6c04208bd616bd99
-  md5: 905145a94ad41fce135074a0214616e9
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.2,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  license: LGPL-2.1-or-later
-  size: 460989
-  timestamp: 1719841137355
-- kind: conda
-  name: pango
-  version: 1.54.0
-  build: hbb871f6_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-hbb871f6_2.conda
-  sha256: 90327dd606f78ae9c881e285f85bc2b0f57d11c807be58ee3f690742354918b2
-  md5: 409c0b778deee649c025b7106549a24f
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.1-or-later
-  size: 450610
-  timestamp: 1723832834434
-- kind: conda
   name: pcre2
-  version: '10.44'
-  build: h070dd5b_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
-  sha256: e9f4b912e48514771d477f2ee955f59d4ff4ef799c3d4d16e4d0f335ce91df67
-  md5: 94022de9682cb1a0bb18a99cbc3541b3
+  version: '10.42'
+  build: h17e33f8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.42-h17e33f8_0.conda
+  sha256: 25e33b148478de58842ccc018fbabb414665de59270476e92c951203d4485bb1
+  md5: 59610c61da3af020289a806ec9c6a7fd
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 884590
-  timestamp: 1723488793100
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h3d7b363_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
-  sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
-  md5: a3a3baddcfb8c80db84bec3cb7746fb8
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 820831
-  timestamp: 1723489427046
+  size: 880802
+  timestamp: 1698611415241
 - kind: conda
   name: pcre2
-  version: '10.44'
-  build: hba22ea6_2
-  build_number: 2
+  version: '10.42'
+  build: hcad00b1_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
-  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
-  md5: df359c09c41cd186fffb93a2d87aa6f5
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
+  sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
+  md5: 679c8961826aa4b50653bce17ee52abe
   depends:
-  - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 952308
-  timestamp: 1723488734144
+  size: 1017235
+  timestamp: 1698610864983
+- kind: conda
+  name: pcre2
+  version: '10.42'
+  build: hd0f9c67_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.42-hd0f9c67_0.conda
+  sha256: 7ef11cc37800dcc4693c6f827e3cb58bc8a8cefe92b4307c6826845b3f198364
+  md5: 683162253dd3b6c4d21bf037e59455f4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 944649
+  timestamp: 1698610795381
 - kind: conda
   name: pixman
   version: 0.43.2
@@ -10149,6 +10374,23 @@ packages:
 - kind: conda
   name: pkg-config
   version: 0.29.2
+  build: h2bf4dc2_1008
+  build_number: 1008
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h2bf4dc2_1008.tar.bz2
+  sha256: f2f64c4774eea3b789c9568452d8cd776bdcf7e2cda0f24bfa9dbcbd7fbb9f6f
+  md5: 8ff5bccb4dc5d153e79b068e0bb301c5
+  depends:
+  - libglib >=2.64.6,<3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 33990
+  timestamp: 1604184834061
+- kind: conda
+  name: pkg-config
+  version: 0.29.2
   build: h4bc722e_1009
   build_number: 1009
   subdir: linux-64
@@ -10165,37 +10407,18 @@ packages:
 - kind: conda
   name: pkg-config
   version: 0.29.2
-  build: h88c491f_1009
-  build_number: 1009
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
-  sha256: 86b0c40c8b569dbc164cb1de098ddabf4c240a5e8f38547aab00493891fa67f3
-  md5: 122d6514d415fbe02c9b58aee9f6b53e
-  depends:
-  - libglib >=2.80.3,<3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 36118
-  timestamp: 1720806338740
-- kind: conda
-  name: pkg-config
-  version: 0.29.2
-  build: hce167ba_1009
-  build_number: 1009
+  build: hb9de7d4_1008
+  build_number: 1008
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
-  sha256: 6468cbfaf1d3140be46dd315ec383d373dbbafd770ce2efe77c3f0cdbc4576c1
-  md5: 05eda637f6465f7e8c5ab7e341341ea9
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hb9de7d4_1008.tar.bz2
+  sha256: 0d6af1ebd78e231281f570ad7ddd1e2789e485c94fba6b5cef4e8ad23ff7f3bf
+  md5: 1d0a81d5da1378d9b989383556c20eac
   depends:
-  - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
+  - libgcc-ng >=7.5.0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 54834
-  timestamp: 1720806008171
+  size: 298687
+  timestamp: 1604185362484
 - kind: conda
   name: pluggy
   version: 1.5.0
@@ -10212,59 +10435,226 @@ packages:
   size: 23815
   timestamp: 1713667175451
 - kind: conda
-  name: proj
-  version: 9.5.0
-  build: h07e4b22_0
+  name: poppler
+  version: 23.11.0
+  build: h3cd87ed_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.5.0-h07e4b22_0.conda
-  sha256: e9ad1ab0162c6bfcb3a1933b5a1b0fb1eb6a79cebbce7c508f6ac226084ac55b
-  md5: 42ea5e580769291c78c080abe85b4bf7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/poppler-23.11.0-h3cd87ed_0.conda
+  sha256: fa954916677872222f93cb53e20537d9ea54cfb5d6cf8f0c36dfe97310dd312a
+  md5: 49cb7e7cbb99d2887c6993fc51c33182
   depends:
-  - libcurl >=8.10.0,<9.0a0
-  - libgcc >=13
-  - libsqlite >=3.46.1,<4.0a0
-  - libstdcxx >=13
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.8.0a0
-  - sqlite
-  constrains:
-  - proj4 ==999999999999
-  license: MIT
-  license_family: MIT
-  size: 3005219
-  timestamp: 1726489790832
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.94,<4.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1955441
+  timestamp: 1698905185381
 - kind: conda
-  name: proj
-  version: 9.5.0
-  build: h12925eb_0
+  name: poppler
+  version: 23.11.0
+  build: h590f24d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
-  sha256: 936de8754054d97223e87cc87b72641d2c7582d536ee9eee4b0443fa66e2733f
-  md5: 8c29983ebe50cc7e0998c34bc7614222
+  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-23.11.0-h590f24d_0.conda
+  sha256: 8050002e01be124efcb82e32e740676f5ed7dfe852f335408554e6dc3b060ad9
+  md5: 671439d8eca2084bb5a75561fff23a85
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcurl >=8.10.0,<9.0a0
-  - libgcc >=13
-  - libsqlite >=3.46.1,<4.0a0
-  - libstdcxx >=13
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.94,<4.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1846082
+  timestamp: 1698899482991
+- kind: conda
+  name: poppler
+  version: 23.11.0
+  build: hc2f3c52_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/poppler-23.11.0-hc2f3c52_0.conda
+  sha256: 90ad58f65d89904df81bcca451fe70a7c8288ef9104389a080bd8dfd1c18ff6a
+  md5: 46ca123b3a217c10d51e446071e1801b
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 2292493
+  timestamp: 1698900356667
+- kind: conda
+  name: poppler-data
+  version: 0.4.12
+  build: hd8ed1ab_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+  sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
+  md5: d8d7293c5b37f39b2ac32940621c6592
+  license: BSD-3-Clause AND (GPL-2.0-only OR GPL-3.0-only)
+  license_family: OTHER
+  size: 2348171
+  timestamp: 1675353652214
+- kind: conda
+  name: postgresql
+  version: '16.3'
+  build: h2294c5c_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/postgresql-16.3-h2294c5c_0.conda
+  sha256: eb93f818f28cd206ea0b020fd33c6007961a78589763cc034490d947cad42b97
+  md5: 834fc612c678f3ea652e8688655a3da0
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libpq 16.3 hcf0348d_0
+  - libxml2 >=2.12.6,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  license: PostgreSQL
+  size: 5119060
+  timestamp: 1715266458221
+- kind: conda
+  name: postgresql
+  version: '16.3'
+  build: h7f155c9_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.3-h7f155c9_0.conda
+  sha256: 7cd34a8803a3687f6fbed5908dd9b2ecb0ff923a1ac7c4d602d0f06a5804edbd
+  md5: a253c97c94a2c2886e1cb79e34a5b641
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libpq 16.3 hab9416b_0
+  - libxml2 >=2.12.6,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PostgreSQL
+  size: 18697452
+  timestamp: 1715267263356
+- kind: conda
+  name: postgresql
+  version: '16.3'
+  build: h8e811e2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.3-h8e811e2_0.conda
+  sha256: 4cd39edd84011657978e35abdc880cf3e49785e8a86f1c99a34029a3e4998abe
+  md5: e4d52462da124ed3792472f95a36fc2a
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libpq 16.3 ha72fbe1_0
+  - libxml2 >=2.12.6,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  license: PostgreSQL
+  size: 5332852
+  timestamp: 1715266435060
+- kind: conda
+  name: proj
+  version: 9.3.0
+  build: h1d62c97_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.3.0-h1d62c97_2.conda
+  sha256: 252f6c31101719e3d524679e69ae81e6323b93b143e1360169bf50e89386bf24
+  md5: b5e57a0c643da391bef850922963eece
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libsqlite >=3.43.2,<4.0a0
+  - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.8.0a0
   - sqlite
   constrains:
   - proj4 ==999999999999
   license: MIT
   license_family: MIT
-  size: 3093445
-  timestamp: 1726489083290
+  size: 2960725
+  timestamp: 1697808524668
 - kind: conda
   name: proj
-  version: 9.5.0
-  build: hd9569ee_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
-  sha256: ebd1fee2834cf5971a08dfb665606f775302aa22e98d5d893d35323805311419
-  md5: 4cfbffd1cd2bbff30e975a71b1769597
+  version: 9.3.0
+  build: h7b42f86_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.3.0-h7b42f86_2.conda
+  sha256: a0705dc06e169b4e5e26a927cb960c51dcbc0dc8533d42434b4135b2010f2d7d
+  md5: ffcc4c6dcdffd1316c1224a96dd6ea76
   depends:
-  - libcurl >=8.10.0,<9.0a0
-  - libsqlite >=3.46.1,<4.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libsqlite >=3.43.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2870578
+  timestamp: 1697809260332
+- kind: conda
+  name: proj
+  version: 9.3.0
+  build: he13c7e8_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/proj-9.3.0-he13c7e8_2.conda
+  sha256: 67a5d032a0343dc8182ef50221d9ee47edb50d34cd94813e65111901cbbbc6d3
+  md5: 4e6d2a06874a1a6cd66e842d29bcd373
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libsqlite >=3.43.2,<4.0a0
   - libtiff >=4.6.0,<4.8.0a0
   - sqlite
   - ucrt >=10.0.20348.0
@@ -10274,68 +10664,74 @@ packages:
   - proj4 ==999999999999
   license: MIT
   license_family: MIT
-  size: 2709612
-  timestamp: 1726489723807
+  size: 2645178
+  timestamp: 1697808796596
 - kind: conda
   name: protobuf
-  version: 5.28.2
-  build: py39h7dbf29c_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/protobuf-5.28.2-py39h7dbf29c_0.conda
-  sha256: bd0999c81e1b0d3b5a314c20cfc92fddfcbaf8cf8c811b2b0387f372f81e6081
-  md5: 1feb9d08ae1f00dfff179bb887bb30cf
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - python >=3.9,<3.10.0a0
-  - python >=3.9,<3.10.0a0 *_cpython
-  - python_abi 3.9.* *_cp39
-  constrains:
-  - libprotobuf 5.28.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 398454
-  timestamp: 1728669986965
-- kind: conda
-  name: protobuf
-  version: 5.28.2
-  build: py39ha51f57c_0
+  version: 3.14.0
+  build: py39h415ef7b_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/protobuf-5.28.2-py39ha51f57c_0.conda
-  sha256: 76b7a88eb97525b7da6cc8996c2d1648a370ed1558eb9a47a5d362af79f64ab6
-  md5: 9569c0ff8fb6d62e7e70376be8fa0b7a
+  url: https://conda.anaconda.org/conda-forge/win-64/protobuf-3.14.0-py39h415ef7b_1.tar.bz2
+  sha256: 44d6a761c045e534f50200958cda8927405234a5ba544a9bf6c4bfc0911c713e
+  md5: ebf378a12f328842ffc448dc36fc3f44
   depends:
+  - libprotobuf 3.14.0.*
+  - libprotobuf >=3.14.0,<3.15.0a0
   - python >=3.9,<3.10.0a0
   - python_abi 3.9.* *_cp39
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libprotobuf 5.28.2
+  - setuptools
+  - six
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   license: BSD-3-Clause
   license_family: BSD
-  size: 379231
-  timestamp: 1728670790872
+  size: 267568
+  timestamp: 1610095132409
 - kind: conda
   name: protobuf
-  version: 5.28.2
-  build: py39hf88036b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-5.28.2-py39hf88036b_0.conda
-  sha256: cc320291ad9b8e493bc725efc726b5e35bc49f291b5cf624aab352c7e36068e9
-  md5: 098e3773daab0e2f81092fb1d1e69756
+  version: 3.14.0
+  build: py39h99ab00b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/protobuf-3.14.0-py39h99ab00b_1.tar.bz2
+  sha256: 887cebb6977d4f997c033455e0ecd6d548451e7bff040b8677593542b1d890be
+  md5: 814afbcb9cbe24fc842c35a03eaa739c
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc-ng >=9.3.0
+  - libprotobuf 3.14.0.*
+  - libprotobuf >=3.14.0,<3.15.0a0
+  - libstdcxx-ng >=9.3.0
   - python >=3.9,<3.10.0a0
   - python_abi 3.9.* *_cp39
-  constrains:
-  - libprotobuf 5.28.2
+  - setuptools
+  - six
   license: BSD-3-Clause
   license_family: BSD
-  size: 389583
-  timestamp: 1728670172149
+  size: 349828
+  timestamp: 1610103986856
+- kind: conda
+  name: protobuf
+  version: 3.14.0
+  build: py39he80948d_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-3.14.0-py39he80948d_1.tar.bz2
+  sha256: 449338a2e4a69224882610ec802e0e73d05bab93df291c32568d75dfb29b7571
+  md5: c56c3408525b195878a8f52831f9378c
+  depends:
+  - libgcc-ng >=9.3.0
+  - libprotobuf 3.14.0.*
+  - libprotobuf >=3.14.0,<3.15.0a0
+  - libstdcxx-ng >=9.3.0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - setuptools
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356131
+  timestamp: 1610094766922
 - kind: conda
   name: pthread-stubs
   version: '0.4'
@@ -10431,44 +10827,46 @@ packages:
   timestamp: 1696182979614
 - kind: conda
   name: pulseaudio-client
-  version: '17.0'
-  build: h729494f_0
+  version: '16.1'
+  build: h729494f_5
+  build_number: 5
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
-  sha256: 209eac3123ee2c84a35401626941c4aa64e04e2c9854084ddeba6432c6078a41
-  md5: f35f57712d5c2abca98c85a51a408bc1
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-16.1-h729494f_5.conda
+  sha256: da519980beffcda9e6f469f3b6a7eb5ee79178c1b0c13b9ce836e8cadb1eb1a0
+  md5: 2a7db85ea4e74dcc7677b2c76e244a9a
   depends:
   - dbus >=1.13.6,<2.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.3,<3.0a0
+  - libglib >=2.76.4,<3.0a0
   - libsndfile >=1.2.2,<1.3.0a0
-  - libsystemd0 >=255
+  - libsystemd0 >=254
   constrains:
-  - pulseaudio 17.0 *_0
+  - pulseaudio 16.1 *_5
   license: LGPL-2.1-or-later
   license_family: LGPL
-  size: 766184
-  timestamp: 1705690164726
+  size: 758313
+  timestamp: 1693928930444
 - kind: conda
   name: pulseaudio-client
-  version: '17.0'
-  build: hb77b528_0
+  version: '16.1'
+  build: hb77b528_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
-  sha256: b27c0c8671bd95c205a61aeeac807c095b60bc76eb5021863f919036d7a964fc
-  md5: 07f45f1be1c25345faddb8db0de8039b
+  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
+  sha256: 9981c70893d95c8cac02e7edd1a9af87f2c8745b772d529f08b7f9dafbe98606
+  md5: ac902ff3c1c6d750dd0dfc93a974ab74
   depends:
   - dbus >=1.13.6,<2.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.3,<3.0a0
+  - libglib >=2.76.4,<3.0a0
   - libsndfile >=1.2.2,<1.3.0a0
-  - libsystemd0 >=255
+  - libsystemd0 >=254
   constrains:
-  - pulseaudio 17.0 *_0
+  - pulseaudio 16.1 *_5
   license: LGPL-2.1-or-later
   license_family: LGPL
-  size: 757633
-  timestamp: 1705690081905
+  size: 754844
+  timestamp: 1693928953742
 - kind: conda
   name: pybind11
   version: 2.13.6
@@ -10635,26 +11033,24 @@ packages:
   timestamp: 1710357496750
 - kind: conda
   name: python
-  version: 3.9.20
-  build: h13acc7a_1_cpython
-  build_number: 1
+  version: 3.9.19
+  build: h0755675_0_cpython
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.20-h13acc7a_1_cpython.conda
-  sha256: 6a30aa8df1745eded1e5c24d167cb10e6f379e75d2f2fa2a212e6dab76030698
-  md5: 951cff166a5f170e27908811917165f8
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.19-h0755675_0_cpython.conda
+  sha256: b9253ca9ca5427e6da4b1d43353a110e0f2edfab9c951afb4bf01cbae2825b31
+  md5: d9ee3647fbd9e8595b8df759b2bbefb8
   depends:
-  - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
   - libffi >=3.4,<4.0a0
-  - libgcc >=13
+  - libgcc-ng >=12
   - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.46.1,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libuuid >=2.38.1,<3.0a0
   - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
@@ -10662,29 +11058,28 @@ packages:
   constrains:
   - python_abi 3.9.* *_cp39
   license: Python-2.0
-  size: 23684398
-  timestamp: 1727719528404
+  size: 23800555
+  timestamp: 1710940120866
 - kind: conda
   name: python
-  version: 3.9.20
-  build: h4a649e4_1_cpython
-  build_number: 1
+  version: 3.9.19
+  build: h4ac3b42_0_cpython
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.9.20-h4a649e4_1_cpython.conda
-  sha256: be697df0f1ea1736289d1f0ac5905d0b5662d74595db55533dfc9bed5e48a175
-  md5: c2833e3d5a6d210ffb433cbd4a1cf174
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.9.19-h4ac3b42_0_cpython.conda
+  sha256: 26845bcb8194e121331d47dca98d07f6197d5bf3bd2cb8da2cd2391722463180
+  md5: 1501507cd9451472ec8900d587ce872f
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-aarch64 >=2.36.1
   - libffi >=3.4,<4.0a0
-  - libgcc >=13
+  - libgcc-ng >=12
   - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.46.1,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libuuid >=2.38.1,<3.0a0
   - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
@@ -10692,34 +11087,32 @@ packages:
   constrains:
   - python_abi 3.9.* *_cp39
   license: Python-2.0
-  size: 12480954
-  timestamp: 1727718626172
+  size: 12542650
+  timestamp: 1710945692074
 - kind: conda
   name: python
-  version: 3.9.20
-  build: hfaddaf0_1_cpython
-  build_number: 1
+  version: 3.9.19
+  build: h4de0772_0_cpython
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.9.20-hfaddaf0_1_cpython.conda
-  sha256: c4ef6a17c8065d8c653fc69cfa17b2a1b0d9a2ca1360ba67a514b450c8797fd9
-  md5: 445389d1d311435a90def248c814ddd6
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.9.19-h4de0772_0_cpython.conda
+  sha256: 92d847bc9e79a60c1d139aa4ca0385d283b90aa2d7421bb3ffcb5dc0678fd72f
+  md5: b6999bc275e0e6beae7b1c8ea0be1e85
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.1,<15
+  - vc14_runtime >=14.16.27033
   - xz >=5.2.6,<6.0a0
   constrains:
   - python_abi 3.9.* *_cp39
   license: Python-2.0
-  size: 17024927
-  timestamp: 1727718943163
+  size: 16906240
+  timestamp: 1710938565297
 - kind: conda
   name: python-dateutil
   version: 2.9.0
@@ -10860,161 +11253,154 @@ packages:
   timestamp: 1725456761667
 - kind: conda
   name: qt-main
-  version: 5.15.15
-  build: h264fbc2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h264fbc2_0.conda
-  sha256: 77c78ce62e5c53ed529f035535283b96ee617ffd64ae1ea6a2dfdea186e39608
-  md5: e6e473c620bc0c3772dbed14f9eb4ab2
+  version: 5.15.8
+  build: h5810be5_19
+  build_number: 19
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h5810be5_19.conda
+  sha256: 41228ec12346d640ef1f549885d8438e98b1be0fdeb68cd1dd3938f255cbd719
+  md5: 54866f708d43002a514d0b9b0f84bc11
   depends:
-  - gst-plugins-base >=1.24.7,<1.25.0a0
-  - gstreamer >=1.24.7,<1.25.0a0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang13 >=19.1.2
-  - libglib >=2.82.2,<3.0a0
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gst-plugins-base >=1.22.9,<1.23.0a0
+  - gstreamer >=1.22.9,<1.23.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libcups >=2.3.3,<2.4.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - libpng >=1.6.42,<1.7.0a0
+  - libpq >=16.2,<17.0a0
+  - libsqlite >=3.45.1,<4.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxkbcommon >=1.6.0,<2.0a0
+  - libxml2 >=2.12.5,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - mysql-libs >=8.0.33,<8.1.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.97,<4.0a0
+  - openssl >=3.2.1,<4.0a0
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.9,<0.4.0a0
+  - xcb-util-wm >=0.4.1,<0.5.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xf86vidmodeproto
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - qt 5.15.8
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 61337596
+  timestamp: 1707958161584
+- kind: conda
+  name: qt-main
+  version: 5.15.8
+  build: h5992497_18
+  build_number: 18
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5992497_18.conda
+  sha256: bc72f2472b1cfc418c99ba8719138c0d3eee4ca51d6d97ae0fea474735bbde40
+  md5: 4d287ec80c254043afc54cecaaf84ad5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gst-plugins-base >=1.22.7,<1.23.0a0
+  - gstreamer >=1.22.7,<1.23.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libcups >=2.3.3,<2.4.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.1,<17.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxkbcommon >=1.6.0,<2.0a0
+  - libxml2 >=2.12.2,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - mysql-libs >=8.0.33,<8.1.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.95,<4.0a0
+  - openssl >=3.2.0,<4.0a0
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.9,<0.4.0a0
+  - xcb-util-wm >=0.4.1,<0.5.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xf86vidmodeproto
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - qt 5.15.8
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 60341847
+  timestamp: 1702216026937
+- kind: conda
+  name: qt-main
+  version: 5.15.8
+  build: h9e85ed6_19
+  build_number: 19
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_19.conda
+  sha256: a132554a24f0617f54668479a29d9af80a2235653b08a4ebd200dcd30da971a8
+  md5: 1e5fa5b05768a8eed9d8bb0bf5585b1f
+  depends:
+  - gst-plugins-base >=1.22.9,<1.23.0a0
+  - gstreamer >=1.22.9,<1.23.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libglib >=2.78.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.42,<1.7.0a0
+  - libsqlite >=3.45.1,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zstd >=1.5.6,<1.6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   constrains:
-  - qt 5.15.15
+  - qt 5.15.8
   license: LGPL-3.0-only
   license_family: LGPL
-  size: 60059195
-  timestamp: 1729904868434
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h374914d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h374914d_0.conda
-  sha256: 333be9817b492b7303d3a01073d3cff71719e72ba11507141ddfdd89732dc7a8
-  md5: 26e8b00e73c114c9b787d36edcbf4424
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.12,<1.3.0a0
-  - dbus >=1.13.6,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gst-plugins-base >=1.24.7,<1.25.0a0
-  - gstreamer >=1.24.7,<1.25.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp19.1 >=19.1.2,<19.2.0a0
-  - libclang13 >=19.1.2
-  - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.123,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.82.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm19 >=19.1.2,<19.2.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libpq >=16.4,<17.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libstdcxx >=13
-  - libxcb >=1.17.0,<2.0a0
-  - libxkbcommon >=1.7.0,<2.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-libs >=9.0.1,<9.1.0a0
-  - nspr >=4.36,<5.0a0
-  - nss >=3.106,<4.0a0
-  - openssl >=3.3.2,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.1,<0.5.0a0
-  - xcb-util-renderutil >=0.3.10,<0.4.0a0
-  - xcb-util-wm >=0.4.2,<0.5.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxxf86vm >=1.1.5,<2.0a0
-  - xorg-xf86vidmodeproto
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - qt 5.15.15
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 52549288
-  timestamp: 1729904847636
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h3c8598d_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h3c8598d_0.conda
-  sha256: efe565fbe7f0b0c39f3c179d383a8a3f39582934e225775927b9c05c9b9792ea
-  md5: 2b6e3e9f306565824c25f64df8953f39
-  depends:
-  - alsa-lib >=1.2.12,<1.3.0a0
-  - dbus >=1.13.6,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gst-plugins-base >=1.24.7,<1.25.0a0
-  - gstreamer >=1.24.7,<1.25.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp19.1 >=19.1.2,<19.2.0a0
-  - libclang13 >=19.1.2
-  - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.123,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.82.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm19 >=19.1.2,<19.2.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libpq >=16.4,<17.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libstdcxx >=13
-  - libxcb >=1.17.0,<2.0a0
-  - libxkbcommon >=1.7.0,<2.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-libs >=9.0.1,<9.1.0a0
-  - nspr >=4.36,<5.0a0
-  - nss >=3.106,<4.0a0
-  - openssl >=3.3.2,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.1,<0.5.0a0
-  - xcb-util-renderutil >=0.3.10,<0.4.0a0
-  - xcb-util-wm >=0.4.2,<0.5.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxxf86vm >=1.1.5,<2.0a0
-  - xorg-xf86vidmodeproto
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - qt 5.15.15
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 51848391
-  timestamp: 1729887971802
+  size: 60081554
+  timestamp: 1707957968211
 - kind: conda
   name: qwt
   version: 6.3.0
@@ -11126,67 +11512,16 @@ packages:
 - kind: conda
   name: ruby
   version: 3.2.2
-  build: h40894ad_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.2.2-h40894ad_2.conda
-  sha256: 4a71f2bb8bf6ae17412c8cccfd30ba1d2ea34a4296aebd03fd8d5d37c09936d1
-  md5: bfff3d63ffe712636db9402a0418cff5
-  depends:
-  - gdbm >=1.18,<1.19.0a0
-  - gmp >=6.3.0,<7.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  track_features:
-  - rb32
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 8127569
-  timestamp: 1719562020806
-- kind: conda
-  name: ruby
-  version: 3.2.2
-  build: ha7facd8_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.2.2-ha7facd8_2.conda
-  sha256: f1844971d787643b9a97f238b19b027ed64acdd09b2fca247b4d3f390e020c6c
-  md5: c7ee89c69a429482525d2d3a689f2bc1
-  depends:
-  - gmp >=6.3.0,<7.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  track_features:
-  - rb32
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 8214301
-  timestamp: 1719562438699
-- kind: conda
-  name: ruby
-  version: 3.2.2
-  build: hc493ab1_2
-  build_number: 2
+  build: h20ad4f3_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ruby-3.2.2-hc493ab1_2.conda
-  sha256: 19ff1e61fc66bb2bbebdea16a350a39e4dae193455d57c7e6145b10913a953b2
-  md5: 075228357cee7b0f2edda08cc9ab52e6
+  url: https://conda.anaconda.org/conda-forge/win-64/ruby-3.2.2-h20ad4f3_1.conda
+  sha256: b1a149dfa4eb2a4560d8b9317e3d18958a4232417506cb0e88f50663062c9a82
+  md5: e4b00fff2518ccf9b1c47111ad35af6c
   depends:
   - libffi >=3.4,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.1,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -11195,43 +11530,93 @@ packages:
   - rb32
   license: BSD-2-Clause
   license_family: BSD
-  size: 15330275
-  timestamp: 1719563007366
+  size: 15322685
+  timestamp: 1703349839755
 - kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: h2a74887_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
-  sha256: 6c21954d98a915d7617c0944440167e5ac695117ca7410f37eea4af0a9f0821c
-  md5: 719245709dd47dbc3f93ce85fa544f43
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1317383
-  timestamp: 1725255076176
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: h3ed165c_0
+  name: ruby
+  version: 3.2.2
+  build: h983345b_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
-  sha256: 80691a3ce313f0f7908480c0af216520d655e9480e036feb489c2095ad37950a
-  md5: be75875082c99c7a9f9fe930a1bd2bb1
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.2.2-h983345b_1.conda
+  sha256: be733598e379edab3b573d094c731d48ee6e773bb0427092c31fcf948b114673
+  md5: c54d030ba62fe04a4545b6a18a65216b
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
+  - gdbm >=1.18,<1.19.0a0
+  - gmp >=6.3.0,<7.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  track_features:
+  - rb32
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8092624
+  timestamp: 1703348802899
+- kind: conda
+  name: ruby
+  version: 3.2.2
+  build: hcdc5f17_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.2.2-hcdc5f17_1.conda
+  sha256: 178f133baeb05d1440165139a671169660950d5e7ffed270c45f79a4728ba446
+  md5: 39290be94d6960c2e9a46c11ebe1ed3d
+  depends:
+  - gmp >=6.3.0,<7.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  track_features:
+  - rb32
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8236895
+  timestamp: 1703349359919
+- kind: conda
+  name: sdl2
+  version: 2.28.5
+  build: h4e7748e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.28.5-h4e7748e_0.conda
+  sha256: 47aba875abfee18ab9be58b887a36a8f592e5cf6b31f4df1af194b2b161d4f34
+  md5: e6acdb75b2a0b729f21aedb5dec913b0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   license: Zlib
-  size: 1391142
-  timestamp: 1725255009793
+  size: 1294716
+  timestamp: 1701816779695
+- kind: conda
+  name: sdl2
+  version: 2.28.5
+  build: h77f46ba_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.28.5-h77f46ba_0.conda
+  sha256: f1380a83bbb8968a4dfafb1b51f86fd76e2c57c75b76a2249faa02d77ec38a8c
+  md5: 8e8d854355eb56c55682f5c0df8b575d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1369406
+  timestamp: 1701816620021
 - kind: conda
   name: sdl2
   version: 2.30.7
@@ -11279,19 +11664,36 @@ packages:
   timestamp: 1620240338595
 - kind: conda
   name: snappy
-  version: 1.2.1
-  build: h1088aeb_0
+  version: 1.1.10
+  build: h8d0c38d_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
-  sha256: 79f5d0a9098acf2ed16e6ecc4c11472b50ccf59feea37a7d585fd43888d7e41f
-  md5: e4ed5b015f525b56f95c26d85a4ea208
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-h8d0c38d_1.conda
+  sha256: 46b1f807e4dc31fa5bdc13bd13cd83bdd7c147efea31c5313efc1813bf8a3b8e
+  md5: f694843d106dfda5d0732f69850c84ec
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 42888
-  timestamp: 1720003817527
+  size: 40644
+  timestamp: 1712591000604
+- kind: conda
+  name: snappy
+  version: 1.1.10
+  build: hdb0a2a9_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-hdb0a2a9_1.conda
+  sha256: 082eadbc355016e948f1acc2f16e721ae362ecdaa204cbd60136ada19bd43f3a
+  md5: 78b8b85bdf1f42b8a2b3cb577d8742d1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40135
+  timestamp: 1712590996060
 - kind: conda
   name: snappy
   version: 1.2.1
@@ -11308,21 +11710,6 @@ packages:
   license_family: BSD
   size: 59350
   timestamp: 1720004197144
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: ha2e4443_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
-  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
-  md5: 6b7dcc7349efd123d493d2dbe85a045f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 42465
-  timestamp: 1720003704360
 - kind: conda
   name: spdlog
   version: 1.13.0
@@ -11374,6 +11761,40 @@ packages:
   timestamp: 1713902039030
 - kind: conda
   name: sqlite
+  version: 3.46.0
+  build: h6d4b2fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.46.0-h6d4b2fc_0.conda
+  sha256: e849d576e52bf3e6fc5786f89b7d76978f2e2438587826c95570324cb572e52b
+  md5: 77ea8dff5cf8550cc8f5629a6af56323
+  depends:
+  - libgcc-ng >=12
+  - libsqlite 3.46.0 hde9e2c9_0
+  - libzlib >=1.2.13,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 860352
+  timestamp: 1718050658212
+- kind: conda
+  name: sqlite
+  version: 3.46.0
+  build: hdc7ab3c_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.46.0-hdc7ab3c_0.conda
+  sha256: d6425bffe24f02a0a2e4e4f228aeca16bde76074b9bce311a976c948f802aebe
+  md5: e0e3a71d3b7092af7cb9e0696f6d0869
+  depends:
+  - libgcc-ng >=12
+  - libsqlite 3.46.0 hf51ef55_0
+  - libzlib >=1.2.13,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 1057383
+  timestamp: 1718050601668
+- kind: conda
+  name: sqlite
   version: 3.47.0
   build: h2466b09_1
   build_number: 1
@@ -11390,106 +11811,68 @@ packages:
   size: 914686
   timestamp: 1730208443157
 - kind: conda
-  name: sqlite
-  version: 3.47.0
-  build: h578a6b9_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.47.0-h578a6b9_1.conda
-  sha256: 56c340844a9d8e8bb7c5175fba309dbea5362d5e81746e3cec6a08ee42444d80
-  md5: 8d4471877330ce83ef7a2a007cb34851
-  depends:
-  - libgcc >=13
-  - libsqlite 3.47.0 hc4a20ef_1
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.2,<9.0a0
-  license: Unlicense
-  size: 1070835
-  timestamp: 1730208195373
-- kind: conda
-  name: sqlite
-  version: 3.47.0
-  build: h9eae976_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
-  sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
-  md5: 53abf1ef70b9ae213b22caa5350f97a9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libsqlite 3.47.0 hadc24fc_1
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.2,<9.0a0
-  license: Unlicense
-  size: 883666
-  timestamp: 1730208056779
-- kind: conda
   name: svt-av1
-  version: 2.3.0
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
-  sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
-  md5: 355898d24394b2af353eb96358db9fdd
+  version: 1.8.0
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
+  sha256: bcf42cef4cf08e0b79a71f4978e16ba92bd70624b25eb32a324a0be3edc79f4c
+  md5: 64801dba0cb1972e64a568b7234331e1
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 2746291
-  timestamp: 1730246036363
+  size: 1798999
+  timestamp: 1702362756845
 - kind: conda
   name: svt-av1
-  version: 2.3.0
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.3.0-h5ad3122_0.conda
-  sha256: 2fad2496a21d198ea72f5dabfdace2fae0ced5cc3ea243922cb372fcf4c18222
-  md5: efb60b536bbf64772929b57f6b30298b
+  version: 1.8.0
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.8.0-h59595ed_0.conda
+  sha256: 6d64facdcdaadc5a3e5e4382ee195b4fde3c84ae3d4156fdd9b78ba7de358ba7
+  md5: a9fb862e9d3beb0ebc61c10806056a7d
   depends:
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 1796731
-  timestamp: 1730246027014
+  size: 2644060
+  timestamp: 1702359203835
 - kind: conda
   name: svt-av1
-  version: 2.3.0
-  build: he0c23c2_0
+  version: 2.0.0
+  build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
-  sha256: c25bf68ef411d41ee29f353acc698c482fdd087426a77398b7b41ce9d968519e
-  md5: ac11ae1da661e573b71870b1191ce079
+  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.0.0-h63175ca_0.conda
+  sha256: 0ece693f79e90819958e9e265b2b19409f36b4434aa132a58c993264a927d029
+  md5: b3c5c51269efb1bc04502c6231506707
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
   license_family: BSD
-  size: 1845727
-  timestamp: 1730246453216
+  size: 2354231
+  timestamp: 1710374384723
 - kind: conda
   name: swig
-  version: 4.3.0
-  build: heed6a68_0
+  version: 4.2.0
+  build: h1bc8f3f_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/swig-4.3.0-heed6a68_0.conda
-  sha256: 4771f7a2323d7f3c4d42b1c8ed670335ede7e78b80d8ba17d3c40b781dedcbdc
-  md5: 0e4da15e507b716140699aca1a279a88
+  url: https://conda.anaconda.org/conda-forge/linux-64/swig-4.2.0-h1bc8f3f_1.conda
+  sha256: d339fe85a44f9114f26e09b34bd3f63e89b630d4def2a0c64a22fee6d9fd7a6f
+  md5: 58501890f58565e93275f4521b7124e9
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - pcre2 >=10.44,<10.45.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pcre2 >=10.42,<10.43.0a0
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 1248414
-  timestamp: 1729588950292
+  size: 1192075
+  timestamp: 1704701978117
 - kind: conda
   name: sysroot_linux-64
   version: '2.17'
@@ -11574,6 +11957,73 @@ packages:
   license_family: APACHE
   size: 178584
   timestamp: 1730477634943
+- kind: conda
+  name: tiledb
+  version: 2.16.3
+  build: h1ffc264_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.16.3-h1ffc264_3.conda
+  sha256: eef243f268655cddfd965dd75966ac24eb130e5b0ed1beb3ab85f2d0cfdb9345
+  md5: 9453d4f0781d29988b3c23db875be022
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libxml2 >=2.11.5,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3826668
+  timestamp: 1694523702257
+- kind: conda
+  name: tiledb
+  version: 2.16.3
+  build: hdb54b9b_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tiledb-2.16.3-hdb54b9b_3.conda
+  sha256: 0f795613b66de8592c3151fcbd108b1239a1092cc009bf0e8098221b2ae97f99
+  md5: e9f97b0e940562a7c0ddf279143312d6
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.5,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 5736712
+  timestamp: 1694522010658
+- kind: conda
+  name: tiledb
+  version: 2.16.3
+  build: hf0b6e87_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.16.3-hf0b6e87_3.conda
+  sha256: 6755c8dde4ea401d2c312dbb1dd2b4632bbac59851375182728ac8d5894acbd8
+  md5: 1e28da846782f91a696af3952a2472f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.5,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 5925543
+  timestamp: 1694521342980
 - kind: conda
   name: tinyxml2
   version: 10.0.0
@@ -11695,6 +12145,35 @@ packages:
   license_family: MIT
   size: 18203
   timestamp: 1727974767524
+- kind: conda
+  name: tzcode
+  version: 2024b
+  build: h86ecc28_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tzcode-2024b-h86ecc28_0.conda
+  sha256: c4c8038d542eea8e035d7fd4eb46c6bc484b4e75d4c369e5b7635475dde87033
+  md5: 90638c890912ee99073cc8913337e13c
+  depends:
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70982
+  timestamp: 1725601541485
+- kind: conda
+  name: tzcode
+  version: 2024b
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024b-hb9d3cd8_0.conda
+  sha256: 20c72e7ba106338d51fdc29a717a54fcd52340063232e944dcd1d38fb6348a28
+  md5: db124840386e1f842f93372897d1b857
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69349
+  timestamp: 1725600364789
 - kind: conda
   name: tzdata
   version: 2024b
@@ -11937,6 +12416,37 @@ packages:
   size: 17453
   timestamp: 1728400827536
 - kind: conda
+  name: vs2019_win-64
+  version: 19.29.30139
+  build: he1865b1_22
+  build_number: 22
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_22.conda
+  sha256: d22e90a4012dae3e67c912c80ab9876eff2ba58c5735e47442ab8bcf3df8525d
+  md5: 8bcfb79dfd0ca4e9bc3a645c6bd9f16a
+  depends:
+  - vswhere
+  constrains:
+  - vs_win-64 2019.11
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19994
+  timestamp: 1728401194337
+- kind: conda
+  name: vswhere
+  version: 3.1.7
+  build: h57928b3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
+  sha256: 8caeda9c0898cb8ee2cf4f45640dbbbdf772ddc01345cfb0f7b352c58b4d8025
+  md5: ba83df93b48acfc528f5464c9a882baa
+  license: MIT
+  license_family: MIT
+  size: 219013
+  timestamp: 1719460515960
+- kind: conda
   name: vulkan-headers
   version: 1.3.231.1
   build: h924138e_0
@@ -11951,39 +12461,6 @@ packages:
   license_family: APACHE
   size: 1024240
   timestamp: 1674926882847
-- kind: conda
-  name: wayland
-  version: 1.23.1
-  build: h3e06ad9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
-  sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
-  md5: 0a732427643ae5e0486a727927791da1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.6.2,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=13
-  - libstdcxx-ng >=13
-  license: MIT
-  license_family: MIT
-  size: 321561
-  timestamp: 1724530461598
-- kind: conda
-  name: wayland-protocols
-  version: '1.37'
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
-  sha256: f6cac1efd4d2a6e30c1671f0566d4e6ac3fe2dc34c9ff7f309bbbc916520ebcf
-  md5: 73ec79a77d31eb7e4a3276cd246b776c
-  depends:
-  - wayland
-  license: MIT
-  license_family: MIT
-  size: 95953
-  timestamp: 1725657284103
 - kind: conda
   name: x264
   version: 1!164.3095
@@ -12080,197 +12557,188 @@ packages:
   timestamp: 1646610147365
 - kind: conda
   name: xcb-util
-  version: 0.4.1
-  build: h5c728e9_2
-  build_number: 2
+  version: 0.4.0
+  build: h31becfc_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
-  sha256: 59f586defd3c1295a32d8eb587036302ab254300d88e605354e8eaa4a27563ec
-  md5: b4cf8ba6cff9cdf1249bcfe1314222b0
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.0-h31becfc_1.conda
+  sha256: 28d5d383128cf869ac7db173c3ae5d37fa15953bf8f836942b59f6f4e3951a94
+  md5: cd63fffc384ebf7ef90c3e03640089d9
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.13
+  - libxcb >=1.15,<1.16.0a0
   license: MIT
   license_family: MIT
-  size: 20597
-  timestamp: 1718844955591
+  size: 21121
+  timestamp: 1684640370585
 - kind: conda
   name: xcb-util
-  version: 0.4.1
-  build: hb711507_2
-  build_number: 2
+  version: 0.4.0
+  build: hd590300_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
-  sha256: 416aa55d946ce4ab173ab338796564893a2f820e80e04e098ff00c25fb981263
-  md5: 8637c3e5821654d0edf97e2b0404b443
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
+  sha256: 0c91d87f0efdaadd4e56a5f024f8aab20ec30f90aa2ce9e4ebea05fbc20f71ad
+  md5: 9bfac7ccd94d54fd21a0501296d60424
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.13
+  - libxcb >=1.15,<1.16.0a0
   license: MIT
   license_family: MIT
-  size: 19965
-  timestamp: 1718843348208
+  size: 19728
+  timestamp: 1684639166048
 - kind: conda
   name: xcb-util-image
   version: 0.4.0
-  build: h5c728e9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
-  sha256: a43058edc001e8fb97f9b291028a6ca16a8969d9b56a998c7aecea083323ac97
-  md5: b82e5c78dbbfa931980e8bfe83bce913
+  build: h8ee46fc_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
+  sha256: 92ffd68d2801dbc27afe223e04ae7e78ef605fc8575f107113c93c7bafbd15b0
+  md5: 9d7bcddf49cbf727730af10e71022c73
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
   license: MIT
   license_family: MIT
-  size: 24910
-  timestamp: 1718880504308
+  size: 24474
+  timestamp: 1684679894554
 - kind: conda
   name: xcb-util-image
   version: 0.4.0
-  build: hb711507_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
-  sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
-  md5: a0901183f08b6c7107aab109733a3c91
+  build: hcb25cf1_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-hcb25cf1_1.conda
+  sha256: 94f546f2d8f5053bd21ccc656be364cfa5b1b8736f95befecadda4343a55b871
+  md5: 395256583f9ba09af83bd2875e2dd43e
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
   license: MIT
   license_family: MIT
-  size: 24551
-  timestamp: 1718880534789
+  size: 24820
+  timestamp: 1684680024607
 - kind: conda
   name: xcb-util-keysyms
-  version: 0.4.1
-  build: h5c728e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
-  sha256: 9d92daa7feb0e14f81bf0d4b3f0b6ff1e8cec3ff514df8a0c06c4d49b518c315
-  md5: 57ca8564599ddf8b633c4ea6afee6f3a
+  version: 0.4.0
+  build: h8ee46fc_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
+  sha256: 8451d92f25d6054a941b962179180728c48c62aab5bf20ac10fef713d5da6a9a
+  md5: 632413adcd8bc16b515cab87a2932913
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.15,<1.16.0a0
   license: MIT
   license_family: MIT
-  size: 14343
-  timestamp: 1718846624153
+  size: 14186
+  timestamp: 1684680497805
 - kind: conda
   name: xcb-util-keysyms
+  version: 0.4.0
+  build: hcb25cf1_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.0-hcb25cf1_1.conda
+  sha256: a6d14beea8c0fca033a375a3ac3059d909bdf3e19d9e0c683358b34247b7f6f7
+  md5: befa651eadbd51987c8ebc462497a8ff
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 14261
+  timestamp: 1684680602585
+- kind: conda
+  name: xcb-util-renderutil
+  version: 0.3.9
+  build: h31becfc_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.9-h31becfc_1.conda
+  sha256: 037a9be6da2afed4fdbfcfb0ea13a60c1d80a025b023e879c89f3fe572571b4c
+  md5: 15c02e09b3441d567b83199173abc1f9
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.13
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 18016
+  timestamp: 1684640014593
+- kind: conda
+  name: xcb-util-renderutil
+  version: 0.3.9
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
+  sha256: 6987588e6fff5892056021c2ea52f7a0deefb2c7348e70d24750e2d60dabf009
+  md5: e995b155d938b6779da6ace6c6b13816
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.13
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 16955
+  timestamp: 1684639112393
+- kind: conda
+  name: xcb-util-wm
   version: 0.4.1
-  build: hb711507_0
+  build: h8ee46fc_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
-  sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
-  md5: ad748ccca349aec3e91743e08b5e2b50
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
+  sha256: 08ba7147c7579249b6efd33397dc1a8c2404278053165aaecd39280fee705724
+  md5: 90108a432fb5c6150ccfee3f03388656
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.15,<1.16.0a0
   license: MIT
   license_family: MIT
-  size: 14314
-  timestamp: 1718846569232
-- kind: conda
-  name: xcb-util-renderutil
-  version: 0.3.10
-  build: h5c728e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
-  sha256: 5827f5617c9741599f72bb7f090726f89c6ef91e4bada621895fdc2bbadfb0f1
-  md5: 7beeda4223c5484ef72d89fb66b7e8c1
-  depends:
-  - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 18139
-  timestamp: 1718849914457
-- kind: conda
-  name: xcb-util-renderutil
-  version: 0.3.10
-  build: hb711507_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
-  sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
-  md5: 0e0cbe0564d03a99afd5fd7b362feecd
-  depends:
-  - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 16978
-  timestamp: 1718848865819
+  size: 52114
+  timestamp: 1684679248466
 - kind: conda
   name: xcb-util-wm
-  version: 0.4.2
-  build: h5c728e9_0
+  version: 0.4.1
+  build: hcb25cf1_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-  sha256: 3f52cd8783e7d953c54266255fd11886c611c2620545eabc28ec8cf470ae8be7
-  md5: f14dcda6894722e421da2b7dcffb0b78
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.1-hcb25cf1_1.conda
+  sha256: 19e4883076c87f998cf3bef532d6e731208f0ef4d65414cde32d7454eb2d1890
+  md5: 615e8be7baf44b5205f8a4f5908f57f7
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.15,<1.16.0a0
   license: MIT
   license_family: MIT
-  size: 50772
-  timestamp: 1718845072660
-- kind: conda
-  name: xcb-util-wm
-  version: 0.4.2
-  build: hb711507_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-  sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
-  md5: 608e0ef8256b81d04456e8d211eee3e8
-  depends:
-  - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 51689
-  timestamp: 1718844051451
+  size: 49952
+  timestamp: 1684680157286
 - kind: conda
   name: xerces-c
   version: 3.2.5
-  build: h595f43b_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xerces-c-3.2.5-h595f43b_2.conda
-  sha256: 5be18356d3b28cef354ba53880fe13bf92022022566f602a0b89fe5ad98be485
-  md5: d0f7b92f36560299e293569278223e2b
-  depends:
-  - icu >=75.1,<76.0a0
-  - libgcc >=13
-  - libnsl >=2.0.1,<2.1.0a0
-  - libstdcxx >=13
-  license: Apache-2.0
-  license_family: Apache
-  size: 1639500
-  timestamp: 1727734160362
-- kind: conda
-  name: xerces-c
-  version: 3.2.5
-  build: h988505b_2
-  build_number: 2
+  build: hac6953d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
-  sha256: 339ab0ff05170a295e59133cd0fa9a9c4ba32b6941c8a2a73484cc13f81e248a
-  md5: 9dda9667feba914e0e80b95b82f7402b
+  url: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-hac6953d_0.conda
+  sha256: 75d06ca406f03f653d7a3183f2a1ccfdb3a3c6c830493933ec4c3c98e06a32bb
+  md5: 63b80ca78d29380fe69e69412dcbe4ac
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=13
+  - icu >=73.2,<74.0a0
+  - libcurl >=8.5.0,<9.0a0
+  - libgcc-ng >=12
   - libnsl >=2.0.1,<2.1.0a0
-  - libstdcxx >=13
+  - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: Apache
-  size: 1648243
-  timestamp: 1727733890754
+  size: 1636164
+  timestamp: 1703092965257
 - kind: conda
   name: xerces-c
   version: 3.2.5
@@ -12289,6 +12757,39 @@ packages:
   size: 3574017
   timestamp: 1727734520239
 - kind: conda
+  name: xerces-c
+  version: 3.2.5
+  build: hf13c1fb_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xerces-c-3.2.5-hf13c1fb_0.conda
+  sha256: 6e64e9dc8d9f8bee4bdef16e946be658da3744e40fdd5ca881ac2219a1aba479
+  md5: 5c6a84e179f9fc7f8e0890c28704a8ce
+  depends:
+  - icu >=73.2,<74.0a0
+  - libcurl >=8.5.0,<9.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 1632056
+  timestamp: 1703093218725
+- kind: conda
+  name: xkeyboard-config
+  version: '2.42'
+  build: h4ab18f5_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.42-h4ab18f5_0.conda
+  sha256: 240caab7d9d85154ef373ecbac3ff9fb424add2029dbb124e949c6cbab2996dd
+  md5: b193af204da1bfb8c13882d131a14bd2
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 388998
+  timestamp: 1717817668629
+- kind: conda
   name: xkeyboard-config
   version: '2.43'
   build: h86ecc28_0
@@ -12304,21 +12805,53 @@ packages:
   size: 391011
   timestamp: 1727840308426
 - kind: conda
-  name: xkeyboard-config
-  version: '2.43'
-  build: hb9d3cd8_0
+  name: xorg-fixesproto
+  version: '5.0'
+  build: hb9d3cd8_1003
+  build_number: 1003
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
-  sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
-  md5: f725c7425d6d7c15e31f3b99a88ea02f
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-hb9d3cd8_1003.conda
+  sha256: 07268980b659a84a4bac64b475329348e9cf5fa4aee255fa94aa0407ae5b804c
+  md5: 19fe37721037acc0a1ed76b8cf937359
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
   license: MIT
   license_family: MIT
-  size: 389475
-  timestamp: 1727840188958
+  size: 11311
+  timestamp: 1727033761080
+- kind: conda
+  name: xorg-kbproto
+  version: 1.0.7
+  build: h57736b2_1003
+  build_number: 1003
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h57736b2_1003.conda
+  sha256: f4118db498f8333e88952da920fd1a90a4a7ccb979085f5a6fdac0d64e46d450
+  md5: 034897696bebad405b3f01580af14c7e
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 30365
+  timestamp: 1726847878179
+- kind: conda
+  name: xorg-kbproto
+  version: 1.0.7
+  build: hb9d3cd8_1003
+  build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-hb9d3cd8_1003.conda
+  sha256: 849555ddf7fee334a5a6be9f159d2931c9d076ffb310a9e75b9124f789049d3e
+  md5: e87bfacb110d85e1eb6099c9ed8e7236
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 30242
+  timestamp: 1726846706299
 - kind: conda
   name: xorg-libice
   version: 1.1.1
@@ -12388,37 +12921,39 @@ packages:
 - kind: conda
   name: xorg-libx11
   version: 1.8.9
-  build: he755bbd_2
-  build_number: 2
+  build: h055a233_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
-  sha256: bcd9ebdd7ca25d8ab1eb4f3f919113e264a8ad84fa713c48e737e9167a82fb4b
-  md5: 7acc45f80415e6ec352b729105dc0375
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-h055a233_0.conda
+  sha256: fe6adc8f0ab7ea026b8ccd5c8c8843e5a01f49bcd193eacec9af1626f0db1194
+  md5: d5f0529d3568a2ce38a9aed44a9a8029
   depends:
-  - libgcc >=13
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
   license: MIT
   license_family: MIT
-  size: 863528
-  timestamp: 1727352755656
+  size: 851567
+  timestamp: 1712415736293
 - kind: conda
   name: xorg-libx11
-  version: 1.8.10
-  build: h4f16b4b_0
+  version: 1.8.9
+  build: h8ee46fc_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
-  sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
-  md5: 0b666058a179b744a622d0a4a0c56353
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
+  sha256: 3e53ba247f1ad68353f18aceba5bf8ce87e3dea930de85d36946844a7658c9fb
+  md5: 077b6e8ad6a3ddb741fce2496dd01bec
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
   license: MIT
   license_family: MIT
-  size: 838308
-  timestamp: 1727356837875
+  size: 828060
+  timestamp: 1712415742569
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
@@ -12452,6 +12987,26 @@ packages:
   timestamp: 1727034741045
 - kind: conda
   name: xorg-libxaw
+  version: 1.0.14
+  build: h7f98852_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.14-h7f98852_1.tar.bz2
+  sha256: e3d90674a3178999b664a1c7c8ec8729ada60d144a2aa16da474488dfc86d713
+  md5: 45b68dc2fc7549c16044d533ceaf340e
+  depends:
+  - libgcc-ng >=9.4.0
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-libxext 1.3.*
+  - xorg-libxmu 1.1.*
+  - xorg-libxpm >=3.5.13,<4.0a0
+  - xorg-libxt >=1.2.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 382060
+  timestamp: 1641502851233
+- kind: conda
+  name: xorg-libxaw
   version: 1.0.16
   build: h86ecc28_0
   subdir: linux-aarch64
@@ -12469,61 +13024,6 @@ packages:
   license_family: MIT
   size: 331138
   timestamp: 1727870334121
-- kind: conda
-  name: xorg-libxaw
-  version: 1.0.16
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
-  sha256: 105ff923b60286188978d7b3aa159b555e2baf4c736801f62602d4127159f06d
-  md5: 7c0a9bf62d573409d12ad14b362a96e5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxmu >=1.2.1,<2.0a0
-  - xorg-libxpm >=3.5.17,<4.0a0
-  - xorg-libxt >=1.3.0,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 307032
-  timestamp: 1727870272246
-- kind: conda
-  name: xorg-libxdamage
-  version: 1.1.6
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
-  sha256: 3afaa2f43eb4cb679fc0c3d9d7c50f0f2c80cc5d3df01d5d5fd60655d0bfa9be
-  md5: d5773c4e4d64428d7ddaa01f6f845dc7
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  license: MIT
-  license_family: MIT
-  size: 13794
-  timestamp: 1727891406431
-- kind: conda
-  name: xorg-libxdamage
-  version: 1.1.6
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
-  sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
-  md5: b5fcc7172d22516e1f965490e65e33a4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  license: MIT
-  license_family: MIT
-  size: 13217
-  timestamp: 1727891438799
 - kind: conda
   name: xorg-libxdmcp
   version: 1.1.5
@@ -12555,6 +13055,23 @@ packages:
   timestamp: 1727794976192
 - kind: conda
   name: xorg-libxext
+  version: 1.3.4
+  build: h0b41bf4_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+  sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+  md5: 82b6df12252e6f32402b96dacc656fec
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 50143
+  timestamp: 1677036907815
+- kind: conda
+  name: xorg-libxext
   version: 1.3.6
   build: h57736b2_0
   subdir: linux-aarch64
@@ -12569,21 +13086,22 @@ packages:
   size: 50746
   timestamp: 1727754268156
 - kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: hb9d3cd8_0
+  name: xorg-libxfixes
+  version: 5.0.3
+  build: h7f98852_1004
+  build_number: 1004
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
-  sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
-  md5: febbab7d15033c913d53c7a2c102309d
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
+  sha256: 1e426a1abb774ef1dcf741945ed5c42ad12ea2dc7aeed7682d293879c3e1e4c3
+  md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
+  - libgcc-ng >=9.3.0
+  - xorg-fixesproto
+  - xorg-libx11 >=1.7.0,<2.0a0
   license: MIT
   license_family: MIT
-  size: 50060
-  timestamp: 1727752228921
+  size: 18145
+  timestamp: 1617717802636
 - kind: conda
   name: xorg-libxfixes
   version: 6.0.1
@@ -12600,21 +13118,24 @@ packages:
   size: 20289
   timestamp: 1727796500830
 - kind: conda
-  name: xorg-libxfixes
-  version: 6.0.1
-  build: hb9d3cd8_0
+  name: xorg-libxmu
+  version: 1.1.3
+  build: h4ab18f5_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
-  sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
-  md5: 4bdb303603e9821baf5fe5fdff1dc8f8
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.1.3-h4ab18f5_1.conda
+  sha256: a34986d71949ba714b27080c8ebb4932857f6e2ebd6383fbb1639415b30f4fd0
+  md5: 4d6c9925cdcda27e9d022e40eb3eac05
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext 1.3.*
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
   license: MIT
   license_family: MIT
-  size: 19575
-  timestamp: 1727794961233
+  size: 89113
+  timestamp: 1714742286287
 - kind: conda
   name: xorg-libxmu
   version: 1.2.1
@@ -12633,25 +13154,6 @@ packages:
   license_family: MIT
   size: 92167
   timestamp: 1727965913339
-- kind: conda
-  name: xorg-libxmu
-  version: 1.2.1
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.2.1-hb9d3cd8_1.conda
-  sha256: 467cba5106e628068487dcbc2ba2dbd6a434e75d752eaf0895086e9fe65e6a8d
-  md5: f35a9a2da717ade815ffa70c0e8bdfbd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxt >=1.3.0,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 89078
-  timestamp: 1727965853556
 - kind: conda
   name: xorg-libxpm
   version: 3.5.17
@@ -12676,25 +13178,44 @@ packages:
 - kind: conda
   name: xorg-libxpm
   version: 3.5.17
-  build: hb9d3cd8_1
-  build_number: 1
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
-  sha256: 8ce7ae21dcbbb759c6fb9e5ad2a2f2f4e54172adf160ea59e11712598edbb75c
-  md5: f35bec7fface97f67f44ca952fc740b7
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hd590300_0.conda
+  sha256: f6b6cfe2b11bf5c50f7cc21a51a279f74d9f1135e91caba22e791ecc4f31fac0
+  md5: 12bf78e12f71405775e1c092902959d3
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - gettext
-  - libasprintf >=0.22.5,<1.0a0
-  - libgcc >=13
-  - libgettextpo >=0.22.5,<1.0a0
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxt >=1.3.0,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
   license: MIT
   license_family: MIT
-  size: 64764
-  timestamp: 1727801210327
+  size: 64324
+  timestamp: 1696449073283
+- kind: conda
+  name: xorg-libxrandr
+  version: 1.5.2
+  build: h7f98852_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-h7f98852_1.tar.bz2
+  sha256: ffd075a463896ed86d9519e26dc36f754b695b9c1e1b6115d34fe138b36d8200
+  md5: 5b0f7da25a4556c9619c3e4b4a98ab07
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-libx11 >=1.7.1,<2.0a0
+  - xorg-libxext
+  - xorg-libxrender
+  - xorg-randrproto
+  - xorg-renderproto
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 29688
+  timestamp: 1621515728586
 - kind: conda
   name: xorg-libxrandr
   version: 1.5.4
@@ -12712,24 +13233,6 @@ packages:
   license_family: MIT
   size: 30197
   timestamp: 1727794957221
-- kind: conda
-  name: xorg-libxrandr
-  version: 1.5.4
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
-  sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
-  md5: 2de7f99d6581a4a7adbff607b5c278ca
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  license: MIT
-  license_family: MIT
-  size: 29599
-  timestamp: 1727794874300
 - kind: conda
   name: xorg-libxrender
   version: 0.9.11
@@ -12750,21 +13253,19 @@ packages:
 - kind: conda
   name: xorg-libxrender
   version: 0.9.11
-  build: hb9d3cd8_1
-  build_number: 1
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
-  sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
-  md5: a7a49a8b85122b49214798321e2e96b4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+  sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
+  md5: ed67c36f215b310412b2af935bf3e530
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-xorgproto
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-renderproto
   license: MIT
   license_family: MIT
-  size: 37780
-  timestamp: 1727529943015
+  size: 37770
+  timestamp: 1688300707994
 - kind: conda
   name: xorg-libxt
   version: 1.3.0
@@ -12786,57 +13287,55 @@ packages:
 - kind: conda
   name: xorg-libxt
   version: 1.3.0
-  build: hb9d3cd8_2
-  build_number: 2
+  build: hd590300_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.0-hb9d3cd8_2.conda
-  sha256: da032ee35fa329af7b551917764d2e161f8af2f7fdbb4c3e4a0fab47f3d968a0
-  md5: d8602724ac0d276c380b97e9eb0f814b
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.0-hd590300_1.conda
+  sha256: e7648d1efe2e858c4bc63ccf4a637c841dc971b37ded85a01be97a5e240fecfa
+  md5: ae92aab42726eb29d16488924f7312cb
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc-ng >=12
+  - xorg-kbproto
   - xorg-libice >=1.1.1,<2.0a0
   - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-xproto
   license: MIT
   license_family: MIT
-  size: 378681
-  timestamp: 1727663260353
+  size: 379256
+  timestamp: 1690288540492
 - kind: conda
-  name: xorg-libxxf86vm
-  version: 1.1.5
-  build: h57736b2_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
-  sha256: db7455e84e3427e800e4830296247e8a465a13f2cd0b389415a5aec989f5fab0
-  md5: 82fa1f5642ef7ac7172e295327ce20e2
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 18392
-  timestamp: 1728920054223
-- kind: conda
-  name: xorg-libxxf86vm
-  version: 1.1.5
-  build: hb9d3cd8_4
-  build_number: 4
+  name: xorg-randrproto
+  version: 1.5.0
+  build: hb9d3cd8_1002
+  build_number: 1002
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
-  sha256: 0b8f062a5b4a2c3833267285b7d41b3542f54d2c935c86ca98504c3e5296354c
-  md5: 7da9007c0582712c4bad4131f89c8372
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-randrproto-1.5.0-hb9d3cd8_1002.conda
+  sha256: d742ac2970c05abb597dacccd411af0d5b7a280b0b3390c4f681022edf4541a2
+  md5: b9485267c7eb6b8601b378e06a9e44d3
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
-  size: 18072
-  timestamp: 1728920051869
+  size: 35658
+  timestamp: 1726801844143
+- kind: conda
+  name: xorg-renderproto
+  version: 0.11.1
+  build: hb9d3cd8_1003
+  build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-hb9d3cd8_1003.conda
+  sha256: 54dd934b0e1c942e54759eb13672fd59b7e523fabea6e69a32d5bf483e45b329
+  md5: bf90782559bce8447609933a7d45995a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 11867
+  timestamp: 1726802820431
 - kind: conda
   name: xorg-xextproto
   version: 7.3.0
@@ -12915,21 +13414,36 @@ packages:
   size: 566948
   timestamp: 1726847598167
 - kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: hb9d3cd8_1
-  build_number: 1
+  name: xorg-xproto
+  version: 7.0.31
+  build: h57736b2_1008
+  build_number: 1008
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
+  sha256: 3415c89f81a03c26c0f2327c6d9b34a77de2e584d88a9157a5fd940f8cae0292
+  md5: 3dd2b75fd06be7955bd3b0c0afa4fb8f
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 73800
+  timestamp: 1726845752367
+- kind: conda
+  name: xorg-xproto
+  version: 7.0.31
+  build: hb9d3cd8_1008
+  build_number: 1008
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
-  sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
-  md5: 7c21106b851ec72c037b162c216d8f05
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-hb9d3cd8_1008.conda
+  sha256: ea02425c898d6694167952794e9a865e02e14e9c844efb067374f90b9ce8ce33
+  md5: a63f5b66876bb1ec734ab4bdc4d11e86
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 565425
-  timestamp: 1726846388217
+  size: 73315
+  timestamp: 1726845753874
 - kind: conda
   name: xz
   version: 5.2.6
@@ -13018,60 +13532,55 @@ packages:
   timestamp: 1641347626613
 - kind: conda
   name: zeromq
-  version: 4.3.5
-  build: h3b0a872_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_6.conda
-  sha256: e67288b1c98a31ee58a5c07bdd873dbe08e75f752e1ad605d5e8c0697339903e
-  md5: 113506c8d2d558e733f5c38f6bf08c50
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - libsodium >=1.0.20,<1.0.21.0a0
-  - libstdcxx >=13
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 335528
-  timestamp: 1728364029042
-- kind: conda
-  name: zeromq
-  version: 4.3.5
-  build: h5efb499_6
-  build_number: 6
+  version: 4.3.4
+  build: h01db608_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zeromq-4.3.5-h5efb499_6.conda
-  sha256: 7cf61f742757ebb8773c5c96a9d768e06a288a0b9bd95ba212dccd17fae25abb
-  md5: c395b75ab44b4f82e5531de2cf9d20ba
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zeromq-4.3.4-h01db608_1.tar.bz2
+  sha256: 8da3cf93c15f43aeb6c598d97eeaad79b83f718317813918769f7b837787929f
+  md5: dd56c9ce3f1f689a5e71941830349279
   depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - libsodium >=1.0.20,<1.0.21.0a0
-  - libstdcxx >=13
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 371083
-  timestamp: 1728368602099
+  - libgcc-ng >=9.4.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=9.4.0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 388994
+  timestamp: 1629969958941
 - kind: conda
   name: zeromq
-  version: 4.3.5
-  build: ha9f60a1_6
-  build_number: 6
+  version: 4.3.4
+  build: h0e60522_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_6.conda
-  sha256: c37130692742cc43eedf4e23270c7d1634235acff50760025e9583f8b46b64e6
-  md5: 33a78bbc44d6550c361abb058a0556e2
+  url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.4-h0e60522_1.tar.bz2
+  sha256: 0489cc6c3bff50620879890431d7142fd6e66b7770ddc6f2d7852094471c0d6c
+  md5: e1aff0583dda5fb917eb3d2c1025aa80
   depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libsodium >=1.0.20,<1.0.21.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 2701749
-  timestamp: 1728364260886
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 9355377
+  timestamp: 1629968018045
+- kind: conda
+  name: zeromq
+  version: 4.3.4
+  build: h9c3ff4c_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.4-h9c3ff4c_1.tar.bz2
+  sha256: 525315b0df21866d4c3d68bc2ff987d26c2fdf0e3e8fd242c49b7255adef04c6
+  md5: 21743a8d2ea0c8cfbbf8fe489b0347df
+  depends:
+  - libgcc-ng >=9.4.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=9.4.0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 359709
+  timestamp: 1629967303309
 - kind: conda
   name: zipp
   version: 3.21.0
@@ -13089,55 +13598,54 @@ packages:
   timestamp: 1731262194278
 - kind: conda
   name: zlib
-  version: 1.3.1
-  build: h2466b09_2
-  build_number: 2
+  version: 1.2.13
+  build: h2466b09_6
+  build_number: 6
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
-  sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
-  md5: be60c4e8efa55fddc17b4131aa47acbd
+  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-h2466b09_6.conda
+  sha256: 7aebf311fdb9227deddaedc33ace85bc960f5116ffb31f3ff07db380dfca0b41
+  md5: 86591a585a18e35d23279b6b384eb4b9
   depends:
-  - libzlib 1.3.1 h2466b09_2
+  - libzlib 1.2.13 h2466b09_6
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Zlib
   license_family: Other
-  size: 107439
-  timestamp: 1727963788936
+  size: 107894
+  timestamp: 1716874644593
 - kind: conda
   name: zlib
-  version: 1.3.1
-  build: h86ecc28_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
-  sha256: b4f649aa3ecdae384d5dad7074e198bff120edd3dfb816588e31738fc6d627b1
-  md5: bc230abb5d21b63ff4799b0e75204783
-  depends:
-  - libgcc >=13
-  - libzlib 1.3.1 h86ecc28_2
-  license: Zlib
-  license_family: Other
-  size: 95582
-  timestamp: 1727963203597
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
+  version: 1.2.13
+  build: h4ab18f5_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
-  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
-  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4ab18f5_6.conda
+  sha256: 534824ea44939f3e59ca8ebb95e3ece6f50f9d2a0e69999fbc692311252ed6ac
+  md5: 559d338a4234c2ad6e676f460a093e67
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib 1.3.1 hb9d3cd8_2
+  - libgcc-ng >=12
+  - libzlib 1.2.13 h4ab18f5_6
   license: Zlib
   license_family: Other
-  size: 92286
-  timestamp: 1727963153079
+  size: 92883
+  timestamp: 1716874088980
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: h68df207_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h68df207_6.conda
+  sha256: 67d2e05bb76308ad2e6d8bd27d54e5f8d866d7900826a13f22b66ecacce02fed
+  md5: 11012f81be8e7dae8495df7ec17c0cc5
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 h68df207_6
+  license: Zlib
+  license_family: Other
+  size: 95937
+  timestamp: 1716874085408
 - kind: conda
   name: zstd
   version: 1.5.6
@@ -13190,47 +13698,49 @@ packages:
 - kind: conda
   name: zziplib
   version: 0.13.69
-  build: h3ca93ac_2
-  build_number: 2
+  build: h1d00b33_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zziplib-0.13.69-h3ca93ac_2.conda
-  sha256: e079aca99369f7a2a6a402a0256dad065cfaf17cd9ede1b03118ca5f38c6711d
-  md5: c79eee98990e5986d5d8bd02cf5a2a5e
+  url: https://conda.anaconda.org/conda-forge/win-64/zziplib-0.13.69-h1d00b33_1.tar.bz2
+  sha256: 6879abfeec82276d81ef8fd35d80d91277294d15a9e5febb6a8c67cd9a08514a
+  md5: 1dfec5d4f9c16420164d55c539b5a8a6
   depends:
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.0-or-later OR MPL-1.1
-  size: 65791
-  timestamp: 1719242575938
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  - zlib >=1.2.11,<1.3.0a0
+  license: GPL-2.0
+  license_family: GPL
+  size: 52361
+  timestamp: 1617437822964
 - kind: conda
   name: zziplib
   version: 0.13.69
-  build: h650d8d0_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
-  sha256: 9e3764d1fb2b509bc43ebb059a5bb77ba11af56bb78a5960e1ba8a21aa1939a6
-  md5: 133bf2541e6bc4f7bb7c4e0546776138
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.0-or-later OR MPL-1.1
-  size: 115725
-  timestamp: 1719242037690
-- kind: conda
-  name: zziplib
-  version: 0.13.69
-  build: he45264a_2
-  build_number: 2
+  build: h27826a3_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
-  sha256: a7c3ba25f384c7eb30c4f4c2d390f62714e0b4946d315aa852749f927b4b03ff
-  md5: 6d2d107e0fb8bc381acd4e9c68dbeae7
+  url: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-h27826a3_1.tar.bz2
+  sha256: 8ce40952fce6bb50ec74afda2f30f384ad9666add5b8a0f88927c6c2407f27f1
+  md5: d0646083f3cb1ef27049538b8043ab15
   depends:
-  - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.0-or-later OR MPL-1.1
-  size: 106915
-  timestamp: 1719242059793
+  - libgcc-ng >=9.3.0
+  - zlib >=1.2.11,<1.3.0a0
+  license: GPL-2.0
+  license_family: GPL
+  size: 99102
+  timestamp: 1617437120421
+- kind: conda
+  name: zziplib
+  version: 0.13.69
+  build: hd8af866_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-hd8af866_1.tar.bz2
+  sha256: b88439eb108b92bdc32ef9f7f8d28a9543eeaa8fe47a3e0a2f3991344201296f
+  md5: f1b99856ad0d917f8b57b8ed8d2383cd
+  depends:
+  - libgcc-ng >=9.3.0
+  - zlib >=1.2.11,<1.3.0a0
+  license: GPL-2.0
+  license_family: GPL
+  size: 106910
+  timestamp: 1617437032572

--- a/conda/envs/legacy/pixi.toml
+++ b/conda/envs/legacy/pixi.toml
@@ -8,14 +8,14 @@ platforms = ["linux-64", "linux-aarch64", "win-64"]
 
 [dependencies]
 assimp = "*"
-bullet-cpp = "*"
+bullet-cpp = "3.25"  # compatible with dart
 cppzmq = "*"
 curl = "*"
 dartsim = "6.13.2.*"
-eigen = "*"
+eigen = "3.4.0"
 ffmpeg = "*"
 freeimage = "*"
-gdal = "*"
+gdal = "3.8.0"  # compatible with dartsim on icu versions
 gflags = "*"
 glib = "*"
 gts = "*"
@@ -26,18 +26,19 @@ libzip = "*"
 ogre = "1.10.12.1.*"
 ogre-next = "2.2.*"
 openssl = "*"
-protobuf = "*"
+protobuf = "3.14.0.*"  # closest with py3.9 ABI to jammy 3.12
 pybind11 = "*"
 python = "3.9.*"
-qt-main = "*"
+qt-main = "5.15.8"  # closets compatible with cmake using krb versions
 qwt = "*"
 ruby = "3.2.*"
 tinyxml2 = "*"
 yaml = "*"
-zeromq = "*"
+zeromq = "4.3.4"
 
 [target.win-64.dependencies]
 dlfcn-win32 = "*"
+vs2019_win-64 = "*"
 
 [target.linux-64.dependencies]
 libglu = "*"


### PR DESCRIPTION
To reduce the number of changes brought by `pixi update` on each iteration, I'm setting some of the versions in pixi.toml for part of the relevant software.

While testing this, I noticed that the we can declare which msvc compiler to use via toml configuration (that previously was included as a dependency by one of versions used by the explicit set of dependencies in this toml file). I'm declaring it explicitly here until we decide in we want to use compilers this way or use the system installed ones.