### PR TITLE
Bump gz-cmake and others in Jetty

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -278,45 +278,45 @@ collections:
   - name: 'jetty'
     libs:
       - name: gz-cmake
-        major_version: 4
+        major_version: 5
         repo:
-          current_branch: gz-cmake4
+          current_branch: main
       - name: gz-tools
         major_version: 2
         repo:
           current_branch: gz-tools2
       - name: gz-utils
-        major_version: 3
+        major_version: 4
         repo:
-          current_branch: gz-utils3
+          current_branch: main
       - name: gz-math
-        major_version: 8
-        repo:
-          current_branch: gz-math8
-      - name: gz-plugin
-        major_version: 3
-        repo:
-          current_branch: gz-plugin3
-      - name: gz-common
-        major_version: 6
-        repo:
-          current_branch: gz-common6
-      - name: gz-msgs
-        major_version: 11
-        repo:
-          current_branch: gz-msgs11
-      - name: gz-rendering
         major_version: 9
         repo:
-          current_branch: gz-rendering9
-      - name: sdformat
-        major_version: 15
+          current_branch: main
+      - name: gz-plugin
+        major_version: 4
         repo:
-          current_branch: sdf15
-      - name: gz-fuel-tools
+          current_branch: main
+      - name: gz-common
+        major_version: 7
+        repo:
+          current_branch: main
+      - name: gz-msgs
+        major_version: 12
+        repo:
+          current_branch: main
+      - name: gz-rendering
         major_version: 10
         repo:
-          current_branch: gz-fuel-tools10
+          current_branch: main
+      - name: sdformat
+        major_version: 16
+        repo:
+          current_branch: main
+      - name: gz-fuel-tools
+        major_version: 11
+        repo:
+          current_branch: main
       - name: gz-transport
         major_version: 15
         repo:
@@ -330,9 +330,9 @@ collections:
         repo:
           current_branch: main
       - name: gz-physics
-        major_version: 8
+        major_version: 9
         repo:
-          current_branch: gz-physics8
+          current_branch: main
       - name: gz-sim
         major_version: 10
         repo:


### PR DESCRIPTION
Update gz-collections.yaml metadata with version bumps.

Part of https://github.com/gazebo-tooling/release-tools/issues/1309.