### PR TITLE
Add OSRFcredentials class and test for DSL

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFCredentials.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFCredentials.groovy
@@ -15,7 +15,7 @@ class OSRFCredentials
             if (credential_keyword == 'OSRFBUILD_GITHUB_TOKEN') {
                 usernamePassword('OSRFBUILD_USER',
                                  'OSRFBUILD_TOKEN',
-                                 'github-osrfbuild-credentials')
+                                 'github-osrfbuild-apitoken')
             } else if (credential_keyword == 'OSRFBUILD_JENKINS_TOKEN') {
                 usernamePassword('OSRFBUILD_JENKINS_USER',
                                  'OSRFBUILD_JENKINS_TOKEN',

--- a/jenkins-scripts/dsl/_configs_/OSRFCredentials.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFCredentials.groovy
@@ -1,0 +1,42 @@
+package _configs_
+
+import javaposse.jobdsl.dsl.Job
+
+class OSRFCredentials
+{
+  static void setOSRFCrendentials(Job job, List crendentials_list)
+  {
+    job.with
+    {
+      wrappers {
+        // Credential name needs to be in sync with provision code at infra/osrf-chef repo
+        credentialsBinding {
+          crendentials_list.each { credential_keyword ->
+            if (credential_keyword == 'OSRFBUILD_GITHUB_TOKEN') {
+                usernamePassword('OSRFBUILD_USER',
+                                 'OSRFBUILD_TOKEN',
+                                 'github-osrfbuild-credentials')
+            } else if (credential_keyword == 'OSRFBUILD_JENKINS_TOKEN') {
+                usernamePassword('OSRFBUILD_JENKINS_USER',
+                                 'OSRFBUILD_JENKINS_TOKEN',
+                                 'jenkins-osrfbuild-apitoken')
+            } else {
+              print ("Credential not support: ${credential_keyword}")
+              exit(1)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  static void allowOsrfbuildToRunTheBuild(Job job)
+  {
+    job.with {
+      authorization {
+        permission('hudson.model.Item.Read', 'osrfbuild')
+        permission('hudson.model.Item.Build', 'osrfbuild')
+      }
+    }
+  }
+}

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -148,11 +148,8 @@ test_credentials_token_job.with
     shell("""\
           #!/bin/bash -xe
 
-          # Check push+commit permissions for osrfbuild by uploading/deleting a
-          # branch. Note that call to the API for permissions require of admin
-          # perms that osrfbuild user does not have. Personal tokens don't
-          # support ssh but https only.
-          
+          # Checking push permissions
+          # See https://github.com/osrf/chef-osrf/issues/282 for restrictions on using new fine-grained tokens
           echo " + Testing OSRFBUILD_GITHUB_TOKEN ability to push into the fork osrfbuild/homebrew-simulation"
           echo "   (out of the test is the ability to create pull requests into osrf/homebrew-simulation)"
           rm -fr homebrew-simulation
@@ -160,7 +157,6 @@ test_credentials_token_job.with
           cd homebrew-simulation
           git config user.name \${OSRFBUILD_USER} --replace-all
           git config user.email "\${OSRFBUILD_USER}@openrobotics.org" --replace-all
-          # Use a credential helper https://git-scm.com/docs/gitfaq#http-credentials-environment
           set +x
           git config url."https://osrfbuild:\${OSRFBUILD_TOKEN}@github.com/osrfbuild/homebrew-simulation.git".InsteadOf https://github.com/osrfbuild/homebrew-simulation.git
           set -x

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -160,7 +160,9 @@ test_credentials_token_job.with
           git config user.name \${OSRFBUILD_USER} --replace-all
           git config user.email "\${OSRFBUILD_USER}@openrobotics.org" --replace-all
           # Use a credential helper https://git-scm.com/docs/gitfaq#http-credentials-environment
-          git config credential.helper '!f() { echo username=\${OSRFBUILD_USER}; echo "password=\${OSRFBUILD_TOKEN}"; };f'
+          set +x
+          git config url."https://osrfbuild:\${OSRFBUILD_TOKEN}@github.com/osrfbuild/homebrew-simulation.git".InsteadOf https://github.com/osrfbuild/homebrew-simulation.git
+          set -x
           git checkout -b _test_job_osrfbuild_
           git commit --allow-empty -m "testing commit"
           # protect token from errors

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -135,8 +135,9 @@ test_credentials_token_job.with
           #!/bin/bash -xe
 
           URL_TO_BUILD="\${JENKINS_URL}/job/\${TEST_JOB_TO_BUILD}/build"
+          
           echo " + Testing OSRFBUILD_JENKINS_TOKEN ability for calling jobs:"
-          echo "   - "\${URL_TO_BUILD}"
+          echo "   - \${URL_TO_BUILD}"
 
           # Warning: using verbose -v will reveal the token
           # If the node permissions are blocking the trigger, be sure of enabling AGENT:BUILD permissions
@@ -163,11 +164,7 @@ test_credentials_token_job.with
           set +x
           git config url."https://osrfbuild:\${OSRFBUILD_TOKEN}@github.com/osrfbuild/homebrew-simulation.git".InsteadOf https://github.com/osrfbuild/homebrew-simulation.git
           set -x
-          git checkout -b _test_job_osrfbuild_
-          git commit --allow-empty -m "testing commit"
-          # protect token from errors
-          git push -u origin _test_job_osrfbuild_ > push_log
-          git push origin --delete _test_job_osrfbuild_ >> push_log
+          GIT_TERMINAL_PROMPT=0 git push -u origin master --dry-run
           """.stripIndent())
     }
 

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -63,7 +63,7 @@ repo_uploader.with
   steps
   {
     copyArtifacts('${PROJECT_NAME_TO_COPY_ARTIFACTS}')
-    {
+   {
       includePatterns("${pkg_sources_dir}/*")
       buildSelector {
         upstreamBuild()
@@ -112,4 +112,87 @@ outdated_job_runner.with
   {
     systemGroovyCommand(readFileFromWorkspace('scripts/jenkins-scripts/tools/outdated-job-runner.groovy'))
   }
+}
+
+// --------------------------------------------------------------------
+def test_credentials_token_job = job("_test_job_osrfbuild-credentials-token_from_dsl")
+OSRFBase.create(test_credentials_token_job)
+OSRFCredentials.setOSRFCrendentials(test_credentials_token_job,
+                                    ['OSRFBUILD_GITHUB_TOKEN', 'OSRFBUILD_JENKINS_TOKEN'])
+test_credentials_token_job.with
+{
+  label "docker"
+
+  parameters
+  {
+    stringParam('TEST_JOB_TO_BUILD',
+                '_test_dummy_callable',
+                'Name of the job to build for checking server crendentials')
+  }
+
+  steps {
+    shell("""\
+          #!/bin/bash -xe
+
+          URL_TO_BUILD="\${JENKINS_URL}/job/\${TEST_JOB_TO_BUILD}/build"
+          echo " + Testing OSRFBUILD_JENKINS_TOKEN ability for calling jobs:"
+          echo "   - "\${URL_TO_BUILD}"
+
+          # Warning: using verbose -v will reveal the token
+          # If the node permissions are blocking the trigger, be sure of enabling AGENT:BUILD permissions
+          # for OSRFBUILD_JENKINS_USER at Global security.
+          curl -X POST --silent --fail --write '\\nReturn code: %{http_code}\\n' --user "\${OSRFBUILD_JENKINS_USER}:\${OSRFBUILD_JENKINS_TOKEN}" \${URL_TO_BUILD} --output /dev/null
+          """.stripIndent())
+
+    shell("""\
+          #!/bin/bash -xe
+
+          # Check push+commit permissions for osrfbuild by uploading/deleting a
+          # branch. Note that call to the API for permissions require of admin
+          # perms that osrfbuild user does not have. Personal tokens don't
+          # support ssh but https only.
+          
+          echo " + Testing OSRFBUILD_GITHUB_TOKEN ability to push into the fork osrfbuild/homebrew-simulation"
+          echo "   (out of the test is the ability to create pull requests into osrf/homebrew-simulation)"
+          rm -fr homebrew-simulation
+          git clone https://github.com/\${OSRFBUILD_USER}/homebrew-simulation.git
+          cd homebrew-simulation
+          git config user.name \${OSRFBUILD_USER} --replace-all
+          git config user.email "\${OSRFBUILD_USER}@openrobotics.org" --replace-all
+          # Use a credential helper https://git-scm.com/docs/gitfaq#http-credentials-environment
+          git config credential.helper '!f() { echo username=\${OSRFBUILD_USER}; echo "password=\${OSRFBUILD_TOKEN}"; };f'
+          git checkout -b _test_job_osrfbuild_
+          git commit --allow-empty -m "testing commit"
+          # protect token from errors
+          git push -u origin _test_job_osrfbuild_ > push_log
+          git push origin --delete _test_job_osrfbuild_ >> push_log
+          """.stripIndent())
+    }
+
+    publishers
+    {
+      postBuildScripts {
+        steps {
+          shell("""\
+                #!/bin/bash -xe
+
+                # remove config after the build ends unconditionally to avoid token leaks
+                rm -fr \${WORKSPACE}/homebrew-simulation/.git/config
+                """.stripIndent())
+        }
+
+        onlyIfBuildSucceeds(false)
+        onlyIfBuildFails(false)
+      }
+    }
+
+    wrappers {
+      preBuildCleanup()
+    }
+}
+
+def test_dummy_job = job("_test_dummy_callable")
+OSRFCredentials.allowOsrfbuildToRunTheBuild(test_dummy_job)
+test_dummy_job.with {
+  label Globals.nontest_label("docker")
 }


### PR DESCRIPTION
This PR replaces the `test.dsl` in #1206 and checks the two main token that are going to be used for the `osrfbuild` user as discussed in https://github.com/gazebo-tooling/release-tools/pull/1206#issuecomment-2483688025:

 * OSRFBUILD_GITHUB_TOKEN: for git operations and pull requests
 * OSRFBUILD_JENKINS_TOKEN: for authenticate into the server
 
The credential class also has an `allowOsrfbuildToRunTheBuild` that can restrict which projects can be build by the `osrfbuild` user when making remote calls.

Operations needs to be done in production:
 * Generate a new `OSRFBUILD_JENKINS_TOKEN` for the `osrfbuild` user with the id of `
 * Change the type of the `OSRFBUILD_GITHUB_TOKEN` or generate a new one and set it up as a `usernamePassword` with the ID `github-osrfbuild-credentials`