### PR TITLE
Conda environments and pixi support for colcon-default-devel-windows.bat

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -78,18 +78,57 @@ if not exist %WORKSPACE%\%VCS_DIRECTORY% (
   exit 1
 )
 
-:: Call vcvarsall and all the friends
-echo # BEGIN SECTION: configure the MSVC compiler
-call %win_lib% :configure_msvc2019_compiler
+:: Prepare a clean vcpkg environment with external dependencies
+echo # BEGIN SECTION: remove vcpkg install directory
+call %win_lib% :remove_vcpkg_installation || goto :error
 echo # END SECTION
 
-:: Prepare a clean vcpkg environment with external dependencies
-call %win_lib% :remove_vcpkg_installation || goto :error
-echo # BEGIN SECTION: vcpkg: install all dependencies
-call %win_lib% :setup_vcpkg_all_dependencies || goto :error
-echo # END SECTION
-echo # BEGIN SECTION: vcpkg: list installed packages
-call %win_lib% :list_vcpkg_packages || goto :error
+if defined USE_PIXI (
+  if not defined REUSE_PIXI_INSTALLATION (
+    echo # BEGIN SECTION: pixi: installation
+    call %win_lib% :pixi_installation || goto :error
+    echo # END SECTION
+
+    echo # BEGIN SECTION: pixi: create legacy environment
+    call %win_lib% :pixi_create_gz_environment_legacy || goto :error
+    echo # END SECTION
+  )
+  echo # BEGIN SECTION: pixi: info
+  call %win_lib% :pixi_cmd info || goto :error
+  echo # END SECTION
+
+  echo # BEGIN SECTION: pixi: list packages
+  call %win_lib% :pixi_cmd list || goto :error
+  echo # END SECTION
+
+  echo # BEGIN SECTION: pixi: enable shell
+  call %win_lib% :pixi_load_shell
+  echo # END SECTION
+
+  echo # BEGIN SECTION: pixi: custom environment variable for gz
+  if "!CONDA_PREFIX!"=="" (
+    echo # BEGIN SECTION: ERROR: CONDA_PREFIX is not set
+    echo CONDA_PREFIX variable was not set. Please set it before calling this script
+    echo # END SECTION
+    goto :error
+  )
+  set OGRE_RESOURCE_PATH=!CONDA_PREFIX!\Library\bin
+  set OGRE2_RESOURCE_PATH=!CONDA_PREFIX!\Library\bin\OGRE-Next
+  echo # END SECTION
+ ) else (
+  :: Call vcvarsall and all the friends
+  echo # BEGIN SECTION: configure the MSVC compiler
+  call %win_lib% :configure_msvc2019_compiler
+  echo # END SECTION
+
+  echo # BEGIN SECTION: vcpkg: install all dependencies
+  call %win_lib% :setup_vcpkg_all_dependencies || goto :error
+  echo # END SECTION
+
+  echo # BEGIN SECTION: vcpkg: list installed packages
+  call %win_lib% :list_vcpkg_packages || goto :error
+  echo # END SECTION
+)
 
 echo # BEGIN SECTION: setup workspace
 if not defined KEEP_WORKSPACE (
@@ -118,10 +157,6 @@ echo # BEGIN SECTION: packages in workspace
 call %win_lib% :list_workspace_pkgs || goto :error
 echo # END SECTION
 
-if exist %LOCAL_WS_SOFTWARE_DIR%\configure.bat (
-  echo "DEPRECATED configure.bat file detected. It should be removed from upstream sources"
-)
-
 :: Check if package is in colcon workspace
 echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
 echo Packages in workspace:
@@ -141,7 +176,6 @@ if errorlevel 1 (
 echo Using package name !COLCON_PACKAGE!
 echo # END SECTION
 
-
 echo # BEGIN SECTION: compiling %VCS_DIRECTORY%
 cd %LOCAL_WS%
 call %win_lib% :build_workspace !COLCON_PACKAGE! !COLCON_PACKAGE_EXTRA_CMAKE_ARGS! || goto :error
@@ -157,7 +191,7 @@ if "%ENABLE_TESTS%" == "TRUE" (
     echo # BEGIN SECTION: export testing results
     if exist %EXPORT_TEST_RESULT_PATH% ( rmdir /q /s %EXPORT_TEST_RESULT_PATH% )
     mkdir %EXPORT_TEST_RESULT_PATH%
-    xcopy !TEST_RESULT_PATH! %EXPORT_TEST_RESULT_PATH% /s /i /e || goto :error^M
+    xcopy !TEST_RESULT_PATH! %EXPORT_TEST_RESULT_PATH% /s /i /e || goto :error
     echo # END SECTION
 )
 

--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -1,10 +1,27 @@
+set "PIXI_VERSION=0.30.0"
+set "PIXI_URL=https://github.com/prefix-dev/pixi/releases/download/v%PIXI_VERSION%/pixi-x86_64-pc-windows-msvc.exe"
+set "PIXI_PROJECT_PATH=%TMP%\pixi\project"
+set "PIXI_TMPDIR=%TMP%\pixi"
+set "PIXI_TMP=%PIXI_TMPDIR%\pixi.exe"
+set "CONDA_ENVS_DIR=%SCRIPT_DIR%\..\conda\envs\"
+
 if exist D:\vcpkg (
   set VCPKG_DIR=D:\vcpkg
 ) else if exist C:\vcpkg (
     set VCPKG_DIR=C:\vcpkg
 ) else (
-   echo "Can not find a vcpkg installation"
-   exit -1
+  if defined USE_PIXI (
+    :: vcpkg removed by pixi. Recreate a fake one until vcpkg is removed from nodes
+    if not exist VCPKG_DIR set "VCPKG_DIR=%TMP%\%RANDOM%\vcpkg"
+    mkdir !VCPKG_DIR!
+  ) else (
+    echo "Can not find a vcpkg installation"
+    exit -1
+  )
+)
+
+if NOT DEFINED EXIT_ON_ERROR (
+  set EXIT_ON_ERROR=
 )
 
 if DEFINED MAKE_JOBS (


### PR DESCRIPTION
Although disabled by default under the flag `USE_PIXI` the PR adds the following support to main Windows build script:

* :pixi_installation:
  *  Download the given version of pixi into the PIXI_TMPDIR
* :pixi_create_gz_environment_legacy
  *  Clean up and create a PIXI_PROJECT_PATH (%TMP%\pixi\project"), copy the legacy environment files and run `pixi install`
* :pixi_cmd 
  * Wrapper to run pixi commands passed as arguments
* :pixi_load_shell
  * Workaround to enable a `pixi shell` like on Jenkins by exporting the results on shell-hook to .bat file and call it.
 

Tested for PIXI [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_gz_rendering_ogre23-pr-cwin&build=34)](https://build.osrfoundation.org/job/_test_gz_rendering_ogre23-pr-cwin/34/)

Tested for current vcpkg: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs-pr-win&build=145)](https://build.osrfoundation.org/job/gz_msgs-pr-win/145/)