### PR TITLE
OSRFSourceCreation: calculate tarball sha256

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -124,8 +124,12 @@ class OSRFSourceCreation
             fi
           fi
 
+          SOURCE_TARBALL_SHA256=\$(shasum --algorithm 256 \${tarball})
+          echo tarball sha256 is \${SOURCE_TARBALL_SHA256}
+
           echo "S3_FILES_TO_UPLOAD=\${tarball}" >> ${properties_file}
           echo "SOURCE_TARBALL_URI=$s3_download_url_basedir/\${tarball}" >> ${properties_file}
+          echo "SOURCE_TARBALL_SHA256=${SOURCE_TARBALL_SHA256}" >> ${properties_file}
           """.stripIndent()
         )
       }


### PR DESCRIPTION
Targeted at #1352, part of passing sha256 values to the debbuild and homebrew_pull_request_updater jobs.