### PR TITLE
Do not allow infinite number of builds. Set base at 75 builds

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
@@ -7,6 +7,7 @@ import javaposse.jobdsl.dsl.Job
 
   Implements:
      - description
+     - keep only 75 builds
      - RTOOLS parame + groovy to set jobDescription
      - base mail for Failures and Unstables
 */
@@ -20,6 +21,10 @@ class OSRFBase
      job.with
      {
      	description 'Automatic generated job by DSL jenkins. Please do not edit manually'
+
+        logRotator {
+          numToKeep(75)
+        }
 
         parameters {
           stringParam('RTOOLS_BRANCH','master','release-tool branch to use')

--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -102,6 +102,14 @@ if [[ -n ${avoid_infinite_build_archive} ]]; then
   exit 1
 fi
 
+avoid_infinite_build_archive_no_setup=$(grep -L '<numToKeep>' -- *.xml || true)
+if [[ -n ${avoid_infinite_build_archive_no_setup} ]]; then
+  echo "Found a job setup to keep infinite number of builds. This is BAD"
+  echo "${avoid_infinite_build_archive_no_setup}"
+  exit 1
+fi
+
+
 check_tag_without_platforms()
 {
   tag=${1}

--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -102,13 +102,13 @@ if [[ -n ${avoid_infinite_build_archive} ]]; then
   exit 1
 fi
 
-avoid_infinite_build_archive_no_setup=$(grep -L '<numToKeep>' -- *.xml || true)
+# <project> is the XML tags for jobs. Views are fine without having a numToKeep
+avoid_infinite_build_archive_no_setup=$(grep -l '<project>' -- *.xml | xargs grep -L '<numToKeep>')
 if [[ -n ${avoid_infinite_build_archive_no_setup} ]]; then
   echo "Found a job setup to keep infinite number of builds. This is BAD"
   echo "${avoid_infinite_build_archive_no_setup}"
   exit 1
 fi
-
 
 check_tag_without_platforms()
 {

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -190,4 +190,8 @@ def test_dummy_job = job("_test_dummy_callable")
 OSRFCredentials.allowOsrfbuildToRunTheBuild(test_dummy_job)
 test_dummy_job.with {
   label Globals.nontest_label("docker")
+
+  logRotator {
+    numToKeep(25)
+  }
 }


### PR DESCRIPTION
Just detected that core.dsl jobs run without a limit in the number of builds. Modifying the Base class in DSL so almost all jobs are covered by at least 75 build limit.

Add a check to the CI to avoid next cases in the future.