### PR TITLE
Windows colcon: relocate Fortress workaround for ignition names

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -138,7 +138,7 @@ if "%ENABLE_TESTS%" == "TRUE" (
     echo # BEGIN SECTION: export testing results
     if exist %EXPORT_TEST_RESULT_PATH% ( rmdir /q /s %EXPORT_TEST_RESULT_PATH% )
     mkdir %EXPORT_TEST_RESULT_PATH%
-    xcopy %TEST_RESULT_PATH% %EXPORT_TEST_RESULT_PATH% /s /i /e || goto :error
+    xcopy !TEST_RESULT_PATH! %EXPORT_TEST_RESULT_PATH% /s /i /e || goto :error^M
     echo # END SECTION
 )
 


### PR DESCRIPTION
Preparing to execute conda enviroments, the existing colcon script does use of colcon as if it was installed in the system. While this is true in the current provisioning, for conda we use colcon declared in the toml file what also facilitates the use of it locally.

The PR relocates the code that helps with the existing `ignition` names (Gz Fortress) into a section after the dependencies/environment files are installed. 

Testing it here [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-pr-win&build=1042)](https://build.osrfoundation.org/job/gz_sim-pr-win/1042/)