### PR TITLE
Update DSL generation: modern Jenkins and Java versions

### DIFF
--- a/.github/workflows/ci-dsl.yaml
+++ b/.github/workflows/ci-dsl.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - name: Download and setup job dsl jar
         run: ./jenkins-scripts/dsl/tools/setup_local_generation.bash
       - name: Generate XML files

--- a/jenkins-scripts/dsl/tools/setup_local_generation.bash
+++ b/jenkins-scripts/dsl/tools/setup_local_generation.bash
@@ -3,20 +3,36 @@ set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-SNAKEYAML_PATH="lib/snakeyaml.jar"
-JOB_DSL_VER="1.77"
-
+# JOB_DSL_VER="1.77"
 pushd "${SCRIPT_DIR}" >/dev/null
+
 echo " * Download job-dsl-core jar"
-curl -sSL https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/job-dsl-core/${JOB_DSL_VER}/job-dsl-core-${JOB_DSL_VER}-standalone.jar -o jobdsl.jar
+# Restore with fixed in master branch
+# curl -sSL https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/job-dsl-core/${JOB_DSL_VER}/job-dsl-core-${JOB_DSL_VER}-standalone.jar -o jobdsl.jar
+curl -sSL https://github.com/j-rivero/job-dsl-plugin/releases/download/job-dsl-1.85-pr-1577/job-dsl-core-1.85-pr-1577-jar-with-dependencies.jar \
+  -o job-dsl-core-jar-with-dependencies.jar
 echo " * Download snakeyaml jar"
-# need to inject the yaml module into the jar file. lib subdir is needed to ineject into
-# tar in the right place.
-mkdir -p lib
-curl -sSL https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.32/snakeyaml-1.32.jar -o ${SNAKEYAML_PATH}
-echo " * Inject snakeyaml in job-dsl-core jar"
-jar uf jobdsl.jar ${SNAKEYAML_PATH}
-rm -fr ${SNAKEYAML_PATH}
-rmdir lib
+curl -sSL https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar -o snakeyaml-2.0.jar
+echo " * Inject snakeyaml in job-dsl-core jar and rebuild"
+
+rm -fr dsl-core-jar && mkdir dsl-core-jar
+pushd dsl-core-jar > /dev/null
+jar -xf ../job-dsl-core-jar-with-dependencies.jar
+popd > /dev/null
+
+rm -fr snake-jar && mkdir snake-jar
+pushd snake-jar > /dev/null
+jar -xf ../snakeyaml-2.0.jar
+popd > /dev/null
+
+cp -a snake-jar/org dsl-core-jar/
+
+pushd dsl-core-jar > /dev/null
+jar -cfm ../jobdsl.jar META-INF/MANIFEST.MF *
+popd > /dev/null
+
+rm -fr snakeyaml-*.jar
+rm -fr job-dsl-core-jar-with-dependencies*.jar
+
 echo " >> Run 'java -jar ${PWD}/jobdsl.jar <file.dsl>' to generate locally the Jenkins XML config"
 popd >/dev/null


### PR DESCRIPTION
This is part of preparations for the 24.04 migration. Closes https://github.com/gazebo-tooling/release-tools/issues/1325.

Mostly resolves the problem of DSL for generation with new versions of Java and new versions of Jenkins. See #1325 for the details and https://github.com/gazebo-tooling/release-tools/pull/1330 for the implementation.