### PR TITLE
brew_release.dsl: stop building ventura bottles

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Job
 Globals.default_emails = "jrivero@osrfoundation.org, scpeters@osrfoundation.org"
 
 // first distro in list is used as touchstone
-brew_supported_distros         = [ "ventura", "arm64_sonoma", "sonoma" ]
+brew_supported_distros         = [ "arm64_sonoma", "sonoma" ]
 bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_updater'
 bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'


### PR DESCRIPTION
Upstream homebrew-core has stopped building new ventura bottles since https://github.com/Homebrew/brew/pull/20672 was merged, so we should stop as well.