### PR TITLE
Script to reproduce the Conda Windows jobs locally

### DIFF
--- a/jenkins-scripts/.reproduce_last_build.bat
+++ b/jenkins-scripts/.reproduce_last_build.bat
@@ -1,0 +1,3 @@
+call C:\Users\josel\AppData\Local\Temp\pixi\project/hooks.bat 
+call C:\Users\josel\AppData\Local\Temp\27723\ws\install\setup.bash 
+cd C:\Users\josel\AppData\Local\Temp\27723\ws 

--- a/jenkins-scripts/.reproduce_last_build.bat
+++ b/jenkins-scripts/.reproduce_last_build.bat
@@ -1,3 +1,0 @@
-call C:\Users\josel\AppData\Local\Temp\pixi\project/hooks.bat 
-call C:\Users\josel\AppData\Local\Temp\27723\ws\install\setup.bash 
-cd C:\Users\josel\AppData\Local\Temp\27723\ws 

--- a/jenkins-scripts/README.md
+++ b/jenkins-scripts/README.md
@@ -2,37 +2,42 @@
 
 The release-tools repository uses the [DSL Jenkins plugin](https://plugins.jenkins.io/job-dsl/) to allow us to programmatically generate the job configuration (configuration as code).  You can find the different job configs under the [`dsl`](./dsl/) folder. 
 
-## Useful links
+## Conda local builder for Windows
+
+TODO
+
+## DSL related
+
+### Useful links
 - [List of installed plugins in Jenkins](https://github.com/osrf/chef-osrf/blob/latest/cookbooks/osrfbuild/attributes/plugins.rb)
 - [Jenkins DSL API docs](https://jenkinsci.github.io/job-dsl-plugin/)
-- [Jenkins DSL Wiki](https://github.com/jenkinsci/job-dsl-plugin/wiki) 
+- [Jenkins DSL Wiki](https://github.com/jenkinsci/job-dsl-plugin/wiki)
 
+### Local testing
 
-## Local testing
-
-To test locally the build of the different `dsl` jobs you need the following: 
+To test locally the build of the different `dsl` jobs you need the following:
 
 1. Run the `dsl/tools/setup_local_generation.bash` script to produce the necessary jar files
-3. In the terminal execute: 
-``` bash
+2. In the terminal execute:
+```bash
 java -jar <path-to-dsl-tools>/jobdsl.jar <file.dsl>
 ```
 For more information go [here](https://github.com/jenkinsci/job-dsl-plugin/wiki/User-Power-Moves#run-a-dsl-script-locally).
 
-## Development workflow
+### Development workflow
 
 1. Make changes locally and test that it builds correctly.
 2. Push changes to a specific branch in `release-tools`
-3. Go to seed job for the job you wanna test (usually you would use [`_dsl_test`](https://build.osrfoundation.org/job/_dsl_test/) to not affect the jobs in production) and build with the parameter pointing to your new custom branch in the `RTOOLS_BRANCH` parameter. 
-4. After it builds correctly, you will have generated jobs with the changes you implemented. You can use and modify the generated job. 
+3. Go to seed job for the job you wanna test (usually you would use [`_dsl_test`](https://build.osrfoundation.org/job/_dsl_test/) to not affect the jobs in production) and build with the parameter pointing to your new custom branch in the `RTOOLS_BRANCH` parameter.
+4. After it builds correctly, you will have generated jobs with the changes you implemented. You can use and modify the generated job.
 
-> WARNING! : Running the _dsl job for a specific job that it's not `test` will modify the configuration for production. You should always aim to utilize `test` jobs. 
+> WARNING! : Running the _dsl job for a specific job that it's not `test` will modify the configuration for production. You should always aim to utilize `test` jobs.
 
-## :arrow_forward: Playbook
+### :arrow_forward: Playbook
 
-### XML injection into DSL 
+#### XML injection into DSL
 How to deal with plugins that do not implement the DSL layer and don't provide a DSL API?
 
-There is a feature called [configure blocks](https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block) that allows us to represent xml job configs as DSL. [Here](https://github.com/gazebo-tooling/release-tools/blob/9fbfe60133d2b7b8b280b92f7c563dc64c8367a5/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy#LL83C1-L92C10) is an example of it's usage with the retryBuild plugin, where `checkRegexp(true)` gets converted into `<checkRegexp>true</checkRegexp>` and the  hierarchy of the definition is respected, so `checkRegexp` exists as a child of `com.chikli.hudson.plugin.naginator.NaginatorPublisher` in the XML definition.
+There is a feature called [configure blocks](https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block) that allows us to represent xml job configs as DSL. [Here](https://github.com/gazebo-tooling/release-tools/blob/9fbfe60133d2b7b8b280b92f7c563dc64c8367a5/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy#LL83C1-L92C10) is an example of its usage with the retryBuild plugin, where `checkRegexp(true)` gets converted into `<checkRegexp>true</checkRegexp>` and the hierarchy of the definition is respected, so `checkRegexp` exists as a child of `com.chikli.hudson.plugin.naginator.NaginatorPublisher` in the XML definition.
 
-To check what are the corresponding names for the XML tags you can refer to the plugin documentation or as an alternative you can manually modify the job to add the information you want and then go to `https://build.osrfoundation.com/job/myjob/config.xml` and match the XML there in the DSL config. 
+To check what are the corresponding names for the XML tags you can refer to the plugin documentation or as an alternative you can manually modify the job to add the information you want and then go to `https://build.osrfoundation.com/job/myjob/config.xml` and match the XML there in the DSL config.

--- a/jenkins-scripts/README.md
+++ b/jenkins-scripts/README.md
@@ -8,7 +8,7 @@ The release-tools repository uses the [DSL Jenkins plugin](https://plugins.jenki
 
 The `local_build.bat` script is used to reproduce Jenkins builds for Windows, specifically supporting Pixi builds.
 
-#### Running the script
+### Running the script
 
 To run the script, use the following command:
 
@@ -16,7 +16,7 @@ To run the script, use the following command:
 local_build.bat <jenkins-bat-script> <gz-sources> [build_mode]
 ```
 
-#### Arguments
+### Arguments
 
 - `jenkins-bat-script`: The script to run from the files in release-tools/jenkins-scripts/gz_*.bat
 - `sources`: Local checkout of the gazebo library sources
@@ -25,7 +25,7 @@ local_build.bat <jenkins-bat-script> <gz-sources> [build_mode]
   - `1`: Only run the compilation, reuse the Pixi build environment created in mode 0
          (be sure of run it first).
 
-#### Example 
+### Example
 
 Use case: reproducing a gz-math pull request for the branch my-testing-branch.
 
@@ -45,7 +45,27 @@ with the `build_mode` 1 enabled to re-use the environment prepared with external
 local_build.bat gz_math-default-devel-windows-amd64.bat C:\Users\foo\code\gz-math 1
 ```
 
-#### Aditional notes
+The script will also generate a `.debug_last_build.bat` file that will source the generated Pixi
+enviroment and the colcon `install.bat` and leave the user in the colcon workspace root inside
+%TMP%. This allows direct debugging without the need to run anything more than colcon and edit
+the code in the colcon workspace.
+
+```bat
+local_build.bat gz_math-default-devel-windows-amd64.bat C:\Users\foo\code\gz-math 1
+call .debug_last_build.bat
+:: ignore errors related to vs2019 if using other version of MSVC
+C:\Users\josel\AppData\Local\Temp\12853\ws> colcon list
+ gz-cmake4       ws\src\gz-cmake (ros.cmake)
+ gz-plugin3      gz-plugin       (ros.cmake)
+ gz-plugin3      ws\src\gz-plugin        (ros.cmake)
+ gz-tools2       ws\src\gz-tools (ros.cmake)
+ gz-utils3       ws\src\gz-utils (ros.cmake)
+ ...
+:: edit code in C:\Users\josel\AppData\Local\Temp\12853\ws\src\gz-sim
+C:\Users\josel\AppData\Local\Temp\12853\ws> colcon build --packages-select gz-sim9
+```
+
+### Aditional notes
 
 - The number of building threads can be customized by setting the `MAKE_JOBS` variable inside the
   `local_setup.bat` script. It defaults to 8.

--- a/jenkins-scripts/README.md
+++ b/jenkins-scripts/README.md
@@ -4,7 +4,51 @@ The release-tools repository uses the [DSL Jenkins plugin](https://plugins.jenki
 
 ## Conda local builder for Windows
 
-TODO
+### Usage of `local_build.bat`
+
+The `local_build.bat` script is used to reproduce Jenkins builds for Windows, specifically supporting Pixi builds.
+
+#### Running the script
+
+To run the script, use the following command:
+
+```bat
+local_build.bat <jenkins-bat-script> <gz-sources> [build_mode]
+```
+
+#### Arguments
+
+- `jenkins-bat-script`: The script to run from the files in release-tools/jenkins-scripts/gz_*.bat
+- `sources`: Local checkout of the gazebo library sources
+- `build_mode` (optional): Specifies the build mode.
+  - `0`: Build all the steps (default, first execution).
+  - `1`: Only run the compilation, reuse the Pixi build environment created in mode 0
+         (be sure of run it first).
+
+#### Example 
+
+Use case: reproducing a gz-math pull request for the branch my-testing-branch.
+
+```bat
+git clone -b my-testing-branch C:\Users\foo\code\gz-math
+local_build.bat gz_math-default-devel-windows-amd64.bat C:\Users\foo\code\gz-math
+```
+
+This command will run `gz_math-default-devel-windows-amd64.bat ` using the sources from `C:\User\foo\code\gz-math`. It will handle the installation of all the system dependencies
+using Pixi (it can take up to 10 minutes) and build all the Gazebo dependencies from source
+using colcon. In a second build it builds gz-math with tests using colcon.
+
+When finishes, you can do modifications in C:\Users\foo\code\gz-math and re-run the script
+with the `build_mode` 1 enabled to re-use the environment prepared with external dependencies.
+
+```bat
+local_build.bat gz_math-default-devel-windows-amd64.bat C:\Users\foo\code\gz-math 1
+```
+
+#### Aditional notes
+
+- The number of building threads can be customized by setting the `MAKE_JOBS` variable inside the
+  `local_setup.bat` script. It defaults to 8.
 
 ## DSL related
 

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -30,22 +30,6 @@ set LOCAL_WS_SOFTWARE_DIR=%LOCAL_WS_SRC%\%VCS_DIRECTORY%
 @if "%COLCON_AUTO_MAJOR_VERSION%" == "" set COLCON_AUTO_MAJOR_VERSION=false
 @if "%CONDA_ENV_NAME%" == "" set CONDA_ENV_NAME=legacy
 
-setlocal ENABLEDELAYEDEXPANSION
-if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
-   for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i
-   set COLCON_PACKAGE=%COLCON_PACKAGE%!PKG_MAJOR_VERSION!
-   echo "MAJOR_VERSION detected: !PKG_MAJOR_VERSION!"
-)
-
-setlocal ENABLEDELAYEDEXPANSION
-if not defined GAZEBODISTRO_FILE (
-  for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i
-  if errorlevel 1 exit 1
-  set GAZEBODISTRO_FILE=%VCS_DIRECTORY%!PKG_MAJOR_VERSION!.yaml
-) else (
-  echo Using user defined GAZEBODISTRO_FILE: %GAZEBODISTRO_FILE%
-)
-
 :: safety checks
 if not defined VCS_DIRECTORY (
   echo # BEGIN SECTION: ERROR: VCS_DIRECTORY is not set
@@ -119,6 +103,23 @@ if not defined KEEP_WORKSPACE (
 mkdir %LOCAL_WS%
 mkdir %LOCAL_WS_SRC%
 echo # END SECTION
+
+:: Check if package is in colcon workspace
+setlocal ENABLEDELAYEDEXPANSION
+if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
+   for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i
+   set COLCON_PACKAGE=%COLCON_PACKAGE%!PKG_MAJOR_VERSION!
+   echo "MAJOR_VERSION detected: !PKG_MAJOR_VERSION!"
+)
+
+setlocal ENABLEDELAYEDEXPANSION
+if not defined GAZEBODISTRO_FILE (
+  for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i
+  if errorlevel 1 exit 1
+  set GAZEBODISTRO_FILE=%VCS_DIRECTORY%!PKG_MAJOR_VERSION!.yaml
+) else (
+  echo Using user defined GAZEBODISTRO_FILE: %GAZEBODISTRO_FILE%
+)
 
 echo # BEGIN SECTION: get open robotics deps (%GAZEBODISTRO_FILE%) sources into the workspace
 call %win_lib% :get_source_from_gazebodistro %GAZEBODISTRO_FILE% %LOCAL_WS_SRC% || goto :error

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -48,10 +48,11 @@ if not exist %WORKSPACE%\%VCS_DIRECTORY% (
 if "%GPU_SUPPORT_NEEDED%" == "true" (
   echo # BEGIN SECTION: dxdiag info
   set DXDIAG_FILE=%WORKSPACE%\dxdiag.txt
-  dxdiag /t !DXDIAG_FILE!
-  type !DXDIAG_FILE!
-  echo Checking for correct NVIDIA GPU support !DXDIAG_FILE!
-  findstr /C:"Manufacturer: NVIDIA" !DXDIAG_FILE!
+  dxdiag /t %DXDIAG_FILE%%
+  :: if errorlevel 1 ( dxdiag \t !DXDIAG_FILE!)
+  type %DXDIAG_FILE%
+  echo Checking for correct NVIDIA GPU support %DXDIAG_FILE%
+  findstr /C:"Manufacturer: NVIDIA" %DXDIAG_FILE%
   if errorlevel 1 (
     echo ERROR: NVIDIA GPU not found in dxdiag
     goto :error

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -242,13 +242,19 @@ goto :EOF
 :: instead use the hook and execute them in the current shell
 set LIB_DIR="%~dp0"
 call %LIB_DIR%\windows_env_vars.bat
+set HOOK_FILE=%PIXI_PROJECT_PATH%\hooks.bat
 
 pushd %PIXI_PROJECT_PATH%
-call %win_lib% :pixi_cmd shell-hook --locked > hooks.bat
-type hooks.bat
-call hooks.bat
+echo Running pixi %~1 %~2
+%PIXI_TMP% shell-hook --locked > %HOOK_FILE%
+if errorlevel 1 exit %EXTRA_EXIT_PARAM% 1
+type %HOOK_FILE%
+call %HOOK_FILE%
 :: ERRORS in hooks will make the build to fail. Be permissive
 :: if errorlevel 1 exit %EXTRA_EXIT_PARAM% EXTRA_exit %EXTRA_EXIT_PARAM%_PARAM 1
+if %DBG_LAST_BUILD_FILE% neq "" (
+  echo call %HOOK_FILE% >> %DBG_LAST_BUILD_FILE%  
+)
 popd
 goto :EOF
 

--- a/jenkins-scripts/local_build.bat
+++ b/jenkins-scripts/local_build.bat
@@ -1,3 +1,4 @@
+@echo off
 :: Trigger local builds for windows builds. Only support Pixi builds
 set SCRIPT_DIR=%~dp0
 
@@ -16,6 +17,17 @@ if "%~2"=="" (
     exit /b 1
 )
 
+if not exist "%1" (
+    echo "Script %1 does not exist"
+    exit /b 1
+)
+
+:: check that visual studio vcvarsall.bat has been called
+if not defined VSCMD_ARG_TGT_ARCH (
+    echo "Visual Studio environment not set. Please run vcvarsall.bat"
+    exit /b 1
+)
+
 set "build_mode=0"
 if not "%~3"=="" (
     set "build_mode=%~3"
@@ -24,16 +36,16 @@ if not "%~3"=="" (
 set "WORKSPACE=%TMP%\%RANDOM%"
 set "SRC_DIRECTORY=%~2"
 :: Only work with PIXI
-set "USE_PIXI=1"
 :: KEEP_WORKSPACE should help with debugging and re-run the compilation only
 set "KEEP_WORKSPACE=1"
 :: Avoid closing the whole terminal
 set "EXTRA_EXIT_PARAM=/b"
 
 set "DBG_LAST_BUILD_FILE=%SCRIPT_DIR%\.debug_last_build.bat"
+if exist %DBG_LAST_BUILD_FILE% ( del %DBG_LAST_BUILD_FILE% )
 
 mkdir "%WORKSPACE%"
-xcopy "%SRC_DIRECTORY%\*" "%WORKSPACE%\%~nx2" /s /e /i /Y >> log
+xcopy "%SRC_DIRECTORY%\*" "%WORKSPACE%\%~nx2" /s /e /i /Y > nul
 
 echo "USING BUILD_MODE=%build_mode%"
 if "%build_mode%"=="0" (
@@ -46,6 +58,7 @@ if "%build_mode%"=="0" (
 )
 
 call "%~1"
+
 @echo off
 if errorlevel 1 (
     echo "Local build failed"

--- a/jenkins-scripts/local_build.bat
+++ b/jenkins-scripts/local_build.bat
@@ -1,0 +1,69 @@
+:: Trigger local builds for windows builds. Only support Pixi builds
+set SCRIPT_DIR=%~dp0
+
+:: Customize the number of building threads. A value is needed
+set "MAKE_JOBS=8"
+
+if "%~2"=="" (
+    echo "Usage: local_build.bat <script> <sources> [build_mode]"
+    echo.
+    echo "Arguments:"
+    echo "  script      The script to run"
+    echo "  sources     Local checkout of sources directory"
+    echo "  build_mode  Build mode (optional):"
+    echo "              0 - Build all the steps (default)"
+    echo "              1 - Only run the compilation, reuse build environment (useful for testing code changes)"
+    exit /b 1
+)
+
+set "build_mode=0"
+if not "%~3"=="" (
+    set "build_mode=%~3"
+)
+
+set "WORKSPACE=%TMP%\%RANDOM%"
+set "SRC_DIRECTORY=%~2"
+:: Only work with PIXI
+set "USE_PIXI=1"
+:: KEEP_WORKSPACE should help with debugging and re-run the compilation only
+set "KEEP_WORKSPACE=1"
+:: Avoid closing the whole terminal
+set "EXTRA_EXIT_PARAM=/b"
+
+set "DBG_LAST_BUILD_FILE=%SCRIPT_DIR%\.debug_last_build.bat"
+
+mkdir "%WORKSPACE%"
+xcopy "%SRC_DIRECTORY%\*" "%WORKSPACE%\%~nx2" /s /e /i /Y >> log
+
+echo "USING BUILD_MODE=%build_mode%"
+if "%build_mode%"=="0" (
+    set "REUSE_PIXI_INSTALLATION="   
+) else if "%build_mode%"=="1" (
+    set "REUSE_PIXI_INSTALLATION=1"
+) else (
+    echo "Value invalid for build_mode: %build_mode%"
+    exit /b 1
+)
+
+call "%~1"
+@echo off
+if errorlevel 1 (
+    echo "Local build failed"
+    echo " ERROR: %errorlevel%"
+
+    if "%LOCAL_WS%"=="" (
+        echo "LOCAL_WS is not set. Internal script error."
+        exit /b 1
+    )
+) else (
+    echo "Local build finished successfully"
+)
+:: Construct the DBG_LAST_BUILD_FILE to reproduce the last build
+:: source the setup.bat file and log into the directory
+echo call %LOCAL_WS%\install\setup.bat >> %DBG_LAST_BUILD_FILE%
+echo cd %LOCAL_WS% >> %DBG_LAST_BUILD_FILE%
+
+echo   - Build root is %WORKSPACE%
+echo   - Build workspace is %LOCAL_WS%
+echo Reproduce the conditions of the last build
+echo   - by running call %DBG_LAST_BUILD_FILE%


### PR DESCRIPTION
The PR adds a `local_build.bat` command that can run the `gz_foo-*-.bat` scripts locally to reproduce the commands done in Jenkins.  The `README.md` file contains detailed instructions about how to use the tool.

The script injects a temporary workspace to imitate the Jenkins directory and handles other required variables. The script uses as input a source code directory of one of the gz libraries and the corresponding script from the jenkins-scripts/*.bat files. Usage is easy:

```
local_build.bat <jenkins-bat-script> <gz-sources> [build_mode]
``` 

**Arguments:**

- `jenkins-bat-script`: The script to run from the files in release-tools/jenkins-scripts/gz_*.bat
- `sources`: Local checkout of the gazebo library sources
- `build_mode` (optional): Specifies the build mode.
  - `0`: Build all the steps (default, first execution).
  - `1`: Only run the compilation, reuse the Pixi build environment created in mode 0
         (be sure of run it first).

The tool can be tested (please follow the README.md documentation) but I would like to reduce the changes to the libraries used and split them in separate PRs before this is ready to merge.