### PR TITLE
Fix auth in release.py for nightly: right handle --auth values in Jenkins calss

### DIFF
--- a/release.py
+++ b/release.py
@@ -588,13 +588,14 @@ def call_jenkins_build(job_name: str,
                              headers=build_credentials_header(auth_input_arg))
             # 201 code is "created", it is the expected return of POST
             if response.status != 201:
-                error(f"Error {response.status}: {response.reason}")
+                http.clear()
+                error(f"{response.status}: {response.reason}")
         except RequestError as e:
+            http.clear()
             error(f"An error occurred in the http request: {e}")
         except Exception as e:
-            error(f"An unexpected error occurred: {e}")
-        finally:
             http.clear()
+            error(f"An unexpected error occurred: {e}")
 
 
 def display_help_job_chain_for_source_calls(args):

--- a/release.py
+++ b/release.py
@@ -535,6 +535,7 @@ def generate_source_params(args):
 
     return params
 
+
 def build_credentials_header(auth_input_arg=None):
     if auth_input_arg:
         if len(auth_input_arg.split(':')) != 2:
@@ -543,7 +544,7 @@ def build_credentials_header(auth_input_arg=None):
     else:
         username, api_token = get_credentials(JENKINS_URL)
         if not username:
-            exit(1)
+            error("No username found in credentials file")
 
     return make_headers(basic_auth=f'{username}:{api_token}')
 
@@ -559,11 +560,11 @@ def check_credentials(auth_input_arg=None):
         exit(1)
 
 
-def call_jenkins_build(job_name,
-                       params,
-                       output_string,
-                       search_description_help,
-                       auth_input_arg=None):
+def call_jenkins_build(job_name: str,
+                       params: dict,
+                       output_string: str,
+                       search_description_help: str,
+                       auth_input_arg: str = ""):
     # Only to help user feedback this block
     help_url = f'{JENKINS_URL}/job/{job_name}'
     if search_description_help:
@@ -585,6 +586,7 @@ def call_jenkins_build(job_name,
                 http.request('POST',
                              url,
                              headers=build_credentials_header(auth_input_arg))
+            print(response)
             # 201 code is "created", it is the expected return of POST
             if response.status != 201:
                 error(f"Error {response.status}: {response.reason}")

--- a/release.py
+++ b/release.py
@@ -535,7 +535,7 @@ def generate_source_params(args):
 
     return params
 
-def build_credentials_header(auth_input_arg = None):
+def build_credentials_header(auth_input_arg=None):
     if auth_input_arg:
         if len(auth_input_arg.split(':')) != 2:
             error("Auth string is not in the form of 'user:token' ")
@@ -547,7 +547,8 @@ def build_credentials_header(auth_input_arg = None):
 
     return make_headers(basic_auth=f'{username}:{api_token}')
 
-def check_credentials(auth_input_arg = None):
+
+def check_credentials(auth_input_arg=None):
     http = urllib3.PoolManager()
     response = http.request('GET',
                             JENKINS_URL,
@@ -562,7 +563,7 @@ def call_jenkins_build(job_name,
                        params,
                        output_string,
                        search_description_help,
-                       auth_input_arg = None):
+                       auth_input_arg=None):
     # Only to help user feedback this block
     help_url = f'{JENKINS_URL}/job/{job_name}'
     if search_description_help:
@@ -579,20 +580,21 @@ def call_jenkins_build(job_name,
 
     if not DRY_RUN:
         http = urllib3.PoolManager()
-        try :
-            response = http.request('POST',
-                                    url ,
-                                    headers=build_credentials_header(auth_input_arg))
+        try:
+            response = \
+                http.request('POST',
+                             url,
+                             headers=build_credentials_header(auth_input_arg))
             # 201 code is "created", it is the expected return of POST
             if response.status != 201:
-                print(f"Error {response.status}: {response.reason}")
-                exit(1)
+                error(f"Error {response.status}: {response.reason}")
         except RequestError as e:
-            print(f"An error occurred in the http request: {e}")
+            error(f"An error occurred in the http request: {e}")
         except Exception as e:
-            print(f"An unexpected error occurred: {e}")
+            error(f"An unexpected error occurred: {e}")
         finally:
             http.clear()
+
 
 def display_help_job_chain_for_source_calls(args):
     # Encode the different ways using in the job descriptions to filter builds


### PR DESCRIPTION
The nightly call was failing without an error message although the same `--dry-run` was just fine.

The PR adds right error reporting an fixes the bad handling of auth credentials by enforcing the parameter in the function call.

Failing: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-__upcoming__-nightly-scheduler&build=32)](https://build.osrfoundation.org/job/ignition-__upcoming__-nightly-scheduler/32/)
Working: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-__upcoming__-nightly-scheduler&build=36)](https://build.osrfoundation.org/job/ignition-__upcoming__-nightly-scheduler/36/)