### PR TITLE
Ignore gz-jetty major version

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -434,7 +434,7 @@ collections:
         - brew
       linux:
         ignore_major_version:
-          - gz-ionic
+          - gz-jetty
   - name: '__upcoming__'
     libs:
       - name: gz-tools

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -600,8 +600,8 @@ install_ci jetty gz_fuel_tools10-install-pkg-noble-amd64
 install_ci jetty gz_fuel_tools10-install_bottle-homebrew-amd64
 install_ci jetty gz_gui9-install-pkg-noble-amd64
 install_ci jetty gz_gui9-install_bottle-homebrew-amd64
-install_ci jetty gz_jetty1-install-pkg-noble-amd64
-install_ci jetty gz_jetty1-install_bottle-homebrew-amd64
+install_ci jetty gz_jetty-install-pkg-noble-amd64
+install_ci jetty gz_jetty-install_bottle-homebrew-amd64
 install_ci jetty gz_launch8-install-pkg-noble-amd64
 install_ci jetty gz_launch8-install_bottle-homebrew-amd64
 install_ci jetty gz_math8-install-pkg-noble-amd64


### PR DESCRIPTION
Gz-jetty major version is not being ignored, producing an error in [jetty-nightly-scheduler](https://build.osrfoundation.org/job/ignition-jetty-nightly-scheduler/5/console):

```
+ python3 ./scripts/release.py gz-jetty1 nightly --auth osrfbuild:**** --release-repo-branch main --nightly-src-branch main --upload-to-repo nightly
Downloading releasing info for gz-jetty1
Error running command (git ls-remote -q --exit-code https://github.com/gazebo-release/gz-jetty1-release).
stdout: 
stderr: fatal: could not read Username for 'https://github.com/': No such device or address
```