### PR TITLE
Replace changed-files action by custom code

### DIFF
--- a/.github/workflows/ci-pixi.yaml
+++ b/.github/workflows/ci-pixi.yaml
@@ -1,9 +1,9 @@
 name: Conda env testing
 
 on:
-  push:
-    paths:
-      - 'conda/envs/**'
+  # Code only works on pull_request events
+  # support push to work on pull_request is not trivial
+  pull_request:
 
 jobs:
   detection:
@@ -15,10 +15,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Get changed files
+    - name: Detect changed files
+      shell: bash
       id: changed-files
-      run: |      
-        echo "ALL_CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}... | tr '\n' ' ')" >> $GITHUB_ENV        
+      run: |
+        # Only works on pull_request events
+        ALL_CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr '\n' ' ')
+        echo "Detected changed files: $ALL_CHANGED_FILES"
+        echo "all_changed_files=$ALL_CHANGED_FILES" >> $GITHUB_OUTPUT
     - name: List all changed files
       id: changed-toml-files
       env:
@@ -33,7 +37,7 @@ jobs:
         ALL_TOML_FILES=${ALL_TOML_FILES# }
         echo "All TOML files: ${ALL_TOML_FILES}"
         JSON_ALL_TOML="{ \"toml_file\": $(echo [\"$(sed 's/ /","/g' <<< ${ALL_TOML_FILES})\"])}"
-        echo "::set-output name=toml_file::$JSON_ALL_TOML"
+        echo "toml_file=${JSON_ALL_TOML}" >> $GITHUB_OUTPUT
   pixi_builder:
     name: Pixi builder
     needs: detection

--- a/.github/workflows/ci-pixi.yaml
+++ b/.github/workflows/ci-pixi.yaml
@@ -34,6 +34,11 @@ jobs:
             ALL_TOML_FILES="$ALL_TOML_FILES $file"
           fi
         done
+        if [[ -z $ALL_TOML_FILES ]]; then
+          echo "No TOML files changed"
+          echo "toml_file=[]" >> $GITHUB_OUTPUT
+          exit 0
+        fi
         ALL_TOML_FILES=${ALL_TOML_FILES# }
         echo "All TOML files: ${ALL_TOML_FILES}"
         JSON_ALL_TOML="{ \"toml_file\": $(echo [\"$(sed 's/ /","/g' <<< ${ALL_TOML_FILES})\"])}"
@@ -42,6 +47,7 @@ jobs:
     name: Pixi builder
     needs: detection
     runs-on: ubuntu-latest
+    if: ${{ needs.detection.outputs.toml_file != '[]' }}
     strategy:
       matrix: ${{ fromJSON(needs.detection.outputs.toml_file) }}
     steps:

--- a/conda/envs/legacy/pixi.toml
+++ b/conda/envs/legacy/pixi.toml
@@ -57,3 +57,4 @@ cmake = "3.28.3.*"
 colcon-common-extensions = "*"
 pkg-config = "*"
 vcstool = "*"
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,5 @@ install_requires =
     argcomplete >= 1.8.0
     
 packages = find:
+
+


### PR DESCRIPTION
Replace the current code based on push + external github action to use pull_request.

The current detection code should filter the changes without toml files so it can operate on all pull request open. The machinery necessary to make the push event to work properly on github pull request is not trivial (hence the github external action) but I think that we can live with this running only pull requests.

Used for testing in #1286 