### PR TITLE
Use new pixi version 0.44.0

### DIFF
--- a/.github/workflows/ci-pixi.yaml
+++ b/.github/workflows/ci-pixi.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: Install dependencies using pixi on ${{ matrix.toml_file }}
         uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659  # v0.8.1
         with:
+          pixi-version: v0.44.0
           locked: true
           cache: false  # 10Gb limit might be too low for caching
           manifest-path: ${{ matrix.toml_file }}

--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -1,4 +1,4 @@
-set "PIXI_VERSION=0.30.0"
+set "PIXI_VERSION=0.44.0"
 set "PIXI_URL=https://github.com/prefix-dev/pixi/releases/download/v%PIXI_VERSION%/pixi-x86_64-pc-windows-msvc.exe"
 set "PIXI_PROJECT_PATH=%TMP%\pixi\project"
 set "PIXI_TMPDIR=%TMP%\pixi"


### PR DESCRIPTION
There are problems with the pixi lock format when running modern pixi versions locally. The PR bumps the use of pixi to 0.44.0. 