### PR TITLE
Fix CI on missing scripts check

### DIFF
--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -19,16 +19,19 @@ fi
 # Check for existing scripts. Lines:
 # 1. lookg for ./scripts/. and exclude comment lnes
 # 2. replaces %WORKSPACE% by .
-# 3. grab only the path from ./scripts/
-# 4. remove spurious "
+# 3. exclude CONDA_ENV_NAME variable lines
+# 4. grab only the path from ./scripts/
+# 5. remove spurious "
 # 5. sor and uniq to get clean output
 for f in $(grep -Eh './scripts/.*' -- *.xml | grep -v '//' | \
            sed 's/%WORKSPACE%/./g' | \
+           grep -v '%CONDA_ENV_NAME%' | \
            grep -Eh -o './scripts/.*' | awk '{print $1}' | \
            sed 's/"//g' | \
            sort | uniq); do
   if ! test -f "${f}"; then
     echo "${f} script not found in the repository"
+    exit 1
   fi
 done
 

--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -32,6 +32,23 @@ for f in $(grep -Eh './scripts/.*' -- *.xml | grep -v '//' | \
   fi
 done
 
+# Check conda enviroments links
+for f in $(ls *-c*win.xml); do
+  CONDA_ENV_NAME=$(grep -oP 'CONDA_ENV_NAME=\K.*' $f)
+  for link in "$(grep -Eh './scripts/conda/envs.*' $f | grep -v '//' | \
+           sed 's/%WORKSPACE%/./g' | \
+           sed "s/%CONDA_ENV_NAME%/${CONDA_ENV_NAME}/g" |\
+           grep -Eh -o './scripts/.*' | awk '{print $1}' | \
+           sed 's/"//g' | \
+           uniq)"; do
+    echo $link
+    if ! test -d "${link}"; then
+      echo "${link} conda env not found in the repository in file ${f}"
+      exit 1
+    fi
+  done
+done
+
 abichecker_main=$(grep '<branch>main</branch>' -- *-abichecker-*.xml || true)
 if [[ -n ${abichecker_main} ]]; then
   echo "Found a main branch in an abichecker job:"


### PR DESCRIPTION
The CI can detect some occasions when the Jenkins scripts are calling a file that is not in the repository anymore. This should have happened in #1263 and although the script detected the problem it did not fail correctly.

The changes to correct this were in #1258 but I'm porting them here so it does not happen again while that PR is being merged. I expect the CI to fail, should be corrected by #1266 