### PR TITLE
Need osrfbuild permissions in gazebo11-debbuilder

### DIFF
--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -422,6 +422,7 @@ all_debbuild_branches = gazebo_supported_branches
 all_debbuild_branches.each { branch ->
   def build_pkg_job = job("${branch}-debbuilder")
   OSRFLinuxBuildPkg.create(build_pkg_job)
+  OSRFCredentials.allowOsrfbuildToRunTheBuild(build_pkg_job)
 
   build_pkg_job.with
   {


### PR DESCRIPTION
Missing permissions in gazebo11-debbuilder. Retriggered 11.15.1 manually with my user but this is the right patch.