### PR TITLE
Clear ~/.gz, ~/.ignition with CLEAR_BREW_CACHE

### DIFF
--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -39,6 +39,8 @@ BREW_CACHE=$(${BREW_BINARY} --cache)
 echo BREW_CACHE=${BREW_CACHE}
 if ${CLEAR_BREW_CACHE}; then
   rm -rf ${BREW_CACHE}
+  # also clear ~/.gz and ~/.ignition
+  rm -rf $HOME/.gz $HOME/.ignition
 fi
 
 pushd $(${BREW_BINARY} --prefix)/Homebrew/Library 2> /dev/null


### PR DESCRIPTION
Testing if a bad `~/.gz` folder is the underlying issue for https://github.com/gazebosim/gz-sim/issues/3031.