### PR TITLE
Add CLEAR_BREW_CACHE jenkins parameter

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFOsXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFOsXBase.groovy
@@ -11,14 +11,18 @@ import _configs_.Globals
 */
 class OSRFOsXBase
 {
-   static void create(Job job)
-   {
-     // UNIX Base
-     OSRFUNIXBase.create(job)
+  static void create(Job job)
+  {
+    // UNIX Base
+    OSRFUNIXBase.create(job)
 
-     job.with
-     {
-         label Globals.nontest_label("osx")
-     }
-   }
+    job.with
+    {
+      label Globals.nontest_label("osx")
+
+      parameters {
+        booleanParam('CLEAR_BREW_CACHE',false,'remove cached brew downloads')
+      }
+    }
+  }
 }

--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -35,6 +35,12 @@ for t in $(HOMEBREW_NO_AUTO_UPDATE=1 \
 done
 ${BREW_BINARY} cleanup --prune-prefix
 
+BREW_CACHE=$(${BREW_BINARY} --cache)
+echo BREW_CACHE=${BREW_CACHE}
+if ${CLEAR_BREW_CACHE}; then
+  rm -rf ${BREW_CACHE}
+fi
+
 pushd $(${BREW_BINARY} --prefix)/Homebrew/Library 2> /dev/null
 git stash && git clean -d -f
 # Need to test if brew installation is still working (use audit cmake to quick check)


### PR DESCRIPTION
Add a parameter for osx builds that allows deleting the contents of `brew --cache`. Currently mac-six is in a bad state:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-ci-main-homebrew-amd64&build=197)](https://build.osrfoundation.org/job/gz_sim-ci-main-homebrew-amd64/197/) https://build.osrfoundation.org/job/gz_sim-ci-main-homebrew-amd64/197/

~~~
==> Downloading https://ghcr.io/v2/homebrew/core/llvm/blobs/sha256:d049d90575f5ca7fc9fff4f5f62c259a3964e0d79baeb51eb48a6ef7d038b16f
Already downloaded: /Users/jenkins/Library/Caches/Homebrew/downloads/f5cc62d9c08daf5f19fe0c86c6969c76bc948655c80b4ed5cba7b529dc1d4112--llvm--20.1.8.ventura.bottle.tar.gz
Error: gz-sim10: SHA256 mismatch
Expected: d049d90575f5ca7fc9fff4f5f62c259a3964e0d79baeb51eb48a6ef7d038b16f
  Actual: 92c71d9c214a852d5feb1671cfd1c8609b497b3eef708dadffc56816ff74b243
    File: /Users/jenkins/Library/Caches/Homebrew/downloads/f5cc62d9c08daf5f19fe0c86c6969c76bc948655c80b4ed5cba7b529dc1d4112--llvm--20.1.8.ventura.bottle.tar.gz
To retry an incomplete download, remove the file above.
~~~