### PR TITLE
DSL: change PostBuildSCript from native to configure block

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
@@ -30,17 +30,21 @@ class OSRFLinuxBuildPkgBase
 
       publishers
       {
-        postBuildScripts {
-          steps {
-            shell("""\
-              #!/bin/bash -xe
-
-              [[ -d \${WORKSPACE}/pkgs ]] && sudo chown -R jenkins \${WORKSPACE}/pkgs
-              """.stripIndent())
+        // This creates a post-build script that changes ownership of pkgs directory to jenkins user
+        // Runs regardless of build success or failure
+        configure { project ->
+          project / 'publishers' / 'org.jenkinsci.plugins.postbuildscript.PostBuildScript' << {
+            buildSteps {
+              'hudson.tasks.Shell' {
+                command("""
+                  #!/bin/bash -xe
+                  [[ -d \${WORKSPACE}/pkgs ]] && sudo chown -R jenkins \${WORKSPACE}/pkgs""")
+              }
+            }
+            scriptOnlyIfSuccess('false')
+            scriptOnlyIfFailure('false')
+            markBuildUnstable('false')
           }
-
-          onlyIfBuildSucceeds(false)
-          onlyIfBuildFails(false)
         }
 
         archiveArtifacts('pkgs/*')

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -140,38 +140,68 @@ class OSRFSourceCreation
     job.with
     {
       publishers {
-        postBuildScripts {
-          steps {
-            conditionalSteps {
-             condition {
-              not {
-                expression('none|None|^$','${ENV,var="UPLOAD_TO_REPO"}')
-                }
-              }
-              steps {
-                // Invoke repository_uploader
-                downstreamParameterized {
-                  trigger(repository_uploader_jobname) {
-                    parameters {
-                      currentBuild()
-                      predefinedProps([PROJECT_NAME_TO_COPY_ARTIFACTS: '${JOB_NAME}',
-                                       PACKAGE_ALIAS: '${PACKAGE_ALIAS}',
-                                       S3_UPLOAD_PATH: "${Globals.s3_releases_dir(package_name)}/"])  // relative path with a final /
-                      propertiesFile(properties_file)  // S3_FILES_TO_UPLOAD
+        // This creates a post-build script that conditionally triggers downstream jobs
+        // (repository uploader and release.py) only when UPLOAD_TO_REPO is not 'none', 'None', or empty
+        configure { project ->
+          project / 'publishers' / 'org.jenkinsci.plugins.postbuildscript.PostBuildScript' << {
+            buildSteps {
+              'org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder' {
+                runner(class: 'org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail')
+                conditionalbuilders {
+                  'hudson.plugins.parameterizedtrigger.TriggerBuilder' {
+                    configs {
+                      'hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig' {
+                        projects(repository_uploader_jobname)
+                        condition('ALWAYS')
+                        triggerWithNoParameters('false')
+                        configs {
+                          'hudson.plugins.parameterizedtrigger.CurrentBuildParameters'()
+                          'hudson.plugins.parameterizedtrigger.FileBuildParameters' {
+                            propertiesFile(properties_file)
+                            failTriggerOnMissing('false')
+                          }
+                          'hudson.plugins.parameterizedtrigger.PredefinedBuildParameters' {
+                            properties("""
+                              PROJECT_NAME_TO_COPY_ARTIFACTS=\${JOB_NAME}
+                              PACKAGE_ALIAS=\${PACKAGE_ALIAS}
+                              S3_UPLOAD_PATH=${Globals.s3_releases_dir(package_name)}
+                              """)
+                          }
+                        }
+                      }
+                    }
+                  }
+                  'hudson.plugins.parameterizedtrigger.TriggerBuilder' {
+                    configs {
+                      'hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig' {
+                        projects(releasepy_jobname)
+                        condition('ALWAYS')
+                        triggerWithNoParameters('false')
+                        configs {
+                          'hudson.plugins.parameterizedtrigger.CurrentBuildParameters'()
+                          'hudson.plugins.parameterizedtrigger.FileBuildParameters' {
+                            propertiesFile(properties_file)
+                            failTriggerOnMissing('false')
+                          }
+                          'hudson.plugins.parameterizedtrigger.PredefinedBuildParameters' {
+                            properties('PROJECT_NAME_TO_COPY_ARTIFACTS=${JOB_NAME}')
+                          }
+                        }
+                      }
                     }
                   }
                 }
-                downstreamParameterized {
-                  trigger(releasepy_jobname) {
-                    parameters {
-                      currentBuild()
-                      predefinedProps([PROJECT_NAME_TO_COPY_ARTIFACTS: "\${JOB_NAME}"])
-                      propertiesFile(properties_file) // SOURCE_TARBALL_URI
-                    }
+                runCondition(class: 'org.jenkins_ci.plugins.run_condition.logic.Not') {
+                  condition(class: 'org.jenkins_ci.plugins.run_condition.core.ExpressionCondition') {
+                    expression('none|None|^$')
+                    delegate.label('${ENV,var="UPLOAD_TO_REPO"}')
                   }
                 }
               }
             }
+            scriptOnlyIfSuccess('true')
+            scriptOnlyIfFailure('false')
+            markBuildUnstable('false')
           }
         }
       }

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -39,46 +39,61 @@ class OSRFUNIXBase extends OSRFBase
              """.stripIndent())
       }
       publishers {
-        postBuildScripts {
-          steps{
-            conditionalSteps {
-              condition {
-                expression("(.)* gpu-nvidia (.)*",'${NODE_LABELS}')
-              }
-              steps {
-                systemGroovyCommand('''\
-                  import hudson.model.Cause.UpstreamCause;
-                  import hudson.model.*;
+        configure { project ->
+          project / 'publishers' / 'org.jenkinsci.plugins.postbuildscript.PostBuildScript' << {
+            buildSteps {
+              'org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder' {
+                runner(class: 'org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail')
+                conditionalbuilders {
+                  'hudson.plugins.groovy.SystemGroovy' {
+                    bindings()
+                    source(class: 'hudson.plugins.groovy.StringSystemScriptSource') {
+                      script {
+                        script('''\
+import hudson.model.Cause.UpstreamCause;
+import hudson.model.*;
 
-                  def node = build.getBuiltOn()
-                  def old_labels = node.getLabelString()
+def node = build.getBuiltOn()
+def old_labels = node.getLabelString()
 
-                  println("Checking if nvidia mismatch error is present in log")
-                  if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
-                    println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any automatic recovery steps")
-                    return 1;
-                  } else {
-                    println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
-                    try {
-                      println(" PROBLEM: NVIDIA driver/library version mismatch was detected in the log. Try to automatically resolve it:")
-                      println("Removing labels and adding 'recovery-process' label to node")
-                      node.setLabelString("recovery-process")
-                    } catch (Exception ex) {
-                      println("ERROR - CANNOT PERFORM RECOVERY ACTIONS FOR NVIDIA ERROR")
-                      println("Restoring to previous state")
-                      node.setLabelString(old_labels)
-                      throw ex
+println("Checking if nvidia mismatch error is present in log")
+if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
+  println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any automatic recovery steps")
+  return 1;
+} else {
+  println("# BEGIN SECTION: NVIDIA MISMATCH RECOVERY")
+  try {
+    println(" PROBLEM: NVIDIA driver/library version mismatch was detected in the log. Try to automatically resolve it:")
+    println("Removing labels and adding 'recovery-process' label to node")
+    node.setLabelString("recovery-process")
+  } catch (Exception ex) {
+    println("ERROR - CANNOT PERFORM RECOVERY ACTIONS FOR NVIDIA ERROR")
+    println("Restoring to previous state")
+    node.setLabelString(old_labels)
+    throw ex
+  }
+  println("# END SECTION: NVIDIA MISMATCH RECOVERY")
+}
+''')
+                        sandbox('false')
+                        classpath()
+                      }
                     }
-                    println("# END SECTION: NVIDIA MISMATCH RECOVERY")
                   }
-                  '''.stripIndent()
-                )
-                shell("""sudo shutdown -r +1""")
+                  'hudson.tasks.Shell' {
+                    command('sudo shutdown -r +1')
+                  }
+                }
+                runCondition(class: 'org.jenkins_ci.plugins.run_condition.core.ExpressionCondition') {
+                  expression('(.)* gpu-nvidia (.)*')
+                  delegate.label('${NODE_LABELS}')
+                }
               }
             }
+            scriptOnlyIfSuccess('false')
+            scriptOnlyIfFailure('true')
+            markBuildUnstable('false')
           }
-          onlyIfBuildSucceeds(false)
-          onlyIfBuildFails(true)
         }
       }
     }

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -133,18 +133,20 @@ gbp_repo_debbuilds.each { software ->
         }
       }
 
-      postBuildScripts {
-        steps {
-          shell("""\
-                #!/bin/bash -xe
-
-                sudo chown -R jenkins \${WORKSPACE}/pkgs
-                """.stripIndent())
+      configure { project ->
+          project / 'publishers' / 'org.jenkinsci.plugins.postbuildscript.PostBuildScript' << {
+            buildSteps {
+              'hudson.tasks.Shell' {
+                command("""
+                  #!/bin/bash -xe
+                  [[ -d \${WORKSPACE}/pkgs ]] && sudo chown -R jenkins \${WORKSPACE}/pkgs""")
+              }
+            }
+            scriptOnlyIfSuccess('false')
+            scriptOnlyIfFailure('false')
+            markBuildUnstable('false')
+          }
         }
-
-        onlyIfBuildSucceeds(false)
-        onlyIfBuildFails(false)
-      }
     }
   }
 }


### PR DESCRIPTION
The PR replaces the use of native postBuild DSL to use the configure block instead. This is related to #1322 and it is caused because the postBulild plugin does not support native DSL anymore starting with version 3.0.0.

We lost a bit of readability but we prevent the whole lost of all the local XML configuration, the CI implementation and a good bunch of QA tests which is a no go.