### PR TITLE
Retry jobs failed that have another brew update process

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
@@ -38,9 +38,15 @@ class OSRFBase
           }
         }
 
-        // Create the naginator retry tag
+        // Create the naginator retry tags
         HelperRetryFailures.create(job, [
           regexpForRerun: "java.nio.channels.ClosedChannelException",
+          checkRegexp: true,
+          maxSchedule: 1
+        ])
+
+        HelperRetryFailures.create(job, [
+          regexpForRerun: "Error: Another `brew update` process is already running.",
           checkRegexp: true,
           maxSchedule: 1
         ])


### PR DESCRIPTION
Jobs that fail with error: `Error: Another ``brew update`` process is already running.` (e.g., https://build.osrfoundation.org/job/gz_sensors-ci-ign-sensors6-homebrew-amd64/123/console), can be retriggered safely