### PR TITLE
Print dxdiag output on Windows colcon builds

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -35,6 +35,11 @@ if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
    echo "MAJOR_VERSION detected: !PKG_MAJOR_VERSION!"
 )
 
+echo # BEGIN SECTION: dxdiag info
+set DXDIAG_FILE=%WORKSPACE%\dxdiag.txt
+dxdiag /t %DXDIAG_FILE%
+type %DXDIAG_FILE%
+echo # END SECTION
 
 setlocal ENABLEDELAYEDEXPANSION
 if not defined GAZEBODISTRO_FILE (


### PR DESCRIPTION
The `dxdiag` binary on Windows can be useful to debug problems related to the configuration and support of Nvidia in the different AWS machines. It can output to a file and the code prints that to the Console for reference.

Used: https://build.osrfoundation.org/job/_test_gz_rendering_ogre23-pr-cwin/20/consoleFull#console-section-0