### PR TITLE
Fix outdated_job_runner when nodes are not fully available (Apply #1214)

### DIFF
--- a/jenkins-scripts/tools/outdated-job-runner.groovy
+++ b/jenkins-scripts/tools/outdated-job-runner.groovy
@@ -27,7 +27,7 @@ def findAvailableNodes() {
     def availableNodes = [osx: [], win: [], docker: []]
 
     Jenkins.instance.nodes.each { node ->
-        if (node.computer.online && node.computer.countIdle() > 0) {
+        if (node.toComputer()?.isOnline() && node.computer.countIdle() > 0) {
             if (node.getLabelString().contains("win")) {
                 availableNodes.win << node.name
             } else if (node.getLabelString().contains("osx")) {


### PR DESCRIPTION
Same logic as #1214 applied to outdated job runner (that also has been failing because of this problem)

