### PR TITLE
gazebo_libs.dsl: fix whitespace breaking builds

### DIFF
--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -193,7 +193,7 @@ void add_win_devel_bat_call(gz_win_ci_job, lib_name, ws_checkout_dir, ci_config)
   {
     steps {
       batchFile("""\
-            set VCS_DIRECTORY=${ws_checkout_dir}            
+            set VCS_DIRECTORY=${ws_checkout_dir}
             set CONDA_ENV_NAME=${conda_env}
             if not exist "./scripts/conda/envs/%CONDA_ENV_NAME%" (
               echo "Conda environment %CONDA_ENV_NAME% not found"


### PR DESCRIPTION
Some whitespace sneaked in with 87f76ef06 in #1274 and is breaking builds. Removing it fixes the builds.

~~~
for /F %i in ('python "C:\J\workspace\gz_utils-3-clowin\scripts\jenkins-scripts\\tools\detect_cmake_major_version.py" "C:\J\workspace\gz_utils-3-clowin\gz-utils            \CMakeLists.txt"') do set PKG_MAJOR_VERSION=%i  
 if errorlevel 1 exit 1  
 set GAZEBODISTRO_FILE=gz-utils            !PKG_MAJOR_VERSION!.yaml 
)  else (echo Using user defined GAZEBODISTRO_FILE:  ) 
Traceback (most recent call last):
  File "C:\J\workspace\gz_utils-3-clowin\scripts\jenkins-scripts\\tools\detect_cmake_major_version.py", line 11, in <module>
    f = open(fileName, 'r')
        ^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\J\\workspace\\gz_utils-3-clowin\\gz-utils            \\CMakeLists.txt'
~~~

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_utils-3-clowin&build=12)](https://build.osrfoundation.org/job/gz_utils-3-clowin/12/) https://build.osrfoundation.org/job/gz_utils-3-clowin/12/

### test with this branch

* deploying: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_gazebo_libs&build=315)](https://build.osrfoundation.org/job/_dsl_gazebo_libs/315/) https://build.osrfoundation.org/job/_dsl_gazebo_libs/315/
* testing: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_utils-3-clowin&build=14)](https://build.osrfoundation.org/job/gz_utils-3-clowin/14/) https://build.osrfoundation.org/job/gz_utils-3-clowin/14/