### PR TITLE
Relocate colcon code after pixi installation

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -73,25 +73,6 @@ echo # END SECTION
 echo # BEGIN SECTION: vcpkg: list installed packages
 call %win_lib% :list_vcpkg_packages || goto :error
 
-:: Check if package is in colcon workspace
-echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
-echo Packages in workspace:
-colcon list --names-only
-
-colcon list --names-only | find "!COLCON_PACKAGE!"
-if errorlevel 1 (
-  :: REQUIRED for Gazebo Fortress
-  set COLCON_PACKAGE=!COLCON_PACKAGE:gz=ignition!
-  set COLCON_PACKAGE=!COLCON_PACKAGE:sim=gazebo!
-)
-colcon list --names-only | find "!COLCON_PACKAGE!"
-if errorlevel 1 (
-  echo Failed to find package !COLCON_PACKAGE! in workspace.
-  goto :error
-)
-echo Using package name !COLCON_PACKAGE!
-echo # END SECTION
-
 echo # BEGIN SECTION: setup workspace
 if not defined KEEP_WORKSPACE (
   IF exist %LOCAL_WS_BUILD% (
@@ -122,6 +103,26 @@ echo # END SECTION
 if exist %LOCAL_WS_SOFTWARE_DIR%\configure.bat (
   echo "DEPRECATED configure.bat file detected. It should be removed from upstream sources"
 )
+
+:: Check if package is in colcon workspace
+echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
+echo Packages in workspace:
+colcon list --names-only
+
+colcon list --names-only | find "!COLCON_PACKAGE!"
+if errorlevel 1 (
+  :: REQUIRED for Gazebo Fortress
+  set COLCON_PACKAGE=!COLCON_PACKAGE:gz=ignition!
+  set COLCON_PACKAGE=!COLCON_PACKAGE:sim=gazebo!
+)
+colcon list --names-only | find "!COLCON_PACKAGE!"
+if errorlevel 1 (
+  echo Failed to find package !COLCON_PACKAGE! in workspace.
+  goto :error
+)
+echo Using package name !COLCON_PACKAGE!
+echo # END SECTION
+
 
 echo # BEGIN SECTION: compiling %VCS_DIRECTORY%
 cd %LOCAL_WS%


### PR DESCRIPTION
We should not expect colcon to be installed before pixi installation. The PR relocates the code before the compilation where it is still needed for Fortress ignition names.

Testing it [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-pr-win&build=250)](https://build.osrfoundation.org/job/gz_math-pr-win/250/)