### PR TITLE
Set ASAN_OPTIONS in build.sh used by docker

### DIFF
--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -5,6 +5,7 @@
 #  - GENERIC_ENABLE_TIMING (optional) [default true]
 #  - GENERIC_ENABLE_CPPCHECK (optional) [default true] run cppcheck
 #  - GENERIC_ENABLE_TESTS (optional) [default true] run tests
+#  - ASAN_OPTIONS (optional) extra asan options
 #  - BUILDING_EXTRA_CMAKE_PARAMS (optional) extra cmake params
 #  - BUILDING_EXTRA_MAKETEST_PARAMS (optional) extra "make test ARGS=" params
 #  - BUILD_<lib name> (optional) build dependency from source, for example, BUILD_GZ_MATH
@@ -92,6 +93,7 @@ echo '# END SECTION'
 if $GENERIC_ENABLE_TESTS; then
   echo '# BEGIN SECTION: running tests'
   init_stopwatch TEST
+  export ASAN_OPTIONS=\${ASAN_OPTIONS:+\$ASAN_OPTIONS:}${ASAN_OPTIONS}
   mkdir -p \$HOME
   make test ARGS="-VV ${BUILDING_EXTRA_MAKETEST_PARAMS} --output-junit cmake_junit_output.xml" || true
   if [ -f cmake_junit_output.xml ]; then


### PR DESCRIPTION
The asan CI builds configured in [gazebo_libs.dsl's generate_asan_ci_job method](https://github.com/gazebo-tooling/release-tools/blob/9b9f9b8550671f095ce89e6b85060e79df40e7c8/jenkins-scripts/dsl/gazebo_libs.dsl#L150C6-L150C26) set the `ASAN_OPTIONS` environment variable on the host machine, but the variable is not passed into the docker container's build script, so it has no effect. This pull request passes it into the generated build.sh script.

To test, I copied  [example code to generate an initialization-order-fiasco bug](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleInitOrderFiasco) into the gz-math Angle_TEST in https://github.com/gazebosim/gz-math/pull/671. I manually reconfigured the [jenkins noble ci-pr_any job](https://build.osrfoundation.org/job/gz_math-ci-pr_any-noble-amd64/) to include the following lines (copied from the [gz_math-ci_asan-gz-math8-noble-amd64](https://build.osrfoundation.org/view/gz-ionic/job/gz_math-ci_asan-gz-math8-noble-amd64) job configuration):

~~~
export ASAN_OPTIONS=check_initialization_order=true:strict_init_order=true
export BUILDING_EXTRA_CMAKE_PARAMS="-DGZ_SANITIZER=Address"
~~~

I then triggered the job using the release-tools master branch and this branch. Both jobs are unstable due to [compiler warnings on gz-math8](https://build.osrfoundation.org/view/gz-ionic/job/gz_math-ci_asan-gz-math8-noble-amd64/59/gcc/), but the Angle_TEST only failed with this branch:

* [Angle_TEST passes with release-tools master branch](https://build.osrfoundation.org/job/gz_math-ci-pr_any-noble-amd64/184/testReport/(root)/AngleTest/)
* [Angle_TEST fails with initialization-order-fiasco bug with this branch](https://build.osrfoundation.org/job/gz_math-ci-pr_any-noble-amd64/185/testReport/junit/(root)/UNIT_Angle_TEST/test_ran/) as expected