### PR TITLE
Add sanity check on version in CMakeLists.txt file

### DIFF
--- a/release.py
+++ b/release.py
@@ -420,7 +420,7 @@ def sanity_checks(args, repo_dir):
     if not NIGHTLY:
         sanity_package_version(repo_dir, args.version, str(args.release_version))
         sanity_check_sdformat_versions(args.package, args.version)
-        if not (args.bump_rev_linux_only or args.source_repo_uri):
+        if not (args.bump_rev_linux_only or args.source_tarball_uri):
             sanity_check_cmake_version(args.package, args.version)
         sanity_project_package_in_stable(args.version, args.upload_to_repository)
 

--- a/release.py
+++ b/release.py
@@ -326,23 +326,44 @@ def sanity_check_sdformat_versions(package, version):
 
     print_success("sdformat version in proper sdformat package")
 
-def sanity_check_cmake_version(version):
-    regex = re.compile(r"^project.*VERSION\s*([0-9.]*).*", re.MULTILINE)
+def get_version_from_cmake(cmake_file="CMakeLists.txt"):
+    version_regex = re.compile(
+        r"project\s*\(\s*[a-z0-9-_]*\s*VERSION\s*([0-9.]*)", re.MULTILINE
+    )
+    # Note the re.DOTALL is used to match any newlines and arguments to 
+    # gz_configure_project before VERSION_SUFFIX
+    suffix_regex = re.compile(
+        r"(?:gz|ign)_configure_project\s*\(.*VERSION_SUFFIX\s*(pre\d+)",
+        re.MULTILINE | re.DOTALL,
+    )
     try:
-        with open("CMakeLists.txt") as f:
-            m = re.search(regex, f.read())
-            if m:
-                cmake_version = m.group(1)
-                if cmake_version != version:
-                    error(f"Error in package version. CMakeLists version: {cmake_version}, provided version: {version}")
-                else:
-                    print_success("Package version in CMakeLists")
+        with open(cmake_file) as f:
+            content = f.read()
+            version_match = re.search(version_regex, content)
+            suffix_match = re.search(suffix_regex, content)
+            if version_match:
+                cmake_version = version_match.group(1)
+                if suffix_match:
+                    cmake_version = f"{cmake_version}~{suffix_match.group(1)}"
+                return cmake_version
             else:
                 error("Error parsing version from CMakeLists.txt file")
-
     except FileNotFoundError as e:
-        print("Could not find CMakeLists file. Are you sure you're in the source directory?")
         print(e)
+        error("Could not find CMakeLists file. Are you sure you're in the source directory?")
+
+def sanity_check_cmake_version(package, version):
+    # These two packages do not follow the same formatting in their CMakeLists files.
+    # Since they are old versions, we'll simply not support them.
+    if package in ["ign-tools", "sdformat9"]:
+        print(f" + NOTE Sanity checking is not supported for {package}")
+        return
+
+    cmake_version = get_version_from_cmake()
+    if cmake_version != version:
+        error(f"Error in package version. CMakeLists version: {cmake_version}, provided version: {version}")
+    else:
+        print_success("Package version in CMakeLists")
 
 def sanity_check_repo_name(repo_name):
     if repo_name in OSRF_REPOS_SUPPORTED:
@@ -400,7 +421,7 @@ def sanity_checks(args, repo_dir):
         sanity_package_version(repo_dir, args.version, str(args.release_version))
         sanity_check_sdformat_versions(args.package, args.version)
         if not (args.bump_rev_linux_only or args.source_repo_uri):
-            sanity_check_cmake_version(args.version)
+            sanity_check_cmake_version(args.package, args.version)
         sanity_project_package_in_stable(args.version, args.upload_to_repository)
 
     check_credentials(args.auth_input_arg)

--- a/release.py
+++ b/release.py
@@ -399,7 +399,8 @@ def sanity_checks(args, repo_dir):
     if not NIGHTLY:
         sanity_package_version(repo_dir, args.version, str(args.release_version))
         sanity_check_sdformat_versions(args.package, args.version)
-        sanity_cmake_version(args.version)
+        if not (args.bump_rev_linux_only or args.source_repo_uri):
+            sanity_cmake_version(args.version)
         sanity_project_package_in_stable(args.version, args.upload_to_repository)
 
     check_credentials(args.auth_input_arg)

--- a/release.py
+++ b/release.py
@@ -326,7 +326,7 @@ def sanity_check_sdformat_versions(package, version):
 
     print_success("sdformat version in proper sdformat package")
 
-def sanity_cmake_version(version):
+def sanity_check_cmake_version(version):
     regex = re.compile(r"^project.*VERSION\s*([0-9.]*).*", re.MULTILINE)
     try:
         with open("CMakeLists.txt") as f:
@@ -400,7 +400,7 @@ def sanity_checks(args, repo_dir):
         sanity_package_version(repo_dir, args.version, str(args.release_version))
         sanity_check_sdformat_versions(args.package, args.version)
         if not (args.bump_rev_linux_only or args.source_repo_uri):
-            sanity_cmake_version(args.version)
+            sanity_check_cmake_version(args.version)
         sanity_project_package_in_stable(args.version, args.upload_to_repository)
 
     check_credentials(args.auth_input_arg)


### PR DESCRIPTION
It the version in the local CMakeLists.txt file doesn't match the intended release version, released.py currently starts the source job, which gives the false impression that everything is working well. However, the source job will fail and debbuilder jobs are never triggered.  This patch adds a sanity check so that released.py fails if the release version doesn't match what's in CMakeLists.txt.

To test the script can parse versions correctly, I ran the following from the **directory containing** `release.py`:
```bash
for d in ~/ws/ionic/src/{gz-*,sdf*}; do echo -n "$d "; python3 -c "import release; print(release.get_version_from_cmake(\"$d/CMakeLists.txt\"))"; done
```
