### PR TITLE
homebrew/test-bot repo is no longer available

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -78,7 +78,6 @@ echo '# BEGIN SECTION: run test-bot'
 # The test-bot makes a full cleanup of all installed pkgs. Be sure of install back
 # git to keep the slave working
 export HOMEBREW_DEVELOPER=1
-brew tap homebrew/test-bot
 brew tap osrf/simulation
 # replace with 'hub -C $(brew --repo osrf/simulation) pr checkout ${ghprbPullId}'
 # after the following hub issue is resolved:


### PR DESCRIPTION
The https://github.com/Homebrew/homebrew-test-bot has been archived and it is no longer working in our CI, see https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/1795/label=osx_arm64_sonoma/

The functionality is in built-in in brew so if I understand correctly it should work without the tap.