### PR TITLE
Complete sha256 support in release: _releasepy job and -debbuilders

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -67,6 +67,10 @@ else
   wget \$no_check_cert_str --quiet -O orig_tarball $SOURCE_TARBALL_URI || \
     echo rerunning wget without --quiet since it failed && \
     wget \$no_check_cert_str -O orig_tarball $SOURCE_TARBALL_URI
+  # check sha256 if it exists
+  if [ -n "${SOURCE_TARBALL_SHA256}" ]; then
+    echo "${SOURCE_TARBALL_SHA256} orig_tarball" | sha256sum -c
+  fi
   TARBALL_EXT=${SOURCE_TARBALL_URI/*tar./}
   mv orig_tarball $PACKAGE_ALIAS\_$VERSION.orig.tar.\${TARBALL_EXT}
   rm -rf \$REAL_PACKAGE_NAME\-$VERSION

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
@@ -58,6 +58,9 @@ class OSRFLinuxBuildPkg
         stringParam("SOURCE_TARBALL_URI",
                     default_params.find{ it.key == "SOURCE_TARBALL_URI"}?.value,
                     "URL to the tarball containing the package sources")
+        stringParam("SOURCE_TARBALL_SHA256",
+                    default_params.find{ it.key == "SOURCE_TARBALL_SHA256"}?.value,
+                    "(optional) sha256 for SOURCE_TARBALL_URI")
         stringParam("RELEASE_REPO_BRANCH",
                     default_params.find{ it.key == "RELEASE_REPO_BRANCH"}?.value,
                     "Branch from the -release repo to be used")

--- a/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
@@ -29,6 +29,9 @@ class OSRFReleasepy
         stringParam("SOURCE_TARBALL_URI",
                     default_params.find{ it.key == "SOURCE_TARBALL_URI"}?.value,
                     "URL to the tarball containing the package sources")
+        stringParam("SOURCE_TARBALL_SHA256",
+                    default_params.find{ it.key == "SOURCE_TARBALL_SHA256"}?.value,
+                    "sha256 for SOURCE_TARBALL_URI")
         stringParam("RELEASE_REPO_BRANCH",
                     default_params.find{ it.key == "RELEASE_REPO_BRANCH"}?.value,
                     "Branch from the -release repo to be used")
@@ -74,6 +77,7 @@ class OSRFReleasepy
               python3 ./scripts/release.py \${dry_run_str} "\${PACKAGE}" "\${VERSION}" \${extra_osrf_repo} \
                       --auth "\${OSRFBUILD_JENKINS_USER}:\${OSRFBUILD_JENKINS_TOKEN}" \
                       --source-tarball-uri \${SOURCE_TARBALL_URI} \
+                      --source-tarball-sha256 \${SOURCE_TARBALL_SHA256} \
                       --release-repo-branch \${RELEASE_REPO_BRANCH} \
                       --upload-to-repo \${UPLOAD_TO_REPO}
             echo " - done"


### PR DESCRIPTION
The PR complete the sha256 support after #1351 and #1353 .

Two commits to implement:
 * _releasepy job support: not optional since it currently only handle the calls using `--source-tarball-uri` (not nightlies) so all the upstream callers can provide sha256.
 * The other support is for the `OSRFLinuxBuildPkg.groovy` that creates the -debbuilders. In this case it is optional since it needs to deal nightlies that do not provide a `SOURCE_TARBALL_URI` but builds the sources directly in the same build.