### PR TITLE
Add libwebsockets dependency to conda

### DIFF
--- a/conda/envs/legacy/pixi.lock
+++ b/conda/envs/legacy/pixi.lock
@@ -509,6 +509,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.5.0-h0886dbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebsockets-4.3.3-h8945da3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
@@ -748,6 +749,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.50.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.5.0-h3b0e114_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebsockets-4.3.3-heb0366b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h283a6d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-h2466b09_6.conda
@@ -8863,6 +8865,23 @@ packages:
 - kind: conda
   name: libwebsockets
   version: 4.3.3
+  build: h8945da3_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebsockets-4.3.3-h8945da3_0.conda
+  sha256: 25a18da74fbc048307f5cb5cce5addeaa9caa3c4f94d3ef1ae11fad2279c6095
+  md5: 2446142d49dadc928caa6e4efb7f2e58
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libuv >=1.46.0,<2.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 395813
+  timestamp: 1700469095651
+- kind: conda
+  name: libwebsockets
+  version: 4.3.3
   build: ha6cc734_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libwebsockets-4.3.3-ha6cc734_0.conda
@@ -8878,6 +8897,24 @@ packages:
   license_family: MIT
   size: 385161
   timestamp: 1700469113171
+- kind: conda
+  name: libwebsockets
+  version: 4.3.3
+  build: heb0366b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebsockets-4.3.3-heb0366b_0.conda
+  sha256: cae70d40d705d69b3e11254681f4692001ef79e692ff61b21475cc861bf50746
+  md5: 35a441c21943345aa0b5a247206dbaed
+  depends:
+  - libuv >=1.48.0,<2.0a0
+  - openssl >=3.2.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 354282
+  timestamp: 1712216657465
 - kind: conda
   name: libxcb
   version: '1.15'

--- a/conda/envs/legacy/pixi.toml
+++ b/conda/envs/legacy/pixi.toml
@@ -36,6 +36,7 @@ tinyxml2 = "*"
 yaml = "*"
 zeromq = "4.3.4"
 cli11 = "2.1.2.*"
+libwebsockets = ">=4.3.3,<5"
 
 [target.win-64.dependencies]
 dlfcn-win32 = "*"

--- a/conda/envs/legacy_ogre23/pixi.lock
+++ b/conda/envs/legacy_ogre23/pixi.lock
@@ -507,6 +507,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.5.0-h0886dbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebsockets-4.3.3-h8945da3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
@@ -745,6 +746,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.50.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.5.0-h3b0e114_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebsockets-4.3.3-heb0366b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h283a6d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-h2466b09_6.conda
@@ -8815,6 +8817,23 @@ packages:
 - kind: conda
   name: libwebsockets
   version: 4.3.3
+  build: h8945da3_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebsockets-4.3.3-h8945da3_0.conda
+  sha256: 25a18da74fbc048307f5cb5cce5addeaa9caa3c4f94d3ef1ae11fad2279c6095
+  md5: 2446142d49dadc928caa6e4efb7f2e58
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libuv >=1.46.0,<2.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 395813
+  timestamp: 1700469095651
+- kind: conda
+  name: libwebsockets
+  version: 4.3.3
   build: ha6cc734_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libwebsockets-4.3.3-ha6cc734_0.conda
@@ -8830,6 +8849,24 @@ packages:
   license_family: MIT
   size: 385161
   timestamp: 1700469113171
+- kind: conda
+  name: libwebsockets
+  version: 4.3.3
+  build: heb0366b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebsockets-4.3.3-heb0366b_0.conda
+  sha256: cae70d40d705d69b3e11254681f4692001ef79e692ff61b21475cc861bf50746
+  md5: 35a441c21943345aa0b5a247206dbaed
+  depends:
+  - libuv >=1.48.0,<2.0a0
+  - openssl >=3.2.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 354282
+  timestamp: 1712216657465
 - kind: conda
   name: libxcb
   version: '1.15'

--- a/conda/envs/legacy_ogre23/pixi.toml
+++ b/conda/envs/legacy_ogre23/pixi.toml
@@ -35,6 +35,7 @@ ruby = "3.2.*"
 tinyxml2 = "*"
 yaml = "*"
 zeromq = "4.3.4"
+libwebsockets = ">=4.3.3,<5"
 
 [target.win-64.dependencies]
 dlfcn-win32 = "*"


### PR DESCRIPTION
Related issue: https://github.com/gazebosim/gz-launch/issues/288
Needed by: https://github.com/gazebosim/gz-sim/pull/2792

The pixi files are updated by running `pixi add libwebsockets`