### PR TITLE
Remove python calls from gz_*.bat scripts. Move MAJOR_VERSION to use lib/colcon-default-windows.bat

### DIFF
--- a/jenkins-scripts/gz_common-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/gz_common-default-devel-windows-amd64.bat
@@ -4,8 +4,6 @@ if not defined VCS_DIRECTORY set VCS_DIRECTORY=gz-common
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set GZ_MAJOR_VERSION=%%i
-
 set COLCON_PACKAGE=gz-common
 set COLCON_AUTO_MAJOR_VERSION=true
 

--- a/jenkins-scripts/gz_tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/gz_tools-default-devel-windows-amd64.bat
@@ -5,35 +5,6 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 set COLCON_PACKAGE=gz-tools
-
-:: override logic @ colcon-default-devel-windows.bat to handle ign-tools1 case on windows
-setlocal ENABLEDELAYEDEXPANSION
-for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i
-echo "MAJOR_VERSION detected: !PKG_MAJOR_VERSION!"
-if "!PKG_MAJOR_VERSION!" == "1" (
-   set COLCON_PACKAGE=%COLCON_PACKAGE%
-) else (
-   set COLCON_PACKAGE=%COLCON_PACKAGE%!PKG_MAJOR_VERSION!
-)
-
-echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
-echo Packages in workspace:
-colcon list --names-only
-
-colcon list --names-only | find "!COLCON_PACKAGE!"
-if errorlevel 1 (
-  set COLCON_PACKAGE=!COLCON_PACKAGE:gz=ignition!
-  set COLCON_PACKAGE=!COLCON_PACKAGE:sim=gazebo!
-)
-colcon list --names-only | find "!COLCON_PACKAGE!"
-if errorlevel 1 (
-  echo Failed to find package !COLCON_PACKAGE! in workspace.
-  goto :error
-)
-echo Using package name !COLCON_PACKAGE!
-echo # END SECTION
-
-
-set COLCON_AUTO_MAJOR_VERSION=false
+set COLCON_AUTO_MAJOR_VERSION=true
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -153,10 +153,17 @@ colcon list --names-only | find "!COLCON_PACKAGE!"
 if errorlevel 1 (
   echo # END SECTION
   echo # BEGIN SECTION: Update package !COLCON_PACKAGE! from gz to ignition
-  :: REQUIRED for Gazebo Fortress
+  :: REQUIRED for Gazebo Fortress  
+  :: Special case for gz-tools version 1 to endup being ignition-tools
+  if "!COLCON_PACKAGE!" == "gz-tools" (
+    if "!PKG_MAJOR_VERSION!" == "1" (
+      set COLCON_PACKAGE=ignition-tools
+    )
+  ) else (
   set COLCON_PACKAGE=%COLCON_PACKAGE%!PKG_MAJOR_VERSION!
   set COLCON_PACKAGE=!COLCON_PACKAGE:gz=ignition!
   set COLCON_PACKAGE=!COLCON_PACKAGE:sim=gazebo!
+  )
 )
 colcon list --names-only | find "!COLCON_PACKAGE!" > nul 2>&1
 if errorlevel 1 (

--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -8,15 +8,7 @@ set IGN_CLEAN_WORKSPACE=true
 
 set DEPEN_PKGS="libxml2 tinyxml2"
 
-for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set SDFORMAT_MAJOR_VERSION=%%i
+set COLCON_PACKAGE=sdformat
+set COLCON_AUTO_MAJOR_VERSION=true
 
-if %SDFORMAT_MAJOR_VERSION% GEQ 10 (
-  set COLCON_PACKAGE=sdformat
-  set COLCON_AUTO_MAJOR_VERSION=true
-  call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"
-) else if %SDFORMAT_MAJOR_VERSION% GEQ 6 (
-  call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"
-) else (
-  echo "Ancient version of sdformat is not supported %SDFORMAT_MAJOR_VERSION%"
-  exit 1
-)
+call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"


### PR DESCRIPTION
When provisioning the new agents for Windows, I think that we can remove the host dependency on Python just by removing some leftovers in the gz_*-default-devel-windows-amd64.bat scripts. The only important piece is ignition-tools from Fortress that implements a logic needed. I moved it to the base lib in c349937d582039c6ae20723d1d7406ef1cb6efbd.

This should leave us with non python base dependency for Agents in buildfarm and user local systems since all the operations with python are done AFTER the pixi environment is created.

Doing some tests in the testing buildarm:
 * gz-common6 is fine [![Build Status](https://citest.build.osrfoundation.org/buildStatus/icon?job=gz_common-6-cnlwin&build=3)](https://citest.build.osrfoundation.org/job/gz_common-6-cnlwin/3/)
 * ign-tools1 in fortress: [![Build Status](https://citest.build.osrfoundation.org/view/gz-fortress/job/gz_tools-ign-tools1-clwin/4/badge/icon)](https://citest.build.osrfoundation.org/view/gz-fortress/job/gz_tools-ign-tools1-clwin/4/)
 * sdformat15 is fine [![Build Status](https://citest.build.osrfoundation.org/buildStatus/icon?job=sdformat-sdf15-clowin&build=8)](https://citest.build.osrfoundation.org/view/gz-ionic/job/sdformat-sdf15-clowin/8/)