### PR TITLE
 Reduce the randomness to make -asan- jobs to work on Noble

### DIFF
--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -156,6 +156,12 @@ if ${NEED_SQUID_WORKAROUND}; then
   sudo service squid-deb-proxy restart
 fi
 
+# Required for asan to work on Noble
+# https://github.com/gazebo-tooling/release-tools/issues/1354
+if [[ ${DISTRO} == 'noble' ]]; then
+  sudo sysctl vm.mmap_rnd_bits=28
+fi
+
 # Docker checking
 # Code imported from https://github.com/CognitiveRobotics/omnimapper/tree/master/docker
 # under the license detailed in https://github.com/CognitiveRobotics/omnimapper/blob/master/LICENSE

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -153,11 +153,6 @@ void generate_asan_ci_job(gz_ci_job, lib_name, branch, ci_config)
                   '-DGZ_SANITIZER=Address',
                   Globals.MAKETEST_SKIP_GZ,
                   'export ASAN_OPTIONS=check_initialization_order=true:strict_init_order=true')
-  // need to figure out what problem we have with logs after migration to 24.04
-  gz_ci_job.with
-  {
-    disabled()
-  }
 }
 
 void add_brew_shell_build_step(gz_brew_ci_job, lib_name, ws_checkout_dir)
@@ -389,6 +384,8 @@ gz_collections_yaml.collections.each { collection ->
             generate_asan_ci_job(gz_ci_asan_job, lib_name, branch_name, ci_config)
             gz_ci_asan_job.with
             {
+              // need to figure out what problem we have with logs after migration to 24.04
+              disabled()
               triggers {
                 scm(Globals.CRON_ON_WEEKEND)
               }


### PR DESCRIPTION
Fixes: #1354 

The PR implements a "fix" in release-tools that really needs to go into the provisioning, see https://github.com/osrf/osrf_jenkins_agent/pull/52.

Tested  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin-ci_asan-main-noble-amd64&build=105)](https://build.osrfoundation.org/view/gz-jetty/job/gz_plugin-ci_asan-main-noble-amd64/105/) 