### PR TITLE
Fix brew formula PR field order

### DIFF
--- a/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
@@ -58,6 +58,7 @@ then
   if [ -n "${VERSION_LINE}" ]; then
     echo remove explicit version on line number ${VERSION_LINE}
     sed -i -e "${VERSION_LINE}d" ${FORMULA_PATH}
+    unset VERSION_LINE
   fi
 else
   if [ -z "${VERSION_LINE}" ]; then


### PR DESCRIPTION
Unset VERSION_LINE variable after deleting a redundant version field to fix the location of sha256 field.

Should fix issue in https://github.com/osrf/homebrew-simulation/pull/3194.

## Testing

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_pull_request_updater&build=1715)](https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/1715/) https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/1715/