### PR TITLE
Fix generate_dsls: use file path not code for filenames

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFDslBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFDslBase.groovy
@@ -16,7 +16,7 @@ class OSRFDslBase extends OSRFBase {
 
       steps {
         dsl {
-          text(readFileFromWorkspace(target_dsl_scripts))
+          external(target_dsl_scripts)
           removeAction('DISABLE')
           removeViewAction('DELETE')
         }

--- a/jenkins-scripts/dsl/_configs_/OSRFDslBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFDslBase.groovy
@@ -16,7 +16,7 @@ class OSRFDslBase extends OSRFBase {
 
       steps {
         dsl {
-          text(target_dsl_scripts)
+          text(readFileFromWorkspace(target_dsl_scripts))
           removeAction('DISABLE')
           removeViewAction('DELETE')
         }


### PR DESCRIPTION
Jobs are failing in citest because we are passing the file paths as DSL code to the generate dsl job. The PR change it to ~~read from workspace as suggested by the DSL API~~ `external` as suggested by the API.