### PR TITLE
gz-jetty: Use stable branch for gz-common7

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -300,7 +300,7 @@ collections:
       - name: gz-common
         major_version: 7
         repo:
-          current_branch: main
+          current_branch: gz-common7
       - name: gz-msgs
         major_version: 12
         repo:

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -63,7 +63,7 @@ asan_ci ionic gz_transport-ci_asan-gz-transport14-noble-amd64
 asan_ci ionic gz_utils-ci_asan-gz-utils3-noble-amd64
 asan_ci ionic sdformat-ci_asan-sdf15-noble-amd64
 asan_ci jetty gz_cmake-ci_asan-gz-cmake5-noble-amd64
-asan_ci jetty gz_common-ci_asan-main-noble-amd64
+asan_ci jetty gz_common-ci_asan-gz-common7-noble-amd64
 asan_ci jetty gz_fuel_tools-ci_asan-main-noble-amd64
 asan_ci jetty gz_gui-ci_asan-main-noble-amd64
 asan_ci jetty gz_launch-ci_asan-main-noble-amd64
@@ -289,9 +289,9 @@ branch_ci ionic sdformat-sdf15-clowin
 branch_ci jetty gz_cmake-5-cnlwin
 branch_ci jetty gz_cmake-ci-gz-cmake5-homebrew-amd64
 branch_ci jetty gz_cmake-ci-gz-cmake5-noble-amd64
-branch_ci jetty gz_common-ci-main-homebrew-amd64
-branch_ci jetty gz_common-ci-main-noble-amd64
-branch_ci jetty gz_common-main-cnlwin
+branch_ci jetty gz_common-7-cnlwin
+branch_ci jetty gz_common-ci-gz-common7-homebrew-amd64
+branch_ci jetty gz_common-ci-gz-common7-noble-amd64
 branch_ci jetty gz_fuel_tools-ci-main-homebrew-amd64
 branch_ci jetty gz_fuel_tools-ci-main-noble-amd64
 branch_ci jetty gz_fuel_tools-main-cnlwin


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/24