### PR TITLE
Replace osrf-migration token by osrfbuild-token in bottle_job_builder

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -135,7 +135,7 @@ bottle_job_builder.with
         preBuildCleanup()
         credentialsBinding {
           // crendetial name needs to be in sync with provision code at infra/osrf-chef repo
-          string('GITHUB_TOKEN', 'osrf-migration-token')
+          string('GITHUB_TOKEN', 'osrfbuild-token')
         }
    }
 

--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -83,6 +83,7 @@ brew tap osrf/simulation
 # replace with 'hub -C $(brew --repo osrf/simulation) pr checkout ${ghprbPullId}'
 # after the following hub issue is resolved:
 # https://github.com/github/hub/issues/2612
+# hub requires authentication to operate. GITHUB_TOKEN enviroment variable for example
 pushd $(brew --repo osrf/simulation) && \
   hub pr checkout ${ghprbPullId} && \
   popd


### PR DESCRIPTION
While removing the osrf-migration token I noticed that it is being used in bottle_job_builder for authenticating the `hub` cli . We need it even if there are no push/clone operations involved, otherwise the `hub` cli is asking for credentials.

This PR changes the osrf-migration user to use existing osrfbuild token. 