### PR TITLE
Fix pixi hooks run: do not use call with windows redirection

### DIFF
--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -242,13 +242,14 @@ goto :EOF
 :: instead use the hook and execute them in the current shell
 set LIB_DIR="%~dp0"
 call %LIB_DIR%\windows_env_vars.bat
+set HOOK_FILE=%PIXI_PROJECT_PATH%\hooks.bat
 
 pushd %PIXI_PROJECT_PATH%
-call %win_lib% :pixi_cmd shell-hook --locked > hooks.bat
-type hooks.bat
-call hooks.bat
+echo Running pixi %~1 %~2
+%PIXI_TMP% shell-hook --locked > %HOOK_FILE%
 :: ERRORS in hooks will make the build to fail. Be permissive
-:: if errorlevel 1 exit %EXTRA_EXIT_PARAM% EXTRA_exit %EXTRA_EXIT_PARAM%_PARAM 1
+type %HOOK_FILE%
+call %HOOK_FILE%
 popd
 goto :EOF
 


### PR DESCRIPTION
To activate the pixi enviroment in our Jenkins the best way I found was to use the `shell-hook` command to create a .bat file that we can "call". For doing it the current code uses the `call %win_lib% :pixi_cmd ... > hooks.bat`. This is making that many of the scripts code ended up in the .bat file and it is generating random commands.

The PR changes the call to use directly the pixi executable. This generates a clear execution.


