### PR TITLE
Fix armhf calls in docker: remove explict buildx support

### DIFF
--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -25,15 +25,13 @@ USER=$(whoami)
 
 # platform support starts on versions greater than 17.07
 PLAFTORM_PARAM=
-DOCKER_CLI_PLUGIN=
 if [[ ${LINUX_DISTRO} == 'ubuntu' && \
       ${DISTRO} != 'focal' && \
       ${ARCH} == 'armhf' ]]; then
   PLAFTORM_PARAM="--platform=linux/armhf"
-  DOCKER_CLI_PLUGIN="buildx"
 fi
 
-sudo docker ${DOCKER_CLI_PLUGIN} build ${PLAFTORM_PARAM} ${_DOCKER_BUILD_EXTRA_ARGS} \
+sudo docker build ${PLAFTORM_PARAM} ${_DOCKER_BUILD_EXTRA_ARGS} \
                   --build-arg GID=$(id -g $USER) \
                   --build-arg USERID=$USERID \
                   --build-arg USER=$USER \


### PR DESCRIPTION
The support in our arm nodes does not seem to be able to use buildx with --platform probably due to a lack of right buildx plugin installation or a low version of the plugin.  Previous builds of armhf in Jenkins did not use the plugin although the support was there, probably a bug making things to work :roll_eyes: 

I'm removing its usage since the standard builder seems to work fine on arm64 to build armhf. 
 
Tested a variant of this branch successfully in gz-cmake5 (built the armhf package). Scheduled these same changes in gz-utils4: [![Build Status](https://build.osrfoundation.org/job/gz-utils4-debbuilder/205/badge/icon)](https://build.osrfoundation.org/job/gz-utils4-debbuilder/205/)