### PR TITLE
Support for ROS 2 Kilted in release.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -28,7 +28,8 @@ GENERIC_BREW_PULLREQUEST_JOB = 'generic-release-homebrew_pull_request_updater'
 LINUX_DISTROS = ['ubuntu', 'debian']
 SUPPORTED_ARCHS = ['amd64', 'armhf', 'arm64']
 RELEASEPY_NO_ARCH_PREFIX = '.releasepy_NO_ARCH_'
-ROS_VENDOR = {'harmonic': 'jazzy', 'ionic': 'rolling'}
+ROS_VENDOR = {'harmonic': ['jazzy'],
+              'ionic': ['kilted', 'rolling']}
 
 OSRF_REPOS_SUPPORTED = "stable prerelease nightly testing none"
 
@@ -811,12 +812,12 @@ def process_ros_vendor_package(args):
     for collection in get_collections_for_package(args.package,
                                                   args.version):
         if collection in ROS_VENDOR:
-            ros_distro = ROS_VENDOR[collection]
-            print(f" * Github {get_vendor_github_repo(args.package)} "
-                  f"part of {collection} in ROS 2 {ros_distro}")
-            print("   + Preparing a PR: ", end='', flush=True)
-            pr_url = create_pr_in_gz_vendor_repo(args, ros_distro)
-            print(pr_url)
+            for ros_distro in ROS_VENDOR[collection]:
+                print(f" * Github {get_vendor_github_repo(args.package)} "
+                      f"part of {collection} in ROS 2 {ros_distro}")
+                print("   + Preparing a PR: ", end='', flush=True)
+                pr_url = create_pr_in_gz_vendor_repo(args, ros_distro)
+                print(pr_url)
 
 
 def go(argv):


### PR DESCRIPTION
Add kilted as a supported ROS 2 distribution linked to Gazebo Ionic.

Needed to change code a little bit to support more than one ROS 2 release per Gazebo collection.

Before using the code, we need to prepare the ROS vendor repositories with a branch named `kilted` or otherwise the script will fail:

```
ROS vendor packages that can be updated:
 * Github gazebo-release/gz_transport_vendor part of ionic in ROS 2 kilted
   + Preparing a PR: WARNING: Skipping /usr/lib/python3.12/dist-packages/pybind11-2.11.1.dist-info due to invalid metadata entry 'name'
WARNING: Skipping /usr/lib/python3.12/dist-packages/pybind11-2.11.1.dist-info due to invalid metadata entry 'name'
Error running command (git clone -q -b kilted https://github.com/gazebo-release/gz_transport_vendor /tmp/tmpl77x8ya8/gz_vendor_repo).
stdout: 
stderr: fatal: Remote branch kilted not found in upstream origin
```