### PR TITLE
release.py: skip ROS for non-stable releases

### DIFF
--- a/release.py
+++ b/release.py
@@ -954,7 +954,9 @@ def go(argv):
                            args.auth_input_arg)
         display_help_job_chain_for_source_calls(args)
         # Process the possible update of an associated ROS vendor package
-        process_ros_vendor_package(args)
+        # for stable releases only
+        if not (PRERELEASE or NIGHTLY):
+            process_ros_vendor_package(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Skip trying to update ROS vendor packages for prerelease or nightly releases.

Without this I get an error when trying to make a prerelease for https://github.com/gazebosim/gz-cmake/pull/469:

~~~
ROS vendor packages that can be updated:
 * Github gazebo-release/gz_cmake_vendor part of ionic in ROS 2 rolling
   + Preparing a PR: 
[notice] A new release of pip is available: 24.2 -> 25.0.1
[notice] To update, run: /private/var/folders/6f/__qxt3jn4j3dxgd2grbmmvtm0000gn/T/tmpmpxnxrxf/venv/bin/python3.12 -m pip install --upgrade pip
Error running command (git -C /var/folders/6f/__qxt3jn4j3dxgd2grbmmvtm0000gn/T/tmpmpxnxrxf/gz_vendor_repo checkout -b releasepy/rolling/4.1.1~pre1).
stdout: 
stderr: fatal: 'releasepy/rolling/4.1.1~pre1' is not a valid branch name
hint: See `man git check-ref-format`
hint: Disable this message with "git config set advice.refSyntax false"

Traceback (most recent call last):
  File "/Users/scpeters/clone/release-tools/release.py", line 961, in <module>
    go(sys.argv)
  File "/Users/scpeters/clone/release-tools/release.py", line 957, in go
    process_ros_vendor_package(args)
  File "/Users/scpeters/clone/release-tools/release.py", line 815, in process_ros_vendor_package
    pr_url = create_pr_in_gz_vendor_repo(args, ros_distro)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scpeters/clone/release-tools/release.py", line 797, in create_pr_in_gz_vendor_repo
    pr_msg = create_pr_for_vendor_package(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scpeters/clone/release-tools/release.py", line 754, in create_pr_for_vendor_package
    _, _ = check_call(branch_cmd, IGNORE_DRY_RUN)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scpeters/clone/release-tools/release.py", line 504, in check_call
    raise Exception('subprocess call failed')
Exception: subprocess call failed
~~~