### PR TITLE
jetty: use gz-physics9 stable branch

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -332,7 +332,7 @@ collections:
       - name: gz-physics
         major_version: 9
         repo:
-          current_branch: main
+          current_branch: gz-physics9
       - name: gz-sim
         major_version: 10
         repo:

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -69,7 +69,7 @@ asan_ci jetty gz_gui-ci_asan-gz-gui10-noble-amd64
 asan_ci jetty gz_launch-ci_asan-main-noble-amd64
 asan_ci jetty gz_math-ci_asan-gz-math9-noble-amd64
 asan_ci jetty gz_msgs-ci_asan-gz-msgs12-noble-amd64
-asan_ci jetty gz_physics-ci_asan-main-noble-amd64
+asan_ci jetty gz_physics-ci_asan-gz-physics9-noble-amd64
 asan_ci jetty gz_plugin-ci_asan-main-noble-amd64
 asan_ci jetty gz_rendering-ci_asan-gz-rendering10-noble-amd64
 asan_ci jetty gz_sensors-ci_asan-gz-sensors10-noble-amd64
@@ -307,9 +307,9 @@ branch_ci jetty gz_math-ci-gz-math9-noble-amd64
 branch_ci jetty gz_msgs-12-cnlwin
 branch_ci jetty gz_msgs-ci-gz-msgs12-homebrew-amd64
 branch_ci jetty gz_msgs-ci-gz-msgs12-noble-amd64
-branch_ci jetty gz_physics-ci-main-homebrew-amd64
-branch_ci jetty gz_physics-ci-main-noble-amd64
-branch_ci jetty gz_physics-main-cnlwin
+branch_ci jetty gz_physics-9-cnlwin
+branch_ci jetty gz_physics-ci-gz-physics9-homebrew-amd64
+branch_ci jetty gz_physics-ci-gz-physics9-noble-amd64
 branch_ci jetty gz_plugin-ci-main-homebrew-amd64
 branch_ci jetty gz_plugin-ci-main-noble-amd64
 branch_ci jetty gz_plugin-main-cnlwin


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/29.