### PR TITLE
Remove filesystem token for Brew. Use crendential plugin

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -62,7 +62,11 @@ release_job.with
    label Globals.nontest_label("master")
 
    wrappers {
-        preBuildCleanup()
+     preBuildCleanup()
+     credentialsBinding {
+       // crendetial name needs to be in sync with provision code at infra/osrf-chef repo
+       string('GITHUB_TOKEN', 'osrfbuild-token')
+     }
    }
 
    parameters
@@ -253,6 +257,10 @@ bottle_job_hash_updater.with
   wrappers
   {
     preBuildCleanup()
+    credentialsBinding {
+      // crendetial name needs to be in sync with provision code at infra/osrf-chef repo
+      string('GITHUB_TOKEN', 'osrfbuild-token')
+    }
   }
 
   parameters

--- a/jenkins-scripts/lib/_homebrew_github_commit.bash
+++ b/jenkins-scripts/lib/_homebrew_github_commit.bash
@@ -66,7 +66,7 @@ ${GIT} push -u pr_head ${PULL_REQUEST_BRANCH}
 
 # Create a pull request if one doesn't yet exist
 if [ -z "${PULL_REQUEST_URL}" ]; then
-  # Check for hub command
+  # Check for hub command. It requires a GITHUB_TOKEN to work
   HUB=hub
   if ! which ${HUB} ; then
     if [ ! -s hub-linux-amd64-2.2.3.tgz ]; then

--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -28,18 +28,6 @@ if [[ -z $(ssh -T git@github.com 2>&1 | grep successfully) ]]; then
     fi
 fi
 
-GITHUB_TOKEN_FILE="/var/lib/jenkins/.github_token"
-if [[ ! -f ${GITHUB_TOKEN_FILE} ]]; then
-   echo "The hub cli tool needs a valid token at file ${GITHUB_TOKEN_FILE}"
-   echo "The file was not found"
-   exit 1
-fi
-
-set +x # keep password secret
-export GITHUB_TOKEN=`cat $GITHUB_TOKEN_FILE`
-set -x # back to debug
-echo '# END SECTION'
-
 echo '# BEGIN SECTION: download linuxbrew'
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 echo '# END SECTION'


### PR DESCRIPTION
The PR removes the injection of the GITHUB token into `jenkins-scripts/lib/_homebrew_github_setup.bash` to work using the same variable injected via credentials plugin. @scpeters if you please find a chance to test it, appreciated.