### PR TITLE
Run the -pr-win stub jobs in all branches

### DIFF
--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -485,7 +485,7 @@ branch_index.each { lib_name, distro_configs ->
         OSRFWinCompilationAnyGitHub.create(gz_win_ci_any_old_job,
                                             "gazebosim/${lib_name}",
                                             DISABLE_TESTING,
-                                            branch_names,
+                                            GITHUB_SUPPORT_ALL_BRANCHES,
                                             ENABLE_GITHUB_PR_INTEGRATION,
                                             DISABLE_CMAKE_WARNS)
         gz_win_ci_any_old_job.with


### PR DESCRIPTION
There is a problem with the `-pr-win` old jobs that are now a stub that should return always green. Affecting this: https://github.com/gazebosim/gz-transport/pull/590

The bug is that it only reacts to the branches that are using new `-pr-clowin` that leaves out the good old Fortress (and the previously removed Citadel).

The code is affected since it generates the same job twice, one with the first Windows configuration `-pr-clwin` and the other one with `-pr-clowin` that overrides the first one. This way the fortress branches configuration is being overriding by the rest of the branches configuration.

A nice fix is not trivial to implement but I think that we can force the stub to operate in all branches without bad side effects.