### PR TITLE
Avoid conflict in branch names used when vendor package PRs

### DIFF
--- a/release.py
+++ b/release.py
@@ -747,7 +747,7 @@ def create_pr_for_vendor_package(args, repo_path, base_branch) -> str:
     if not _out.decode():
         return 'vendor tool did not produce any change, avoid the PR'
 
-    branch_name = f'releasepy/{args.version}'
+    branch_name = f'releasepy/{base_branch}/{args.version}'
     vendor_repo = get_vendor_repo_url(args.package)
     branch_cmd = ['git', "-C", repo_path,
                   'checkout', '-b',  branch_name]


### PR DESCRIPTION
There's a conflict in the branch name used by release.py when a package belongs to multiple collections (eg. gz-tools2 is used in Harmonic and Ionic) since it tries to create two PRs with the same branch. See https://github.com/gazebo-release/gz_tools_vendor/pull/5 https://github.com/gazebo-release/gz_tools_vendor/pull/6

This fixes it by adding the base branch name (eg. rolling or jazzy) in the generated branch. See https://github.com/gazebo-release/gz_tools_vendor/pull/7 and https://github.com/gazebo-release/gz_tools_vendor/pull/8