### PR TITLE
brew: check gz-cmake, gz-utils for cmake warnings

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -570,7 +570,6 @@ ci_configs:
         - gz-jetty
         - __upcoming__
     cmake_warnings_disabled:
-      - gz-cmake
       - gz-common
       - gz-fuel-tools
       - gz-sim
@@ -583,7 +582,6 @@ ci_configs:
       - gz-sensors
       - gz-tools
       - gz-transport
-      - gz-utils
       - sdformat
     ci_categories_enabled:
       - pr


### PR DESCRIPTION
There are currently no cmake warnings for gz-cmake or gz-utils on brew, so enable checking for these warnings.