### PR TITLE
Use stable branch for gz-cmake5

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -280,7 +280,7 @@ collections:
       - name: gz-cmake
         major_version: 5
         repo:
-          current_branch: main
+          current_branch: gz-cmake5
       - name: gz-tools
         major_version: 2
         repo:


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/19