### PR TITLE
Replace tj-actions by pure git code

### DIFF
--- a/.github/workflows/ci-pixi.yaml
+++ b/.github/workflows/ci-pixi.yaml
@@ -17,7 +17,9 @@ jobs:
         fetch-depth: 0
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f  # v45.0.6
+      run: |
+        echo "ALL_CHANGED_FILES=$(git diff --name-only -r ${{ github.base_ref }} HEAD | xargs)" >> $GITHUB_ENV
+        echo $ALL_CHANGED_FILES
     - name: List all changed files
       id: changed-toml-files
       env:

--- a/.github/workflows/ci-pixi.yaml
+++ b/.github/workflows/ci-pixi.yaml
@@ -17,9 +17,8 @@ jobs:
         fetch-depth: 0
     - name: Get changed files
       id: changed-files
-      run: |
-        echo "ALL_CHANGED_FILES=$(git diff --name-only -r ${{ github.base_ref }} HEAD | xargs)" >> $GITHUB_ENV
-        echo $ALL_CHANGED_FILES
+      run: |      
+        echo "ALL_CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}... | tr '\n' ' ')" >> $GITHUB_ENV        
     - name: List all changed files
       id: changed-toml-files
       env:


### PR DESCRIPTION
Answering the security issue https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/.

