### PR TITLE
Restore sdformat scripts removed in #1263

### DIFF
--- a/jenkins-scripts/docker/lib/_sdformat_version_hook.bash
+++ b/jenkins-scripts/docker/lib/_sdformat_version_hook.bash
@@ -1,0 +1,10 @@
+# Identify SDFORMAT_MAJOR_VERSION to help with dependency resolution
+SDFORMAT_MAJOR_VERSION=$(\
+  python3 ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \
+  ${WORKSPACE}/sdformat/CMakeLists.txt)
+
+# Check SDFORMAT version is integer
+if ! [[ ${SDFORMAT_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
+  echo "Error! SDFORMAT_MAJOR_VERSION is not an integer, check the detection"
+  exit -1
+fi

--- a/jenkins-scripts/docker/sdformat-compilation.bash
+++ b/jenkins-scripts/docker/sdformat-compilation.bash
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+
+# Knowing Script dir beware of symlink
+[[ -L ${0} ]] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
+SCRIPT_DIR="${SCRIPT_DIR%/*}"
+
+if [[ -z ${ARCH} ]]; then
+  echo "ARCH variable not set!"
+  exit 1
+fi
+
+if [[ -z ${DISTRO} ]]; then
+  echo "DISTRO variable not set!"
+  exit 1
+fi
+
+. "${SCRIPT_DIR}/lib/_sdformat_version_hook.bash"
+
+export BUILDING_SOFTWARE_DIRECTORY="${BUILDING_SOFTWARE_DIRECTORY:-sdformat}"
+
+if [[ ${SDFORMAT_MAJOR_VERSION} -ge 8 ]]; then
+  export NEED_C17_COMPILER=true
+fi
+
+export GZDEV_PROJECT_NAME="sdformat${SDFORMAT_MAJOR_VERSION}"
+
+# master and major branches compilations
+export BUILDING_PKG_DEPENDENCIES_VAR_NAME="SDFORMAT_BASE_DEPENDENCIES"
+
+. "${SCRIPT_DIR}/lib/generic-building-base.bash"

--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -17,5 +17,6 @@ if %SDFORMAT_MAJOR_VERSION% GEQ 10 (
 ) else if %SDFORMAT_MAJOR_VERSION% GEQ 6 (
   call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"
 ) else (
-  call "%SCRIPT_DIR%/lib/sdformat-base-windows.bat"
+  echo "Ancient version of sdformat is not supported %SDFORMAT_MAJOR_VERSION%"
+  exit 1
 )

--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -1,0 +1,21 @@
+@echo on
+
+set SCRIPT_DIR=%~dp0
+
+if not defined VCS_DIRECTORY set VCS_DIRECTORY=sdformat
+set PLATFORM_TO_BUILD=x86_amd64
+set IGN_CLEAN_WORKSPACE=true
+
+set DEPEN_PKGS="libxml2 tinyxml2"
+
+for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set SDFORMAT_MAJOR_VERSION=%%i
+
+if %SDFORMAT_MAJOR_VERSION% GEQ 10 (
+  set COLCON_PACKAGE=sdformat
+  set COLCON_AUTO_MAJOR_VERSION=true
+  call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"
+) else if %SDFORMAT_MAJOR_VERSION% GEQ 6 (
+  call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"
+) else (
+  call "%SCRIPT_DIR%/lib/sdformat-base-windows.bat"
+)


### PR DESCRIPTION
Needed for:
* https://build.osrfoundation.org/job/sdformat-ci-main-noble-amd64/73/
* https://build.osrfoundation.org/job/sdformat-main-clowin/6/console

./scripts/jenkins-scripts/docker/sdformat-compilation.bash and ./scripts/jenkins-scripts/sdformat-default-devel-windows-amd64.bat were removed in #1263 