### PR TITLE
Refactor arguments to _homebrew_github_commit.bash

### DIFF
--- a/jenkins-scripts/lib/_homebrew_github_commit.bash
+++ b/jenkins-scripts/lib/_homebrew_github_commit.bash
@@ -1,31 +1,30 @@
 # parameters:
+# - COMMIT_MESSAGE
 # - TAP_PREFIX
 # - PULL_REQUEST_BRANCH
-# - PACKAGE_ALIAS
-# - VERSION
+# - PULL_REQUEST_TITLE or PULL_REQUEST_URL
 
 # Can be defined outside the script. if not, default value is set
 PR_URL_export_file=${PR_URL_export_file:-${WORKSPACE}/pull_request_created.properties}
 
 echo '# BEGIN SECTION: check variables'
+if [ -z "${COMMIT_MESSAGE}" ]; then
+  echo COMMIT_MESSAGE not specified
+  exit -1
+fi
 if [ -z "${PULL_REQUEST_BRANCH}" ]; then
   echo PULL_REQUEST_BRANCH not specified
   exit -1
 fi
+if [ -z "${PULL_REQUEST_TITLE}" ]; then
+  if [ -z "${PULL_REQUEST_URL}" ]; then
+    echo One of PULL_REQUEST_TITLE or PULL_REQUEST_URL must be specified
+    exit -1
+  fi
+fi
 if [ -z "${TAP_PREFIX}" ]; then
   echo TAP_PREFIX not specified
   exit -1
-fi
-# PACKAGE_ALIAS and VERSION are required if a pull request doesn't yet exist
-if [ -z "${PULL_REQUEST_URL}" ]; then
-  if [ -z "${PACKAGE_ALIAS}" ]; then
-    echo PACKAGE_ALIAS not specified
-    exit -1
-  fi
-  if [ -z "${VERSION}" ]; then
-    echo VERSION not specified
-    exit -1
-  fi
 fi
 echo '# END SECTION'
 
@@ -39,12 +38,9 @@ fi
 echo ==========================================================
 ${GIT} diff
 echo ==========================================================
-echo '# END SECTION'
 
 echo
 echo '# BEGIN SECTION: commit and pull request creation'
-${GIT} config user.name "OSRF Build Bot"
-${GIT} config user.email "osrfbuild@osrfoundation.org"
 ${GIT} remote -v
 # check if branch already exists
 if ${GIT} rev-parse --verify ${PULL_REQUEST_BRANCH} ; then
@@ -52,10 +48,7 @@ if ${GIT} rev-parse --verify ${PULL_REQUEST_BRANCH} ; then
 else
   ${GIT} checkout -b ${PULL_REQUEST_BRANCH}
 fi
-if [ -n "${PACKAGE_ALIAS}" ]; then
-  COMMIT_MESSAGE_PREFIX="${PACKAGE_ALIAS}: "
-fi
-${GIT} commit ${FORMULA_PATH} -m "${COMMIT_MESSAGE_PREFIX}update ${VERSION}${COMMIT_MESSAGE_SUFFIX}"
+${GIT} commit ${FORMULA_PATH} -m "${COMMIT_MESSAGE}"
 echo
 ${GIT} status
 echo
@@ -83,7 +76,7 @@ if [ -z "${PULL_REQUEST_URL}" ]; then
   PR_URL=$(${HUB} -C ${TAP_PREFIX} pull-request \
     -b osrf:master \
     -h osrfbuild:${PULL_REQUEST_BRANCH} \
-    -m "${PACKAGE_ALIAS} ${VERSION}")
+    -m "${PULL_REQUEST_TITLE}")
 
   echo "Pull request created: ${PR_URL}"
 

--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -60,3 +60,7 @@ ${GIT} fetch pr_head
 if [ -n "${PULL_REQUEST_BRANCH}" ]; then
   ${GIT} checkout --track pr_head/${PULL_REQUEST_BRANCH}
 fi
+
+# configure git for committing
+${GIT} config user.name "OSRF Build Bot"
+${GIT} config user.email "osrfbuild@osrfoundation.org"

--- a/jenkins-scripts/lib/homebrew_bottle_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_pullrequest.bash
@@ -53,5 +53,5 @@ export FORMULA_PATH='-a'
 
 echo '# END SECTION'
 
-COMMIT_MESSAGE_SUFFIX=" bottle."
+COMMIT_MESSAGE="update bottle"
 . ${SCRIPT_LIBDIR}/_homebrew_github_commit.bash

--- a/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
@@ -110,5 +110,7 @@ fi
 
 # create branch with name and sanitized version string
 PULL_REQUEST_BRANCH="${PACKAGE_ALIAS}_$(echo ${VERSION_SANITIZED} | tr ' ~:^?*[' '_')_$(date +%s)"
+PULL_REQUEST_TITLE="${PACKAGE_ALIAS} ${VERSION}"
+COMMIT_MESSAGE="${PACKAGE_ALIAS} ${VERSION}"
 
 . ${SCRIPT_LIBDIR}/_homebrew_github_commit.bash


### PR DESCRIPTION
Uses COMMIT_MESSAGE and PULL_REQUEST_TITLE environment variables instead of PACKAGE_ALIAS and VERSION.
Also move git name and email config to setup script.

This was split out from #1390.