### PR TITLE
Fix console error message when finding brew

### DIFF
--- a/jenkins-scripts/lib/_homebrew_path_setup.sh
+++ b/jenkins-scripts/lib/_homebrew_path_setup.sh
@@ -2,7 +2,7 @@
 set -e
 
 # skip logic if brew command is already in the PATH
-if ! brew --prefix; then
+if ! which -s brew; then
 
   echo brew not in PATH, checking standard locations
 


### PR DESCRIPTION
Fixes noisy console message reported in https://github.com/gazebo-tooling/release-tools/pull/1366#issuecomment-3210595440.

Testing with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_gui6-install_bottle-homebrew-amd64&build=616)](https://build.osrfoundation.org/job/gz_gui6-install_bottle-homebrew-amd64/616/) https://build.osrfoundation.org/job/gz_gui6-install_bottle-homebrew-amd64/616/