### PR TITLE
Do not exit if ROS is not found when building gz-transport15

### DIFF
--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -83,7 +83,6 @@ if [ -f /opt/ros/${ROS_DISTRO_SETUP_NEEDED}/setup.bash ]; then
   source /opt/ros/${ROS_DISTRO_SETUP_NEEDED}/setup.bash
 else
   echo "ROS_DISTRO_SETUP_NEEDED set to ${ROS_DISTRO_SETUP_NEEDED} but no ROS 2 installation found"
-  exit 1
 fi
 echo '# END SECTION'
 DELIM_ROS_DISTRO_SETUP


### PR DESCRIPTION
https://github.com/gazebo-tooling/release-tools/pull/1311 made ROS setup a requirement when building gz-transport15. That  's needed for the zenoh work being done in the `zenoh_main` branch in gz-transport. However, we are not ready to merge those changes back to the `main` branch yet so temporarily commenting out the exit logic if ROS is not found. This is so that we can continue building and testing `main` for now.

Test build

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-pr_any-noble-amd64&build=156)](https://build.osrfoundation.org/job/gz_transport-ci-pr_any-noble-amd64/156/) 