### PR TITLE
Implement --source-tarball-sha256 for release.py

### DIFF
--- a/check_releasepy.bash
+++ b/check_releasepy.bash
@@ -139,6 +139,15 @@ expect_number_of_jobs "${source_tarball_uri_test}" "7"
 expect_param "${source_tarball_uri_test}" "SOURCE_TARBALL_URI=https%3A%2F%2Fgazebosim%2Fgz-foo-1.2.3.tar.gz"
 expect_no_vendor "${source_tarball_uri_test}"
 
+source_tarball_uri_with_sha256_test=$(exec_releasepy_test "--source-tarball-uri https://gazebosim/gz-foo-1.2.3.tar.gz --source-tarball-sha256 abc123def456")
+expect_job_run "${source_tarball_uri_with_sha256_test}" "gz-foo-debbuilder"
+expect_job_run "${source_tarball_uri_with_sha256_test}" "generic-release-homebrew_pull_request_updater"
+expect_job_not_run "${source_tarball_uri_with_sha256_test}" "gz-foo-source"
+expect_number_of_jobs "${source_tarball_uri_with_sha256_test}" "7"
+expect_param "${source_tarball_uri_with_sha256_test}" "SOURCE_TARBALL_URI=https%3A%2F%2Fgazebosim%2Fgz-foo-1.2.3.tar.gz"
+expect_param "${source_tarball_uri_with_sha256_test}" "SOURCE_TARBALL_SHA256=abc123def456"
+expect_no_vendor "${source_tarball_uri_with_sha256_test}"
+
 nightly_test=$(exec_releasepy_test "--nightly-src-branch my-nightly-branch3 --upload-to-repo nightly")
 expect_job_run "${nightly_test}" "gz-foo-debbuilder"
 expect_job_not_run "${nightly_test}" "generic-release-homebrew_pull_request_updater"

--- a/release.py
+++ b/release.py
@@ -122,6 +122,8 @@ A) Generate source: local repository tag + call source job:
 B) Call builders: reuse existing tarball version + call build jobs:
    $ release.py --source-tarball-uri <URL> <package> <version>
    (no call to source job, directly build jobs with tarball URL)
+   # Optionally include SHA256 checksum for verification
+   $ release.py --source-tarball-uri <URL> --source-tarball-sha256 <SHA256> <package> <version>
 
 C) Nightly builds (linux)
    $ release.py --source-repo-existing-ref <git_branch> --upload-to-repo nightly <URL> <package> <version>
@@ -160,6 +162,9 @@ C) Nightly builds (linux)
     parser.add_argument('--source-tarball-uri',
                         dest='source_tarball_uri', default=None,
                         help='Indicate the URL of the sources to grab the release sources from.')  # NOQA
+    parser.add_argument('--source-tarball-sha256',
+                        dest='source_tarball_sha256', default=None,
+                        help='SHA256 checksum of the tarball specified in --source-tarball-uri.')  # NOQA
     parser.add_argument('--upload-to-repo', dest='upload_to_repository', default="stable",
                         help='OSRF repo to upload: stable | prerelease | nightly')
     parser.add_argument('--extra-osrf-repo', dest='extra_repo', default="",
@@ -570,6 +575,8 @@ def generate_source_params(args):
         params['SOURCE_TARBALL_URI'] = args.nightly_branch
     elif args.source_tarball_uri:
         params['SOURCE_TARBALL_URI'] = args.source_tarball_uri
+        if args.source_tarball_sha256:
+            params['SOURCE_TARBALL_SHA256'] = args.source_tarball_sha256
     else:
         params['SOURCE_REPO_URI'] = \
             args.source_repo_uri if args.source_repo_uri else \


### PR DESCRIPTION
As part of implementing a sha256 verification of sources produced by gz-*-source jobs in the gz-*-debbuilders, this PR implements the intermediate step of adding the feature to release.py.

The calling chain is:
```
JOB gz-source -> 
Generates artifact foo.tar.bz
  CALLS:
   --> JOB repository_uploader_packages 
        Upload to S3 the [foo.tar.bz]
   --> JOB _release.py
         Runs release.py  --source-tarball-uri S3://.../foo.bar.bz ... that end up calling the jobs:
        --->JOB gz-*-debbuilder
        --->JOB generic-release-homebrew_pull_request_updater
```

There is support to be made for the Jenkins jobs to pass the parameters around but this first PR allows release.py to call jobs with the optional support of sha256.