### PR TITLE
jetty: use gz-math9 stable branch

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -292,7 +292,7 @@ collections:
       - name: gz-math
         major_version: 9
         repo:
-          current_branch: main
+          current_branch: gz-math9
       - name: gz-plugin
         major_version: 4
         repo:

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -67,7 +67,7 @@ asan_ci jetty gz_common-ci_asan-gz-common7-noble-amd64
 asan_ci jetty gz_fuel_tools-ci_asan-main-noble-amd64
 asan_ci jetty gz_gui-ci_asan-main-noble-amd64
 asan_ci jetty gz_launch-ci_asan-main-noble-amd64
-asan_ci jetty gz_math-ci_asan-main-noble-amd64
+asan_ci jetty gz_math-ci_asan-gz-math9-noble-amd64
 asan_ci jetty gz_msgs-ci_asan-main-noble-amd64
 asan_ci jetty gz_physics-ci_asan-main-noble-amd64
 asan_ci jetty gz_plugin-ci_asan-main-noble-amd64
@@ -301,9 +301,9 @@ branch_ci jetty gz_gui-main-cnlwin
 branch_ci jetty gz_launch-ci-main-homebrew-amd64
 branch_ci jetty gz_launch-ci-main-noble-amd64
 branch_ci jetty gz_launch-main-cnlwin
-branch_ci jetty gz_math-ci-main-homebrew-amd64
-branch_ci jetty gz_math-ci-main-noble-amd64
-branch_ci jetty gz_math-main-cnlwin
+branch_ci jetty gz_math-9-cnlwin
+branch_ci jetty gz_math-ci-gz-math9-homebrew-amd64
+branch_ci jetty gz_math-ci-gz-math9-noble-amd64
 branch_ci jetty gz_msgs-ci-main-homebrew-amd64
 branch_ci jetty gz_msgs-ci-main-noble-amd64
 branch_ci jetty gz_msgs-main-cnlwin


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/22.