### PR TITLE
Source ros distro setup file if needed

### DIFF
--- a/jenkins-scripts/docker/gz_transport-compilation.bash
+++ b/jenkins-scripts/docker/gz_transport-compilation.bash
@@ -33,7 +33,10 @@ if [[ ${GZ_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
 fi
 
 if [[ ${GZ_TRANSPORT_MAJOR_VERSION} -ge 15 ]]; then
-  export ROS_DISTRO="jazzy"
+  # gz-transport version >= 15 will use zenoh_cpp_vendor package from ROS 2
+  # repo for zenoh support. Setting this env var will set up ROS env with the
+  # specified ROS distro in the generated build.sh script.
+  export ROS_DISTRO_SETUP_NEEDED="jazzy"
 fi
 
 export GZDEV_PROJECT_NAME="gz-transport${GZ_TRANSPORT_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/gz_transport-compilation.bash
+++ b/jenkins-scripts/docker/gz_transport-compilation.bash
@@ -32,6 +32,10 @@ if [[ ${GZ_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
   export NEED_C17_COMPILER=true
 fi
 
+if [[ ${GZ_TRANSPORT_MAJOR_VERSION} -ge 15 ]]; then
+  export ROS_DISTRO="jazzy"
+fi
+
 export GZDEV_PROJECT_NAME="gz-transport${GZ_TRANSPORT_MAJOR_VERSION}"
 
 . "${SCRIPT_DIR}/lib/generic-building-base.bash"

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -73,7 +73,8 @@ done
 if [[ -n ${ROS_DISTRO} ]]; then
 cat >> build.sh << DELIM_ROS_DISTRO_SETUP
 echo '# BEGIN SECTION: sourcing ros setup script'
-if [ -f /opt/ros/${ROS_DISTRO}/setup.sh ]; then
+if [ -f /opt/ros/${ROS_DISTRO}/setup.bash]; then
+  export ROS_DISTRO=${ROS_DISTRO}
   echo "sourcing ros ${ROS_DISTRO} setup script"
   source /opt/ros/${ROS_DISTRO}/setup.bash
 else

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -70,12 +70,26 @@ DELIM_BUILD_DEPS
   fi
 done
 
+if [[ -n ${ROS_DISTRO} ]]; then
+cat >> build.sh << DELIM_ROS_DISTRO_SETUP
+echo '# BEGIN SECTION: sourcing ros setup script'
+if [ -f /opt/ros/${ROS_DISTRO}/setup.sh ]; then
+  echo "sourcing ros ${ROS_DISTRO} setup script"
+  source /opt/ros/${ROS_DISTRO}/setup.bash
+else
+  echo "ros ${ROS_DISTRO} setup script not found"
+fi
+echo '# END SECTION'
+DELIM_ROS_DISTRO_SETUP
+fi
+
 cat >> build.sh << DELIM
 echo '# BEGIN SECTION: configure'
 # Step 2: configure and build
 cd $WORKSPACE
 [[ ! -d $WORKSPACE/build ]] && mkdir -p $WORKSPACE/build
 cd $WORKSPACE/build
+
 cmake $WORKSPACE/${SOFTWARE_DIR} ${BUILDING_EXTRA_CMAKE_PARAMS} \
     -DCMAKE_INSTALL_PREFIX=/usr
 echo '# END SECTION'

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -70,8 +70,10 @@ DELIM_BUILD_DEPS
   fi
 done
 
-# Set up ROS env. This is needed by gz-transport versions >= 15 so that
-# it can find ROS 2's zenoh_cpp_vendor package that is installed in
+# Minimal ROS env setup for finding ROS packages.
+# We don't need a full ROS env setup for building ROS packages or running
+# ROS tests. The ROS setup here is needed by gz-transport versions >= 15
+# so that  it can find ROS 2's zenoh_cpp_vendor package that is installed in
 # /opt/ros/<ROS_DISTRO>.
 # See jenkins-scripts/docker/gz_transport-compilation.bash
 if [[ -n ${ROS_DISTRO_SETUP_NEEDED} ]]; then

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -79,12 +79,11 @@ done
 if [[ -n ${ROS_DISTRO_SETUP_NEEDED} ]]; then
 cat >> build.sh << DELIM_ROS_DISTRO_SETUP
 echo '# BEGIN SECTION: sourcing ros setup script'
-if [ -f /opt/ros/${ROS_DISTRO}/setup.bash ]; then
-  export ROS_DISTRO=${ROS_DISTRO}
-  echo "Sourcing ros ${ROS_DISTRO} setup script"
-  source /opt/ros/${ROS_DISTRO}/setup.bash
+if [ -f /opt/ros/${ROS_DISTRO_SETUP_NEEDED}/setup.bash ]; then
+  source /opt/ros/${ROS_DISTRO_SETUP_NEEDED}/setup.bash
 else
-  echo "ros ${ROS_DISTRO} setup script not found"
+  echo "ROS_DISTRO_SETUP_NEEDED set to ${ROS_DISTRO_SETUP_NEEDED} but no ROS 2 installation found"
+  exit 1
 fi
 echo '# END SECTION'
 DELIM_ROS_DISTRO_SETUP

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -73,7 +73,7 @@ done
 if [[ -n ${ROS_DISTRO} ]]; then
 cat >> build.sh << DELIM_ROS_DISTRO_SETUP
 echo '# BEGIN SECTION: sourcing ros setup script'
-if [ -f /opt/ros/${ROS_DISTRO}/setup.bash]; then
+if [ -f /opt/ros/${ROS_DISTRO}/setup.bash ]; then
   export ROS_DISTRO=${ROS_DISTRO}
   echo "sourcing ros ${ROS_DISTRO} setup script"
   source /opt/ros/${ROS_DISTRO}/setup.bash

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -70,12 +70,16 @@ DELIM_BUILD_DEPS
   fi
 done
 
-if [[ -n ${ROS_DISTRO} ]]; then
+# Set up ROS env. This is needed by gz-transport versions >= 15 so that
+# it can find ROS 2's zenoh_cpp_vendor package that is installed in
+# /opt/ros/<ROS_DISTRO>.
+# See jenkins-scripts/docker/gz_transport-compilation.bash
+if [[ -n ${ROS_DISTRO_SETUP_NEEDED} ]]; then
 cat >> build.sh << DELIM_ROS_DISTRO_SETUP
 echo '# BEGIN SECTION: sourcing ros setup script'
 if [ -f /opt/ros/${ROS_DISTRO}/setup.bash ]; then
   export ROS_DISTRO=${ROS_DISTRO}
-  echo "sourcing ros ${ROS_DISTRO} setup script"
+  echo "Sourcing ros ${ROS_DISTRO} setup script"
   source /opt/ros/${ROS_DISTRO}/setup.bash
 else
   echo "ros ${ROS_DISTRO} setup script not found"


### PR DESCRIPTION
gz-transport15 depends on ros2 repo's `ros-jazzy-zenoh-cpp-vendor` package. We need to source the ros setup.bash script to find this package