### PR TITLE
ci-dsl.yaml: use upload-artifact@v4

### DIFF
--- a/.github/workflows/ci-dsl.yaml
+++ b/.github/workflows/ci-dsl.yaml
@@ -62,12 +62,12 @@ jobs:
           diff -qr -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration | sort > /tmp/xml_config_files_changed.diff || true
           diff -ur -I '.*<id>dashboard_portlet_.*</id>.*' /tmp/current_xml_configuration /tmp/pr_xml_configuration > /tmp/xml_config_content_changed.diff || true
       - name: Archive files changes
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xml_config_files_changed
           path: /tmp/xml_config_files_changed.diff
       - name: Archive content changes
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xml_config_content_changed
           path: /tmp/xml_config_content_changed.diff


### PR DESCRIPTION
Version `v3` of actions/upload-artifact is [no longer working](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/); switch to `v4`.