### PR TITLE
brew_release.dsl: support arm64_sonoma bottles

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Job
 Globals.default_emails = "jrivero@osrfoundation.org, scpeters@osrfoundation.org"
 
 // first distro in list is used as touchstone
-brew_supported_distros         = [ "ventura", "sonoma" ]
+brew_supported_distros         = [ "ventura", "arm64_sonoma", "sonoma" ]
 bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_updater'
 bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1294.

Add `arm64_sonoma` bottle label to `brew_supported_distros`. Merge this once https://build.osrfoundation.org/computer/mac%2Dsix%2Darm.sonoma/ has the label `arm64_sonoma` and we are ready to try building bottles for this architecture.