### PR TITLE
Only run the GPU test on Conda

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -35,18 +35,23 @@ if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
    echo "MAJOR_VERSION detected: !PKG_MAJOR_VERSION!"
 )
 
-if "%GPU_SUPPORT_NEEDED%" == "true" (
-  echo # BEGIN SECTION: dxdiag info
-  set DXDIAG_FILE=%WORKSPACE%\dxdiag.txt
-  dxdiag /t !DXDIAG_FILE!
-  type !DXDIAG_FILE!
-  echo Checking for correct NVIDIA GPU support !DXDIAG_FILE!
-  findstr /C:"Manufacturer: NVIDIA" !DXDIAG_FILE!
-  if errorlevel 1 (
-    echo ERROR: NVIDIA GPU not found in dxdiag
-    goto :error
+:: vcpkg cache provisioned agents does not seems to support
+:: the GPU correctly so only apply the check if the agent
+:: is working with pixi
+if "%USE_PIXI%" == "true" (
+  if "%GPU_SUPPORT_NEEDED%" == "true" (
+    echo # BEGIN SECTION: dxdiag info
+    set DXDIAG_FILE=%WORKSPACE%\dxdiag.txt
+    dxdiag /t !DXDIAG_FILE!
+    type !DXDIAG_FILE!
+    echo Checking for correct NVIDIA GPU support !DXDIAG_FILE!
+    findstr /C:"Manufacturer: NVIDIA" !DXDIAG_FILE!
+    if errorlevel 1 (
+      echo ERROR: NVIDIA GPU not found in dxdiag
+      goto :error
+    )
+    echo # END SECTION
   )
-  echo # END SECTION
 )
 
 setlocal ENABLEDELAYEDEXPANSION


### PR DESCRIPTION
There is a problem with the production Windows agents provisioned with the vcpkg static cache. Since it is not affecting to the production CI builds, this PR restrict the fail on bad GPU setup to just the testing that uses Conda.

Testing:
[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-pr-win&build=1131)](https://build.osrfoundation.org/job/gz_sim-pr-win/1131/)