### PR TITLE
gz-jetty: Use stable branch for gz-gui10

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -324,7 +324,7 @@ collections:
       - name: gz-gui
         major_version: 10
         repo:
-          current_branch: main
+          current_branch: gz-gui10
       - name: gz-sensors
         major_version: 10
         repo:


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/32