### PR TITLE
Do not setup ROS distro for gz-transport15

### DIFF
--- a/jenkins-scripts/docker/gz_transport-compilation.bash
+++ b/jenkins-scripts/docker/gz_transport-compilation.bash
@@ -32,13 +32,6 @@ if [[ ${GZ_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
   export NEED_C17_COMPILER=true
 fi
 
-if [[ ${GZ_TRANSPORT_MAJOR_VERSION} -ge 15 ]]; then
-  # gz-transport version >= 15 will use zenoh_cpp_vendor package from ROS 2
-  # repo for zenoh support. Setting this env var will set up ROS env with the
-  # specified ROS distro in the generated build.sh script.
-  export ROS_DISTRO_SETUP_NEEDED="jazzy"
-fi
-
 export GZDEV_PROJECT_NAME="gz-transport${GZ_TRANSPORT_MAJOR_VERSION}"
 
 . "${SCRIPT_DIR}/lib/generic-building-base.bash"


### PR DESCRIPTION
It was previously added to get `zenoh-cpp-vendor` packages from ROS repo. This is no longer needed as the zenoh packages have been imported to packages.osrfoundation.org. Removing this env will make gz-transport15 use the zenoh packages from packages.osrfoundation.org.

Test build: https://build.osrfoundation.org/job/gz_transport-ci-pr_any-noble-amd64/282/
[![Build Status](https://build.osrfoundation.org/job/gz_transport-ci-pr_any-noble-amd64/282/badge/icon)](https://build.osrfoundation.org/job/gz_transport-ci-pr_any-noble-amd64/280/)

Related PR for github actions: https://github.com/gazebosim/gz-transport/pull/696