### PR TITLE
Add Run/Update permission to osrfbuild

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFCredentials.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFCredentials.groovy
@@ -36,6 +36,7 @@ class OSRFCredentials
       authorization {
         permission('hudson.model.Item.Read', 'osrfbuild')
         permission('hudson.model.Item.Build', 'osrfbuild')
+        permission('hudson.model.Run.Update', 'osrfbuild')
       }
     }
   }


### PR DESCRIPTION
Reported problem by @Crola1702 about failing deb-builder in https://build.osrfoundation.org/job/gz-launch9-debbuilder/56/console . 

The PR adds permissins to Run.Update for osrfbuild in order to update the job description.

Being tested in build 57 and 58 of https://build.osrfoundation.org/job/gz-launch9-debbuilder/
