### PR TITLE
OSRFLinuxBuildPkg dsl: use sh syntax

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
@@ -37,8 +37,7 @@ class OSRFLinuxBuildPkgBase
             buildSteps {
               'hudson.tasks.Shell' {
                 command("""
-                  #!/bin/bash -xe
-                  [[ -d \${WORKSPACE}/pkgs ]] && sudo chown -R jenkins \${WORKSPACE}/pkgs""")
+                  [ -d \${WORKSPACE}/pkgs ] && sudo chown -R jenkins \${WORKSPACE}/pkgs""")
               }
             }
             scriptOnlyIfSuccess('false')


### PR DESCRIPTION
Try to fix debbuilds (follow up to https://github.com/gazebo-tooling/release-tools/pull/1327#issuecomment-2954284977) by replacing `[[` / `]]` with `[` / `]` for compatibility with `sh`.