### PR TITLE
Remove -pr-win stub jobs

### DIFF
--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -477,21 +477,6 @@ branch_index.each { lib_name, distro_configs ->
         add_brew_shell_build_step(gz_brew_ci_any_job, lib_name, ws_checkout_dir)
       } else if (ci_config.system.so == 'windows') {
         distro_sort_name = get_windows_distro_sortname(ci_config)
-        // TODO(j-rivero): remove the stub jobs
-        // generating a job that always return true and do nothing
-        def gz_win_ci_any_old_job_name = "${gz_job_name_prefix}-pr-win"
-        def gz_win_ci_any_old_job = job(gz_win_ci_any_old_job_name)
-        Globals.gazebodistro_branch = true
-        OSRFWinCompilationAnyGitHub.create(gz_win_ci_any_old_job,
-                                            "gazebosim/${lib_name}",
-                                            DISABLE_TESTING,
-                                            GITHUB_SUPPORT_ALL_BRANCHES,
-                                            ENABLE_GITHUB_PR_INTEGRATION,
-                                            DISABLE_CMAKE_WARNS)
-        gz_win_ci_any_old_job.with
-        {
-          description('Stub job: check new -pr-c*win jobs')
-        }
         Globals.gazebodistro_branch = false
         def gz_win_ci_any_job_name = "${gz_job_name_prefix}-pr-${distro_sort_name}win"
         def gz_win_ci_any_job = job(gz_win_ci_any_job_name)


### PR DESCRIPTION
The `-pr-win` jobs were removed during the transition to Conda. The stub to report green has been running for some weeks now to give time to the PRs to update to the new jobs while not being blocked by previous failures in these -pr-win jobs. Might a be a good time to remove them so they are not reporting useless CI in new builds.