### PR TITLE
Windows: fix whitespace in versionless package names

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -147,7 +147,7 @@ colcon list --names-only | find "!COLCON_PACKAGE!" > nul 2>&1
 if errorlevel 1 (
   echo # END SECTION
   echo # BEGIN SECTION: try package name !COLCON_PACKAGE_ORIGINAL! without major version
-  set COLCON_PACKAGE=!COLCON_PACKAGE_ORIGINAL! > nul 2>&1
+  set COLCON_PACKAGE=!COLCON_PACKAGE_ORIGINAL!
 )
 colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (


### PR DESCRIPTION
Follow up to #1246.

## Failed build using 14491fd0

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-pr-clowin&build=297)](https://build.osrfoundation.org/job/gz_sim-pr-clowin/297/) https://build.osrfoundation.org/job/gz_sim-pr-clowin/297/

~~~
Update package gz-sim  from gz to ignition
~~~

## Test build with this branch

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-pr-clowin&build=299)](https://build.osrfoundation.org/job/gz_sim-pr-clowin/299/) https://build.osrfoundation.org/job/gz_sim-pr-clowin/299/