### PR TITLE
Correct path in source uploads after configure block movement

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -161,7 +161,8 @@ class OSRFSourceCreation
                           'hudson.plugins.parameterizedtrigger.PredefinedBuildParameters' {
                             properties("""
                               PROJECT_NAME_TO_COPY_ARTIFACTS=\${JOB_NAME}
-                              PACKAGE_ALIAS=\${PACKAGE_ALIAS}
+                              PACKAGE_ALIAS=\${PACKAGE}
+                              PACKAGE=\${PACKAGE}
                               S3_UPLOAD_PATH=${Globals.s3_releases_dir(package_name)}
                               """)
                           }

--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -6,12 +6,9 @@ import _configs_.Globals
 class OSRFSourceCreation
 {
   static String properties_file = "package_name.prop"
-  static String package_name = ""
 
   static void addParameters(Job job, Map default_params = [:])
   {
-    package_name = default_params.find{ it.key == "PACKAGE"}?.value
-
     job.with
     {
       parameters {
@@ -134,6 +131,7 @@ class OSRFSourceCreation
 
   // Useful to inject testing jobs
   static void call_uploader_and_releasepy(Job job,
+                                          String package_name,
                                           String repository_uploader_jobname,
                                           String releasepy_jobname)
   {

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -574,6 +574,7 @@ pkgconf_per_src_index.each { pkg_src, pkg_src_configs ->
       PACKAGE: pkg_src,
       SOURCE_REPO_URI: "https://github.com/gazebosim/${canonical_lib_name}.git"])
     OSRFSourceCreation.call_uploader_and_releasepy(gz_source_job,
+      canonical_lib_name,
       'repository_uploader_packages',
       '_releasepy')
   }

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -34,6 +34,7 @@ OSRFSourceCreation.create(gz_source_job, [
   SOURCE_REPO_URI: "https://github.com/gazebosim/gz-plugin.git",
   SOURCE_REPO_REF: "gz-plugin2"])
 OSRFSourceCreation.call_uploader_and_releasepy(gz_source_job,
+  'gz-plugin'
   '_test_repository_uploader',
   '_test_releasepy')
 // repository_uploader fake test job


### PR DESCRIPTION
The changes introduced by #1327 have made that all the source upload jobs failed since all them are pointed to `gz-tools`. I think that somehow static class resolution happening of the Groovy Classes is now being resolved for all libs before the value of the package_name variable is calculated so all them get the last of the libraries (alphabetically) `gz-tools`.

Did not find a good way of getting the value from the job parameters so it was easy to pass the library name as a parameter to the DSL function 58a3c4d902f8b854a4f9a42a22bc9d8e07ba4f9b.

I've also injecting the PACKAGE variable for PACKAGE_ALIAS (not being defined anymore) in  ea1bb600800b6003d4f02004478287427f14f013