### PR TITLE
Fix nightly_labeler when nodes are not fully available

### DIFF
--- a/jenkins-scripts/tools/label-assignment-backstop.groovy
+++ b/jenkins-scripts/tools/label-assignment-backstop.groovy
@@ -49,7 +49,7 @@ for (tup in exactly_one_labels) {
     println("Appointing a node from the configured pool matching '${pool_label}'")
 
     def node_pool = Jenkins.instance.nodes.findAll { node ->
-      node.computer.online &&
+      node.toComputer()?.isOnline() &&
       node.getLabelString().contains(pool_label) &&
       !node.getLabelString().contains(nightly_label_prefix) &&
       !node.getLabelString().contains("test-instance")
@@ -58,7 +58,7 @@ for (tup in exactly_one_labels) {
     if (node_pool.size() <= 0) {
       println("The Pool of '${pool_label}' machines for ${nightly_label} is empty. Reusing a node:")
       node_pool = Jenkins.instance.nodes.findAll { node ->
-        node.computer.online &&
+        node.toComputer()?.isOnline() &&
         node.getLabelString().contains(pool_label) &&
         !node.getLabelString().contains("test-instance")
       }


### PR DESCRIPTION
Fix the plain wrong code to use the right API call `node.toComputer().IsOnline()`. The call is not safe since `toComputer()` can return NULL in cases were nodes are not fully initialized.

`node.toComputer()?.IsOnline()` should deal with it.

Failing [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_nightly_node_labeler&build=17250)](https://build.osrfoundation.org/job/_nightly_node_labeler/17250/)
Fixed [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_nightly_node_labeler&build=17251)](https://build.osrfoundation.org/job/_nightly_node_labeler/17251/)