### PR TITLE
Include a gazebodistro to vendor repos vcs script

### DIFF
--- a/release-repo-scripts/README.md
+++ b/release-repo-scripts/README.md
@@ -73,12 +73,13 @@ git clone https://github.com/gz-release/gz-rendering7-release
 cd gz-rendering7-release
 ./path/to/release-tools/release-repo-scripts/changelog_spawn.sh 7.1.0-1
 ```
+
 ### convert_gazebodistro_to_release.py
 
 Convert a gazebodistro file into a vcs compatible file with the -release repositories
 associated to the repositories in the input file.
 
-### Usage
+#### Usage
 
 Output will printed to stdout:
 
@@ -86,7 +87,7 @@ Output will printed to stdout:
 ./path/to/release-tools/release-repo-scripts/convert_gazebodistro_to_release.py <gazbodistro_file>
 ```
 
-### Example
+#### Example
 
 To import all release repositories related to gz Harmonic collection:
 
@@ -94,6 +95,31 @@ To import all release repositories related to gz Harmonic collection:
 ./path/to/release-tools/release-repo-scripts/convert_gazebodistro_to_release.py ~/code/gazebodistro/collection-harmonic.yaml  > collection-harmonic-release.yaml
 vcs import < collection-harmonic-release.yaml
 ```
+
+### convert_gazebodistro_to_release_ros_vendor.py
+
+Convert a gazebodistro file into a vcs compatible file with the Gazebo ROS vendor
+repositories related to the repositories in the input file. These vendor
+repositories follow the naming convention of `package_name_vendor`. The default
+branch to set in the vcs new file is `rolling`.
+
+#### Usage
+
+Output will be printed to stdout:
+
+```bash
+./path/to/release-tools/release-repo-scripts/convert_gazebodistro_to_release_ros_vendor.py <gazebodistro_file>
+```
+
+#### Example
+
+To import all ROS vendor repositories related to gz Ionic collection:
+
+```bash
+./path/to/release-tools/release-repo-scripts/convert_gazebodistro_to_release_ros_vendor.py ~/code/gazebodistro/collection-ionic.yaml > collection-ionic-vendor.yaml
+vcs import < collection-ionic-vendor.yaml
+
+
 
 ### new_ubuntu_distribution.bash
 

--- a/release-repo-scripts/convert_gazebodistro_to_release_ros_vendor.py
+++ b/release-repo-scripts/convert_gazebodistro_to_release_ros_vendor.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+import argparse
+import sys
+
+import yaml
+
+def _load_gazebodistro_file(filepath) -> dict:
+    with open(filepath, 'r') as file:
+        gazebodistro = yaml.load(file, Loader=yaml.FullLoader)
+
+    return gazebodistro
+
+
+def _convert_to_release(input_yaml) -> None:
+    repos = {}
+    for repo, repo_info in input_yaml['repositories'].items():
+        repo_name = f'{repo.replace('-','_')}_vendor'
+        repos[repo_name] = {'type': repo_info['type'],
+                            'url': f'https://github.com/gazebo-release/{repo_name}',
+                            'version': 'rolling'}
+    repos = {'repositories': repos}
+    yaml.dump(repos, sys.stdout)
+
+
+def _init_argparse() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        usage='%(prog)s GAZEBODISTRO_FILE',
+        description='Transform gazebodistro files into vcs files for release repos'
+    )
+    parser.add_argument('input_file', nargs=1, type=str)
+    return parser
+
+
+def main() -> None:
+    """Convert gazebodistro files into vcs files for release repositories of Gazebo/ROS vendor in the input file."""
+    parser = _init_argparse()
+    args = parser.parse_args()
+    input_yaml = _load_gazebodistro_file(args.input_file[0])
+    _convert_to_release(input_yaml)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add an script to get a compatible vcs file for Gazebo ROS vendor repositories with the input of a gazebodistro file.

