### PR TITLE
releasepy: push only the tag of the release

### DIFF
--- a/release.py
+++ b/release.py
@@ -510,7 +510,7 @@ def tag_repo(args):
         # tilde is not a valid character in git
         tag = '%s_%s' % (args.package_alias, args.version.replace('~', '-'))
         check_call(['git', 'tag', '-f', tag])
-        check_call(['git', 'push', '--tags'])
+        check_call(['git', 'push', 'origin', 'tag', tag])
     except ErrorNoPermsRepo:
         print('The Git server reports problems with permissions')
         print('The branch could be blocked by configuration if you do not have')


### PR DESCRIPTION
release.py was using git push with the `--tags` option, what caused to push all the tags to the remote. This was causing troubles to @caguero with old tags that were not matching the remote tags. We can limit the action to just the push of the generated tag, this is what this PR is doing.

Needs manual testing before merging.