### PR TITLE
Add linuxbrew bin to PATH, use brew

### DIFF
--- a/jenkins-scripts/lib/_homebrew_github_get_formula_path.bash
+++ b/jenkins-scripts/lib/_homebrew_github_get_formula_path.bash
@@ -26,6 +26,6 @@ fi
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: export formula path'
-export FORMULA_PATH=`${BREW} ruby -e "puts \"${PACKAGE_ALIAS}\".f.path"`
+export FORMULA_PATH=`brew ruby -e "puts \"${PACKAGE_ALIAS}\".f.path"`
 echo Modifying ${FORMULA_PATH}
 echo '# END SECTION'

--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -32,16 +32,15 @@ echo '# BEGIN SECTION: download linuxbrew'
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 echo '# END SECTION'
 
-BREW_PREFIX="/home/linuxbrew/.linuxbrew"
-BREW=${BREW_PREFIX}/bin/brew
-${BREW} up
+export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+brew up
 
-${BREW} ruby -e "puts 'brew ruby success'"
+brew ruby -e "puts 'brew ruby success'"
 
 # tap osrf/simulation
-${BREW} untap osrf/simulation || true
-${BREW} tap osrf/simulation
-TAP_PREFIX=$(${BREW} --repo osrf/simulation)
+brew untap osrf/simulation || true
+brew tap osrf/simulation
+TAP_PREFIX=$(brew --repo osrf/simulation)
 GIT="git -C ${TAP_PREFIX}"
 ${GIT} remote add pr_head ${PULL_REQUEST_HEAD_REPO}
 # unshallow to get a full clone able to push

--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -32,7 +32,14 @@ echo '# BEGIN SECTION: download linuxbrew'
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 echo '# END SECTION'
 
-export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+# either SCRIPT_LIBDIR or SCRIPT_DIR may be set by calling scripts
+if [[ -f ${SCRIPT_LIBDIR}/_homebrew_path_setup.sh ]]; then
+    . ${SCRIPT_LIBDIR}/_homebrew_path_setup.sh
+elif [[ -f ${SCRIPT_DIR}/lib/_homebrew_path_setup.sh ]]; then
+    . ${SCRIPT_DIR}/lib/_homebrew_path_setup.sh
+else
+    export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+fi
 brew up
 
 brew ruby -e "puts 'brew ruby success'"

--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -37,8 +37,11 @@ if [[ -f ${SCRIPT_LIBDIR}/_homebrew_path_setup.sh ]]; then
     . ${SCRIPT_LIBDIR}/_homebrew_path_setup.sh
 elif [[ -f ${SCRIPT_DIR}/lib/_homebrew_path_setup.sh ]]; then
     . ${SCRIPT_DIR}/lib/_homebrew_path_setup.sh
-else
+elif [[ -d "/home/linuxbrew/.linuxbrew/bin" ]]; then
     export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+else
+    echo "Can not find brew setup configuration"
+    exit 1
 fi
 brew up
 

--- a/jenkins-scripts/lib/homebrew_bottle_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_pullrequest.bash
@@ -46,7 +46,7 @@ fi
 
 echo "# BEGIN SECTION: update bottle hashes"
 
-${BREW} bottle --merge --write --no-commit ${KEEP_OLD} ${FILES_WITH_NEW_HASH}
+brew bottle --merge --write --no-commit ${KEEP_OLD} ${FILES_WITH_NEW_HASH}
 
 # ensure that all modified files are committed
 export FORMULA_PATH='-a'

--- a/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
@@ -37,7 +37,7 @@ PULL_REQUEST_HEAD_REPO=git@github.com:osrfbuild/homebrew-simulation.git
 
 echo '# BEGIN SECTION: calculating the SHA hash and changing the formula'
 # get stable uri and its line number
-URI=`${BREW} ruby -e "puts \"${PACKAGE_ALIAS}\".f.stable.url"`
+URI=`brew ruby -e "puts \"${PACKAGE_ALIAS}\".f.stable.url"`
 echo Changing url from
 echo ${URI} to
 echo ${SOURCE_TARBALL_URI}
@@ -52,7 +52,7 @@ echo
 VERSION_LINE=$(awk \
   "/^  version ['\"]/ {print FNR}" ${FORMULA_PATH} | head -1)
 # check if version can be correctly auto-detected from url
-if ${BREW} ruby -e "exit Version.parse(\"${SOURCE_TARBALL_URI}\").to_s == \"${VERSION_SANITIZED}\""
+if brew ruby -e "exit Version.parse(\"${SOURCE_TARBALL_URI}\").to_s == \"${VERSION_SANITIZED}\""
 then
   echo Version can be correctly auto-detected from URL
   if [ -n "${VERSION_LINE}" ]; then
@@ -74,7 +74,7 @@ fi
 
 echo
 # check if stable sha256 is specified
-SHA=`${BREW} ruby -e "puts \"${PACKAGE_ALIAS}\".f.stable.checksum"`
+SHA=`brew ruby -e "puts \"${PACKAGE_ALIAS}\".f.stable.checksum"`
 if [ -n "$SHA" ]
 then
   echo Changing sha256 from
@@ -99,7 +99,7 @@ fi
 
 echo
 # revision line if it's nonzero
-FORMULA_REVISION=$(${BREW} ruby -e "puts \"${PACKAGE_ALIAS}\".f.pkg_version.revision")
+FORMULA_REVISION=$(brew ruby -e "puts \"${PACKAGE_ALIAS}\".f.pkg_version.revision")
 if [ "$FORMULA_REVISION" -gt 0 ]; then
   echo Deleting formula revision $FORMULA_REVISION
   FORMULA_REVISION_LINE=$(awk "/  revision ${FORMULA_REVISION}/ {print FNR}" ${FORMULA_PATH} | head -1)


### PR DESCRIPTION
Set the `PATH` appropriately and replace usage of BREW variable with brew in `_homebrew_github_setup.bash` and related scripts to match the approach taken for scripts that execute on macOS in https://github.com/gazebo-tooling/release-tools/pull/1366. I attempt to use `_homebrew_path_setup.sh` in https://github.com/gazebo-tooling/release-tools/pull/1392/commits/035cf90e9126ab340b81f0e39de1109bfd194f8c, though it requires checking for the presence of `SCRIPT_LIBDIR` or `SCRIPT_DIR` and includes a fallback.