### PR TITLE
Add arch to OSRFOsXBase and brew_{arch} in gz-collections

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBrewCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBrewCompilation.groovy
@@ -11,9 +11,9 @@ import javaposse.jobdsl.dsl.Job
 */
 class OSRFBrewCompilation extends OSRFOsXBase
 {
-  static void create(Job job, enable_testing = true, enable_cmake_warnings = false)
+  static void create(Job job, enable_testing = true, enable_cmake_warnings = false, arch)
   {
-    OSRFOsXBase.create(job)
+    OSRFOsXBase.create(job, arch)
 
     /* Properties from generic compilations */
     GenericCompilation.create(job, enable_testing)

--- a/jenkins-scripts/dsl/_configs_/OSRFBrewCompilationAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBrewCompilationAnyGitHub.groovy
@@ -16,9 +16,10 @@ class OSRFBrewCompilationAnyGitHub
                      boolean enable_testing  = true,
                      ArrayList supported_branches = [],
                      boolean enable_github_pr_integration = true,
-                     boolean enable_cmake_warnings = false)
+                     boolean enable_cmake_warnings = false,
+                     String arch)
   {
-    OSRFBrewCompilation.create(job, enable_testing, enable_cmake_warnings)
+    OSRFBrewCompilation.create(job, enable_testing, enable_cmake_warnings, arch)
 
     GenericAnyJobGitHub.create(job, github_repo,
                                supported_branches,

--- a/jenkins-scripts/dsl/_configs_/OSRFBrewInstall.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBrewInstall.groovy
@@ -9,9 +9,9 @@ import javaposse.jobdsl.dsl.Job
 */
 class OSRFBrewInstall extends OSRFOsXBase
 {
-  static void create(Job job)
+  static void create(Job job, String arch)
   {
-    OSRFOsXBase.create(job)
+    OSRFOsXBase.create(job, arch)
 
     job.with
     {

--- a/jenkins-scripts/dsl/_configs_/OSRFOsXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFOsXBase.groovy
@@ -11,14 +11,14 @@ import _configs_.Globals
 */
 class OSRFOsXBase
 {
-  static void create(Job job)
+  static void create(Job job, String arch)
   {
     // UNIX Base
     OSRFUNIXBase.create(job)
 
     job.with
     {
-      label Globals.nontest_label("osx")
+      label Globals.nontest_label("osx && ${arch}")
 
       parameters {
         booleanParam('CLEAR_BREW_CACHE',false,'remove cached brew downloads')

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -130,7 +130,8 @@ OSRFBrewCompilationAnyGitHub.create(bottle_job_builder,
                                     "osrf/homebrew-simulation",
                                     DISABLE_TESTS,
                                     NO_SUPPORTED_BRANCHES,
-                                    DISABLE_GITHUB_INTEGRATION)
+                                    DISABLE_GITHUB_INTEGRATION,
+                                    'x86_64')
 bottle_job_builder.with
 {
    wrappers {

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -99,13 +99,15 @@ collections:
     ci:
       configs:
         - focal
-        - brew
+        - brew_amd64
+        - brew_arm64
         - win_conda_L
     packaging:
       configs:
         - focal
         - jammy
-        - brew
+        - brew_amd64
+        - brew_arm64
       linux:
         ignore_major_version:
           - gz-fortress
@@ -183,13 +185,15 @@ collections:
       configs:
         - jammy
         - noble_no_pr
-        - brew
+        - brew_amd64
+        - brew_arm64
         - win_conda_LO23
     packaging:
       configs:
         - jammy
         - noble
-        - brew
+        - brew_amd64
+        - brew_arm64
       linux:
         ignore_major_version:
           - gz-harmonic
@@ -266,12 +270,14 @@ collections:
     ci:
       configs:
         - noble
-        - brew
+        - brew_amd64
+        - brew_arm64
         - win_conda_LO23
     packaging:
       configs:
         - noble
-        - brew
+        - brew_amd64
+        - brew_arm64
       linux:
         ignore_major_version:
           - gz-ionic
@@ -348,12 +354,14 @@ collections:
     ci:
       configs:
         - noble
-        - brew
+        - brew_amd64
+        - brew_arm64
         - win_conda_noble
     packaging:
       configs:
         - noble
-        - brew
+        - brew_amd64
+        - brew_arm64
       linux:
         ignore_major_version:
           - gz-jetty
@@ -426,12 +434,14 @@ collections:
     ci:
       configs:
         - noble
-        - brew
+        - brew_amd64
+        - brew_arm64
         - win_conda_noble
     packaging:
       configs:
         - noble
-        - brew
+        - brew_amd64
+        - brew_arm64
       linux:
         nightly:
           distros:
@@ -555,7 +565,7 @@ ci_configs:
     tests_disabled:
     ci_categories_enabled:
       - stable_branches
-  - name: brew
+  - name: brew_amd64
     system:
       so: darwin
       distribution: macOSX
@@ -585,6 +595,38 @@ ci_configs:
       - sdformat
     ci_categories_enabled:
       - pr
+      - stable_branches
+  - name: brew_arm64
+    system:
+      so: darwin
+      distribution: macOSX
+      version: all
+      arch: arm64
+    requirements:
+    exclude:
+      all:
+        - gz-fortress
+        - gz-harmonic
+        - gz-ionic
+        - gz-jetty
+        - __upcoming__
+    cmake_warnings_disabled:
+      - gz-common
+      - gz-fuel-tools
+      - gz-sim
+      - gz-gui
+      - gz-launch
+      - gz-math
+      - gz-msgs
+      - gz-physics
+      - gz-rendering
+      - gz-sensors
+      - gz-tools
+      - gz-transport
+      - sdformat
+    ci_categories_enabled:
+      # Don't enable prs yet
+      # - pr
       - stable_branches
   - name: win_conda_L
     system:
@@ -731,10 +773,17 @@ packaging_configs:
         - "export MAKE_JOBS=1"
     exclude:
         - __upcoming__
-  - name: brew
+  - name: brew_amd64
     system:
       so: darwin
       distribution: macOSX
       version: all
       arch:
         - amd64
+  - name: brew_arm64
+    system:
+      so: darwin
+      distribution: macOSX
+      version: all
+      arch:
+        - arm64

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -6,8 +6,10 @@ Globals.default_emails = "jrivero@osrfoundation.org"
 // Usual CI jobs
 def ignition_ci_job = job("_test_job_from_dsl")
 OSRFLinuxBase.create(ignition_ci_job)
-def ignition_ci_job_mac = job("_test_job_from_dsl_mac")
-OSRFOsXBase.create(ignition_ci_job_mac)
+def ignition_ci_job_mac_amd64 = job("_test_job_from_dsl_mac_amd64")
+OSRFOsXBase.create(ignition_ci_job_mac_amd64, 'x86_64')
+def ignition_ci_job_mac_arm64 = job("_test_job_from_dsl_mac_arm64")
+OSRFOsXBase.create(ignition_ci_job_mac_arm64, 'arm64')
 def ignition_ci_job_win = job("_test_job_from_dsl_win")
 OSRFWinBase.create(ignition_ci_job_win)
 def ignition_ci_pr_job = job("_test_pr_job_from_dsl")


### PR DESCRIPTION
With these changes the generated jobs are the same `gz_{package}-install_bottle-homebrew-{arch}` and `gz_{package}-ci-{pacakge_version}-homebrew-{distro}`. And the only thing that changes between jobs are the assigned node labels.


Examples:

```
❯ diff gz_cmake2-install_bottle-homebrew-amd64.xml gz_cmake2-install_bottle-homebrew-arm64.xml
265c265
<     <assignedNode>(osx &amp;&amp; x86_64) &amp;&amp; !test-instance</assignedNode>
---
>     <assignedNode>(osx &amp;&amp; arm64) &amp;&amp; !test-instance</assignedNode>
```

```
❯ diff gz_cmake-ci-gz-cmake5-homebrew-arm64.xml gz_cmake-ci-gz-cmake5-homebrew-amd64.xml 
332c332
<     <assignedNode>(osx &amp;&amp; arm64) &amp;&amp; !test-instance</assignedNode>
---
>     <assignedNode>(osx &amp;&amp; x86_64) &amp;&amp; !test-instance</assignedNode>
```